### PR TITLE
[vllm online serving] adding ignore-eos

### DIFF
--- a/benchmark/vllm/README.md
+++ b/benchmark/vllm/README.md
@@ -51,6 +51,17 @@ cat /proc/sys/kernel/numa_balancing
 
 For the experimental features and known issues concerning ROCm optimization efforts on vLLM, see the developer's guide at [ROCm/vLLM](https://github.com/ROCm/vllm/blob/main/docs/dev-docker/README.md).
 
+To change the the latency batch size, input sequence length (ISL), and output sequence length (OSL), you can modify at [vllm benchark script](../../scripts/vllm/vllm_benchmark_report.sh#L73)
+
+-   Default batch size: 1, 2, 4, 8, 16, 32, 64, 128, 256
+-   Default ISL: 128, 2048
+-   Default OSL: 1, 128
+
+Throughput input sequence length (ISL) and output sequence length (OSL) can be changed at [vllm benchark script](../../scripts/vllm/vllm_benchmark_report.sh#L78)
+*
+
+-   Default ISL/OSL: 128:128, 2048:128, 128:2048, 2048:2048
+
 ### Download the Docker image 🐳
 
 The following command pulls the Docker image from Docker Hub.

--- a/scripts/vllm/vllm_benchmark_report.sh
+++ b/scripts/vllm/vllm_benchmark_report.sh
@@ -185,7 +185,7 @@ if [ "$scenario" == "serving" ] || [ "$scenario" == "all" ]; then
                 do
                     outjson=${report_dir}/${model_name}_${mode}_req${np}_in${inp}_out${out}_mc${mc}_${datatype}.json
                     outcsv=${report_summary_dir}/${model_name}_${mode}_report.csv
-                    python3 $tool_serving --model $model --percentile-metrics "ttft,tpot,itl,e2el" --dataset-name random --random-input-len $inp --random-output-len $out --num-prompts $np --max-concurrency $mc --save-result --result-filename $outjson
+                    python3 $tool_serving --model $model --percentile-metrics "ttft,tpot,itl,e2el" --dataset-name random --random-input-len $inp --random-output-len $out --num-prompts $np --max-concurrency $mc --ignore-eos --save-result --result-filename $outjson
                     python3 $tool_report --mode $mode --model $model_name --num-prompts $np --tp $tp --input-len $inp --output-len $out --max-concurrency $mc --input-json $outjson --output-csv $outcsv --dtype $datatype
                 done
             done


### PR DESCRIPTION
Adding
--ignore-eos
at vllm online serving to give consistent performance across different runs. Without this option, the requests could terminate earlier and perf will shift randomly in random datasets.