### PR TITLE
2nd unified docker 

### DIFF
--- a/docker/pyt_vllm.ubuntu.amd.Dockerfile
+++ b/docker/pyt_vllm.ubuntu.amd.Dockerfile
@@ -24,7 +24,7 @@
 # SOFTWARE.
 #
 #################################################################################
-ARG BASE_DOCKER=rocm/vllm:rocm6.2_mi300_ubuntu22.04_py3.9_vllm_7c5fd50
+ARG BASE_DOCKER=rocm/vllm-dev:vllm-20241009-tuned 
 FROM $BASE_DOCKER
 
 USER root

--- a/models.json
+++ b/models.json
@@ -93,6 +93,54 @@
      "--model_repo meta-llama/Llama-2-7b-chat-hf --test_option latency,throughput --num_gpu 1 --datatype float16"
   },
   {
+    "name": "pyt_vllm_llama-2-70b",
+    "url": "",
+    "dockerfile": "docker/pyt_vllm",
+    "scripts": "scripts/vllm/run.sh",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm"
+    ],
+    "args":
+     "--model_repo meta-llama/Llama-2-70b-chat-hf --test_option latency,throughput --num_gpu 8 --datatype float16"
+  },
+  {
+    "name": "pyt_vllm_mixtral-8x7b",
+    "url": "",
+    "dockerfile": "docker/pyt_vllm",
+    "scripts": "scripts/vllm/run.sh",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm"
+    ],
+    "args":
+     "--model_repo mistralai/Mixtral-8x7B-Instruct-v0.1 --test_option latency,throughput --num_gpu 8 --datatype float16"
+  },
+  {
+    "name": "pyt_vllm_mixtral-8x22b",
+    "url": "",
+    "dockerfile": "docker/pyt_vllm",
+    "scripts": "scripts/vllm/run.sh",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm"
+    ],
+    "args":
+     "--model_repo mistralai/Mixtral-8x22B-Instruct-v0.1 --test_option latency,throughput --num_gpu 8 --datatype float16"
+  },
+  {
     "name": "pyt_vllm_mistral-7b",
     "url": "",
     "dockerfile": "docker/pyt_vllm",
@@ -125,6 +173,22 @@
      "--model_repo Qwen/Qwen2-7B-Instruct --test_option latency,throughput --num_gpu 1 --datatype float16"
   },
   {
+    "name": "pyt_vllm_qwen2-72b",
+    "url": "",
+    "dockerfile": "docker/pyt_vllm",
+    "scripts": "scripts/vllm/run.sh",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm"
+    ],
+    "args":
+     "--model_repo Qwen/Qwen2-72B-Instruct --test_option latency,throughput --num_gpu 1 --datatype float16"
+  },
+  {
     "name": "pyt_vllm_jais-13b",
     "url": "",
     "dockerfile": "docker/pyt_vllm",
@@ -155,5 +219,85 @@
     ],
     "args":
      "--model_repo core42/jais-30b-chat-v3 --test_option latency,throughput --num_gpu 1 --datatype float16"
