### PR TITLE
Update for vllm 0.8.3 inference docker update

### DIFF
--- a/benchmark/vllm/README.md
+++ b/benchmark/vllm/README.md
@@ -14,7 +14,7 @@ This Docker image packages vLLM with PyTorch for an AMD Instinct™ MI300X
 accelerator. It includes:
 
 -   ✅ ROCm™ 6.3.1
--   ✅ vLLM 0.7.3
+-   ✅ vLLM 0.8.3
 -   ✅ PyTorch 2.7.0 (dev nightly)
 -   ✅ hipBLASLt 0.13
 
@@ -100,8 +100,6 @@ users can also change the benchmarking parameters. Refer to the [Standalone benc
 | pyt_vllm_mistral-7b                    |
 | pyt_vllm_qwen2-7b                      |
 | pyt_vllm_qwen2-72b                     |
-| pyt_vllm_jais-13b                      |
-| pyt_vllm_jais-30b                      |
 | pyt_vllm_dbrx-instruct                 |
 | pyt_vllm_gemma-2-27b                   |
 | pyt_vllm_c4ai-command-r-plus-08-2024   |
@@ -170,8 +168,6 @@ cd MAD/scripts/vllm
 |              | mistralai/Mistral-7B-Instruct-v0.3      | [Mistral 7B](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3)                           |
 |              | Qwen/Qwen2-7B-Instruct                  | [Qwen2 7B](https://huggingface.co/Qwen/Qwen2-7B-Instruct)                                       |
 |              | Qwen/Qwen2-72B-Instruct                 | [Qwen2 72B](https://huggingface.co/Qwen/Qwen2-72B-Instruct)                                      |
-|              | core42/jais-13b-chat                    | [JAIS 13B](https://huggingface.co/core42/jais-13b-chat)                                         |
-|              | core42/jais-30b-chat-v3                 | [JAIS 30B](https://huggingface.co/core42/jais-30b-chat-v3)                                      |
 |              | databricks/dbrx-instruct                | [DBRX Instruct](https://huggingface.co/databricks/dbrx-instruct)                                     |
 |              | google/gemma-2-27b                      | [Gemma 2 27B](https://huggingface.co/google/gemma-2-27b)                                           |
 |              | CohereForAI/c4ai-command-r-plus-08-2024 | [C4AI Command R+ 08-2024](https://huggingface.co/CohereForAI/c4ai-command-r-plus-08-2024)                      |
@@ -304,7 +300,7 @@ owners and are only mentioned for informative purposes.   
 ----------
 This release note summarizes notable changes since the previous docker release.
 
--   The vLLM version number was incremented from 0.6.6 to 0.7.3.
+-   The vLLM version number was incremented from 0.7.3 to 0.8.3.
 
 -   Improved fp8 throughput performance with HipblasLT 0.13
 

--- a/docker/pyt_vllm.ubuntu.amd.Dockerfile
+++ b/docker/pyt_vllm.ubuntu.amd.Dockerfile
@@ -24,7 +24,7 @@
 # SOFTWARE.
 #
 #################################################################################
-ARG BASE_DOCKER=rocm/vllm:instinct_main
+ARG BASE_DOCKER=rocm/vllm:rocm6.3.1_instinct_vllm0.8.3_20250410
 FROM $BASE_DOCKER
 
 USER root

--- a/docker/pyt_vllm.ubuntu.amd.Dockerfile
+++ b/docker/pyt_vllm.ubuntu.amd.Dockerfile
@@ -24,7 +24,7 @@
 # SOFTWARE.
 #
 #################################################################################
-ARG BASE_DOCKER=rocm/vllm:rocm6.3.1_instinct_vllm0.8.3_20250410
+ARG BASE_DOCKER=rocm/vllm:instinct_main
 FROM $BASE_DOCKER
 
 USER root

--- a/models.json
+++ b/models.json
@@ -227,42 +227,6 @@
      "--model_repo Qwen/Qwen2-72B-Instruct --test_option latency,throughput --num_gpu 8 --datatype float16 --tunableop off"
   },
   {
-    "name": "pyt_vllm_jais-13b",
-    "url": "",
-    "dockerfile": "docker/pyt_vllm",
-    "scripts": "scripts/vllm/run.sh",
-    "data": "huggingface",
-    "n_gpus": "-1",
-    "owner": "mad.support@amd.com",
-    "training_precision": "",
-    "multiple_results": "perf_jais-13b-chat.csv",
-    "tags": [
-      "pyt",
-      "vllm"
-    ],
-    "timeout": -1,
-    "args":
-     "--model_repo core42/jais-13b-chat --test_option latency,throughput --num_gpu 1 --datatype float16 --tunableop off"
-  },
-  {
-    "name": "pyt_vllm_jais-30b",
-    "url": "",
-    "dockerfile": "docker/pyt_vllm",
-    "scripts": "scripts/vllm/run.sh",
-    "data": "huggingface",
-    "n_gpus": "-1",
-    "owner": "mad.support@amd.com",
-    "training_precision": "",
-    "multiple_results": "perf_jais-30b-chat-v3.csv",
-    "tags": [
-      "pyt",
-      "vllm"
-    ],
-    "timeout": -1,
-    "args":
-     "--model_repo core42/jais-30b-chat-v3 --test_option latency,throughput --num_gpu 1 --datatype float16 --tunableop off"
-  },
-  {
     "name": "pyt_vllm_dbrx-instruct",
     "url": "",
     "dockerfile": "docker/pyt_vllm",


### PR DESCRIPTION
1) Update README
2) Remove jais 13b and 30b models