+  },
+  {
+    "name": "pyt_vllm_llama-3.1-8b_fp8",
+    "url": "",
+    "dockerfile": "docker/pyt_vllm",
+    "scripts": "scripts/vllm/run.sh",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm"
+    ],
+    "args":
+     "--model_repo amd/Meta-Llama-3.1-8B-Instruct-FP8-KV --test_option latency,throughput --num_gpu 1 --datatype float8"
+  },
+  {
+    "name": "pyt_vllm_llama-3.1-70b_fp8",
+    "url": "",
+    "dockerfile": "docker/pyt_vllm",
+    "scripts": "scripts/vllm/run.sh",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm"
+    ],
+    "args":
+     "--model_repo amd/Meta-Llama-3.1-70B-Instruct-FP8-KV --test_option latency,throughput --num_gpu 8 --datatype float8"
+  },
+  {
+    "name": "pyt_vllm_llama-3.1-405b_fp8",
+    "url": "",
+    "dockerfile": "docker/pyt_vllm",
+    "scripts": "scripts/vllm/run.sh",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm"
+    ],
+    "args":
+     "--model_repo amd/Meta-Llama-3.1-405B-Instruct-FP8-KV --test_option latency,throughput --num_gpu 8 --datatype float8"
+  },
+  {
+    "name": "pyt_vllm_mixtral-8x7b_fp8",
+    "url": "",
+    "dockerfile": "docker/pyt_vllm",
+    "scripts": "scripts/vllm/run.sh",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm"
+    ],
+    "args":
+     "--model_repo amd/Mixtral-8x7B-Instruct-v0.1-FP8-KV --test_option latency,throughput --num_gpu 8 --datatype float8"
+  },
+  {
+    "name": "pyt_vllm_mixtral-8x22b_fp8",
+    "url": "",
+    "dockerfile": "docker/pyt_vllm",
+    "scripts": "scripts/vllm/run.sh",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm"
+    ],
+    "args":
+     "--model_repo amd/Mixtral-8x22B-Instruct-v0.1-FP8-KV --test_option latency,throughput --num_gpu 8 --datatype float8"
   }
 ]

--- a/scripts/vllm/README.md
+++ b/scripts/vllm/README.md
@@ -7,7 +7,15 @@
 ./vllm_benchmark_report.sh -s $test_option -m $model_repo -g $num_gpu -d $datatype
 ```
 
-Note: The input sequence length, output sequence length, and tensor parallel (TP) are already configured. You don't need to specify them with this script.
+-   Note: The input sequence length, output sequence length, and tensor parallel (TP) are already configured. You don't need to specify them with this script.
+
+-   Note: If you encounter this error, pass your access-authorized Hugging Face token to the gated models.
+```sh
+OSError: You are trying to access a gated repo.
+
+# pass your HF_TOKEN
+export HF_TOKEN=$your_personal_hf_token
+```
 
 #### Variables
 
@@ -17,26 +25,53 @@ Note: The input sequence length, output sequence length, and tensor parallel (TP
 |              | throughput                              | Measure token generation throughput              |
 |              | all                                     | Measure both throughput and latency              |
 | $model_repo  | meta-llama/Meta-Llama-3.1-8B-Instruct   | Llama 3.1 8B                                     |
-|              | meta-llama/Meta-Llama-3.1-70B-Instruct  | Llama 3.1 70B                                    |
+| (float16)    | meta-llama/Meta-Llama-3.1-70B-Instruct  | Llama 3.1 70B                                    |
 |              | meta-llama/Meta-Llama-3.1-405B-Instruct | Llama 3.1 405B                                   |
 |              | meta-llama/Llama-2-7b-chat-hf           | Llama 2 7B                                       |
+|              | meta-llama/Llama-2-70b-chat-hf          | Llama 2 70B                                      |
+|              | mistralai/Mixtral-8x7B-Instruct-v0.1    | Mistral 8x7B                                     |
+|              | mistralai/Mixtral-8x22B-Instruct-v0.1   | Mistral 8x22B                                    |
 |              | mistralai/Mistral-7B-Instruct-v0.3      | Mistral 7B                                       |
 |              | Qwen/Qwen2-7B-Instruct                  | Qwen2 7B                                         |
+|              | Qwen/Qwen2-72B-Instruct                 | Qwen2 72B                                        |
 |              | core42/jais-13b-chat                    | JAIS 13B                                         |
 |              | core42/jais-30b-chat-v3                 | JAIS 30B                                         |
+| $model_repo  | amd/Meta-Llama-3.1-8B-Instruct-FP8-KV   | Llama 3.1 8B                                     |
+| (float8)     | amd/Meta-Llama-3.1-70B-Instruct-FP8-KV  | Llama 3.1 70B                                    |
+|              | amd/Meta-Llama-3.1-405B-Instruct-FP8-KV | Llama 3.1 405B                                   |
+|              | amd/Mixtral-8x7B-Instruct-v0.1-FP8-KV   | Mistral 8x7B                                     |
+|              | amd/Mixtral-8x22B-Instruct-v0.1-FP8-KV  | Mistral 8x22B                                    |
 | $num_gpu     | 1 or 8                                  | Number of GPUs.                                  |
-| $datatype    | float16                                 |                                                  |
+| $datatype    | float16, float8                         |                                                  |
 
-## example
-#### latency + throughput
-```sh
-./vllm_benchmark_report.sh -s all -m meta-llama/Meta-Llama-3.1-8B-Instruct -g 1 -d float16
-```
-#### latency 
+#### Run the benchmark tests on the MI300X accelerator 🏃
+
+Here are some examples and the test results:
+
+-   Benchmark example - latency
+ 
+Use this command to benchmark the latency of the Llama 3.1 8B model on one GPU with the float16 and float8 data type.
+
 ```sh
 ./vllm_benchmark_report.sh -s latency -m meta-llama/Meta-Llama-3.1-8B-Instruct -g 1 -d float16
+./vllm_benchmark_report.sh -s latency -m amd/Meta-Llama-3.1-8B-Instruct-FP8-KV -g 1 -d float8
 ```
-#### throughput
+
+You can find the latency report at *./reports_float16/summary/Meta-Llama-3.1-8B-Instruct_latency_report.csv*.
+You can find the latency report at *./reports_float8/summary/Meta-Llama-3.1-8B-Instruct-FP8-KV_latency_report.csv*.
+
+-   Benchmark example - throughput
+
+Use this command to benchmark the throughput of the Llama 3.1 8B model on one GPU with the float16 and float8 data type.
+
 ```sh
 ./vllm_benchmark_report.sh -s throughput -m meta-llama/Meta-Llama-3.1-8B-Instruct -g 1 -d float16
+./vllm_benchmark_report.sh -s throughput -m amd/Meta-Llama-3.1-8B-Instruct-FP8-KV -g 1 -d float8
 ```
+
+You can find the throughput report at *./reports_float16/summary/Meta-Llama-3.1-8B-Instruct_throughput_report.csv*.
+You can find the throughput report at *./reports_float8/summary/Meta-Llama-3.1-8B-Instruct-FP8-KV_throughput_report.csv*.
+
+-   throughput\_tot = requests \* (**input lengths + output lengths**) / elapsed\_time
+
+-   throughput\_gen = requests \* **output lengths** / elapsed\_time

--- a/scripts/vllm/vllm_benchmark_report.sh
+++ b/scripts/vllm/vllm_benchmark_report.sh
@@ -51,6 +51,20 @@ model_org_name=(${model//// })
 model_name=${model_org_name[1]}
 tp=$numgpu
 
+# perf env setting
+export HIP_FORCE_DEV_KERNARG=1
+export VLLM_USE_ROCM_CUSTOM_PAGED_ATTN=1
+export VLLM_USE_TRITON_FLASH_ATTN=0
+export VLLM_INSTALL_PUNICA_KERNELS=1
+export TOKENIZERS_PARALLELISM=false
+export RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES=1
+export NCCL_MIN_NCHANNELS=112
+export VLLM_FP8_PADDING=1
+export VLLM_FP8_ACT_PADDING=1
+export VLLM_FP8_WEIGHT_PADDING=1
+export VLLM_FP8_REDUCE_CONV=1
+export VLLM_SCHED_PREFILL_KVC_FREEPCT=31.0
+
 if [ $tp -eq 1 ]; then
     DIST_BE=" --enforce-eager "
 else

--- a/scripts/vllm/vllm_benchmark_report.sh
+++ b/scripts/vllm/vllm_benchmark_report.sh
@@ -46,29 +46,37 @@ do
 done
 echo "MODEL: $model ";
 
-# only for ROCM
-export HIP_FORCE_DEV_KERNARG=1
-export VLLM_USE_TRITON_FLASH_ATTN=0
-export VLLM_USE_ROCM_CUSTOM_PAGED_ATTN=1
-export VLLM_TUNE_GEMM=0
-
 # args
 model_org_name=(${model//// })
 model_name=${model_org_name[1]}
-dtype=$datatype
 tp=$numgpu
+
+if [ $tp -eq 1 ]; then
+    DIST_BE=" --enforce-eager "
+else
+    DIST_BE=" --distributed-executor-backend mp "
+fi
+
+if [[ $datatype = "float16" ]]; then
+    DTYPE=" --dtype float16 "	
+elif [[ $datatype == "float8" ]]; then
+    DTYPE=" --dtype float16 --quantization fp8 --kv-cache-dtype fp8 " 
+fi
+
+OPTION_LATENCY=" --gpu-memory-utilization 0.99 --num-scheduler-steps 10 "
+OPTION_THROUGHPUT=" --gpu-memory-utilization 0.99 --num-scheduler-steps 128 --max-num-seqs 1000 "
 
 # latency conditions
 Bat="1 2 4 8 16 32 64 128 256"
 InLatency="128 2048"
-OutLatency=128
+OutLatency="1 128 2048"
 
 # throughput conditions
 Req="256 2000"
 InThroughput="128 2048"
 OutThroughput="128 2048"
 
-report_dir="../reports_${dtype}"
+report_dir="reports_${datatype}"
 report_summary_dir="${report_dir}/summary"
 tool_latency="/app/vllm/benchmarks/benchmark_latency.py"
 tool_throughput="/app/vllm/benchmarks/benchmark_throughput.py"
@@ -78,39 +86,22 @@ n_itr=5
 mkdir -p $report_dir
 mkdir -p $report_summary_dir
 
+
 if [ "$scenario" == "latency" ] || [ "$scenario" == "all" ]; then
     echo "[INFO] LATENCY"
     mode="latency"
-    for inp in $InLatency;
+    for out in $OutLatency;
     do
-        out=1
-        for bat in $Bat;
+        for inp in $InLatency;
         do
-            outjson=${report_dir}/${model_name}_${mode}_prefill_bs${bat}_in${inp}_out${out}_${dtype}.json
-            outcsv=${report_summary_dir}/${model_name}_${mode}_report.csv
-            echo $model $mode $bat $tp $inp $out
-            if [ $tp -eq 1 ]; then
-                python3 $tool_latency --model $model --batch-size $bat -tp $tp --input-len $inp --output-len $out --num-iters-warmup $n_warm --num-iters $n_itr --trust-remote-code --dtype $dtype --enforce-eager --output-json $outjson
-            else
-                python3 $tool_latency --model $model --batch-size $bat -tp $tp --input-len $inp --output-len $out --num-iters-warmup $n_warm --num-iters $n_itr --trust-remote-code --dtype $dtype --output-json $outjson --distributed-executor-backend "mp"
-            fi
-            python3 $tool_report --mode ${mode} --model $model_name --batch-size $bat --tp $tp --input-len $inp --output-len $out --dtype $dtype --input-json $outjson --output-csv $outcsv
-        done
-    done
-    for bat in $Bat;
-    do
-        inp=1
-        for out in $OutLatency;
-        do
-            outjson=${report_dir}/${model_name}_${mode}_decoding_bs${bat}_in${inp}_out${out}_${dtype}.json
-            outcsv=${report_summary_dir}/${model_name}_${mode}_report.csv
-            echo $model $mode $bat $tp $inp $out
-            if [ $tp -eq 1 ]; then
-                python3 $tool_latency --model $model --batch-size $bat -tp $tp --input-len $inp --output-len $out --num-iters-warmup $n_warm --num-iters $n_itr --trust-remote-code --dtype $dtype --enforce-eager --output-json $outjson
-            else
-                python3 $tool_latency --model $model --batch-size $bat -tp $tp --input-len $inp --output-len $out --num-iters-warmup $n_warm --num-iters $n_itr --trust-remote-code --dtype $dtype --output-json $outjson --distributed-executor-backend "mp"
-            fi
-            python3 $tool_report --mode ${mode} --model $model_name --batch-size $bat --tp $tp --input-len $inp --output-len $out --dtype $dtype --input-json $outjson --output-csv $outcsv
+            for bat in $Bat;
+            do
+                outjson=${report_dir}/${model_name}_${mode}_decoding_bs${bat}_in${inp}_out${out}_${datatype}.json
+                outcsv=${report_summary_dir}/${model_name}_${mode}_report.csv
+                echo $model $mode $bat $tp $inp $out
+                python3 $tool_latency --model $model --batch-size $bat -tp $tp --input-len $inp --output-len $out --num-iters-warmup $n_warm --num-iters $n_itr --trust-remote-code --enforce-eager --output-json $outjson $DTYPE $DIST_BE $OPTION_LATENCY
+                python3 $tool_report --mode $mode --model $model_name --batch-size $bat --tp $tp --input-len $inp --output-len $out $dtype --input-json $outjson --output-csv $outcsv
+            done
         done
     done
 fi
@@ -124,15 +115,11 @@ if [ "$scenario" == "throughput" ] || [ "$scenario" == "all" ]; then
         do
             for inp in $InThroughput;
             do
-                outjson=${report_dir}/${model_name}_${mode}_req${req}_in${inp}_out${out}_${dtype}.json
+                outjson=${report_dir}/${model_name}_${mode}_req${req}_in${inp}_out${out}_${datatype}.json
                 outcsv=${report_summary_dir}/${model_name}_${mode}_report.csv
                 echo $model $mode $req $tp $inp $out
-                if [ $tp -eq 1 ]; then
-                    python3 $tool_throughput --model $model --num-prompts $req -tp $tp --input-len $inp --output-len $out --trust-remote-code --dtype $dtype --enforce-eager --output-json $outjson
-                else
-                    python3 $tool_throughput --model $model --num-prompts $req -tp $tp --input-len $inp --output-len $out --trust-remote-code --dtype $dtype --output-json $outjson --distributed-executor-backend "mp"
-                fi
-                python3 $tool_report --mode $mode --model $model_name --num-prompts $req --tp $tp --input-len $inp --output-len $out --dtype $dtype --input-json $outjson --output-csv $outcsv
+                python3 $tool_throughput --model $model --num-prompts $req -tp $tp --input-len $inp --output-len $out --trust-remote-code --output-json $outjson $DTYPE $DIST_BE $OPTION_THROUGHPUT
+                python3 $tool_report --mode $mode --model $model_name --num-prompts $req --tp $tp --input-len $inp --output-len $out $dtype --input-json $outjson --output-csv $outcsv
             done
         done
     done


### PR DESCRIPTION
HI @amathews-amd 

this is the PR for the 2nd unified docker 
==
python3 tools/run_models.py --tags pyt_vllm_llama-3.1-8b_fp8   --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_llama-3.1-70b_fp8  --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_llama-3.1-405b_fp8 --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_mixtral-8x7b_fp8   --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_mixtral-8x22b_fp8  --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_llama-3.1-8b       --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_llama-3.1-70b      --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_llama-3.1-405b     --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_llama-2-7b         --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_llama-2-70b        --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_mixtral-8x7b       --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_mixtral-8x22b      --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_mistral-7b         --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_qwen2-7b           --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_qwen2-72b          --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_jais-13b           --keep-model-dir --live-output --timeout 28800
python3 tools/run_models.py --tags pyt_vllm_jais-30b           --keep-model-dir --live-output --timeout 28800