### PR TITLE
JAX-Maxtext training v25.7 JAX 0.6.0 patch

### DIFF
--- a/docker/jax_maxtext.ubuntu.amd.Dockerfile
+++ b/docker/jax_maxtext.ubuntu.amd.Dockerfile
@@ -21,7 +21,7 @@
 # SOFTWARE.
 #
 #################################################################################
-ARG BASE_DOCKER=rocm/jax-training:maxtext-v25.7
+ARG BASE_DOCKER=rocm/jax-training:maxtext-v25.7-jax060
 FROM $BASE_DOCKER
 
 USER root

--- a/scripts/jax-maxtext/env_scripts/llama2_70b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/llama2_70b_env.sh
@@ -24,7 +24,18 @@
 #
 #################################################################################
 
-export XLA_FLAGS="--xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_graph_level=0 --xla_gpu_autotune_level=0 --xla_gpu_enable_reduce_scatter_combine_by_dim=false --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_all_reduce_combine_threshold_bytes=8589934592  --xla_gpu_all_gather_combine_threshold_bytes=137438953472 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
-export XLA_PYTHON_CLIENT_MEM_FRACTION=0.975
-export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH
+export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
+export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
+export NVTE_USE_HIPBLASLT=1
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export GPU_MAX_HW_QUEUES=2
+export HIP_FORCE_DEV_KERNARG=1
+export HSA_FORCE_FINE_GRAIN_PCIE=1
+export NVTE_FUSED_ATTN=1
+export NCCL_DEBUG=VERSION
 export NVTE_CK_USES_BWD_V3=1
+export NVTE_CK_USES_FWD_V3=1
+export NVTE_CK_IS_V3_ATOMIC_FP32=0
+export NVTE_CK_HOW_V3_BF16_CVT=2
+export NVTE_FUSED_ATTN_CK=1
+export NVTE_FUSED_ATTN_AOTRITON=0

--- a/scripts/jax-maxtext/env_scripts/llama2_7b.yml
+++ b/scripts/jax-maxtext/env_scripts/llama2_7b.yml
@@ -44,7 +44,7 @@ ici_fsdp_parallelism: 8
 ici_data_parallelism: 1
 remat_policy: "minimal_flash"
 use_iota_embed: True
-scan_layers: False
+scan_layers: True
 async_checkpointing: False
 logits_dot_in_fp32: False
 profiler: ""

--- a/scripts/jax-maxtext/env_scripts/llama2_7b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/llama2_7b_env.sh
@@ -24,7 +24,18 @@
 #
 #################################################################################
 
-export XLA_FLAGS="--xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_graph_level=0 --xla_gpu_autotune_level=0 --xla_gpu_enable_latency_hiding_scheduler=TRUE --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_all_gather_combine_by_dim=FALSE --xla_gpu_memory_limit_slop_factor=95"
-export XLA_PYTHON_CLIENT_MEM_FRACTION=0.967
-export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH
+export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
+export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
+export NVTE_USE_HIPBLASLT=1
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export GPU_MAX_HW_QUEUES=2
+export HIP_FORCE_DEV_KERNARG=1
+export HSA_FORCE_FINE_GRAIN_PCIE=1
+export NVTE_FUSED_ATTN=1
+export NCCL_DEBUG=VERSION
 export NVTE_CK_USES_BWD_V3=1
+export NVTE_CK_USES_FWD_V3=1
+export NVTE_CK_IS_V3_ATOMIC_FP32=0
+export NVTE_CK_HOW_V3_BF16_CVT=2
+export NVTE_FUSED_ATTN_CK=1
+export NVTE_FUSED_ATTN_AOTRITON=0

--- a/scripts/jax-maxtext/env_scripts/llama3.3_70b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/llama3.3_70b_env.sh
@@ -24,7 +24,18 @@
 #
 #################################################################################
 
-export XLA_FLAGS="--xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_graph_level=0 --xla_gpu_autotune_level=0 --xla_gpu_enable_reduce_scatter_combine_by_dim=false --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_all_reduce_combine_threshold_bytes=8589934592  --xla_gpu_all_gather_combine_threshold_bytes=137438953472 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
-export XLA_PYTHON_CLIENT_MEM_FRACTION=0.975
-export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH
+export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
+export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
+export NVTE_USE_HIPBLASLT=1
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export GPU_MAX_HW_QUEUES=2
+export HIP_FORCE_DEV_KERNARG=1
+export HSA_FORCE_FINE_GRAIN_PCIE=1
+export NVTE_FUSED_ATTN=1
+export NCCL_DEBUG=VERSION
 export NVTE_CK_USES_BWD_V3=1
+export NVTE_CK_USES_FWD_V3=1
+export NVTE_CK_IS_V3_ATOMIC_FP32=0
+export NVTE_CK_HOW_V3_BF16_CVT=2
+export NVTE_FUSED_ATTN_CK=1
+export NVTE_FUSED_ATTN_AOTRITON=0

--- a/scripts/jax-maxtext/env_scripts/llama3_70b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/llama3_70b_env.sh
@@ -24,7 +24,18 @@
 #
 #################################################################################
 
-export XLA_FLAGS="--xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_graph_level=0 --xla_gpu_autotune_level=0 --xla_gpu_enable_reduce_scatter_combine_by_dim=false --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_all_reduce_combine_threshold_bytes=8589934592  --xla_gpu_all_gather_combine_threshold_bytes=137438953472 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
-export XLA_PYTHON_CLIENT_MEM_FRACTION=0.975
-export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH
+export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
+export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
+export NVTE_USE_HIPBLASLT=1
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export GPU_MAX_HW_QUEUES=2
+export HIP_FORCE_DEV_KERNARG=1
+export HSA_FORCE_FINE_GRAIN_PCIE=1
+export NVTE_FUSED_ATTN=1
+export NCCL_DEBUG=VERSION
 export NVTE_CK_USES_BWD_V3=1
+export NVTE_CK_USES_FWD_V3=1
+export NVTE_CK_IS_V3_ATOMIC_FP32=0
+export NVTE_CK_HOW_V3_BF16_CVT=2
+export NVTE_FUSED_ATTN_CK=1
+export NVTE_FUSED_ATTN_AOTRITON=0

--- a/scripts/jax-maxtext/env_scripts/llama3_8b.yml
+++ b/scripts/jax-maxtext/env_scripts/llama3_8b.yml
@@ -44,7 +44,7 @@ ici_fsdp_parallelism: 8
 ici_data_parallelism: 1
 remat_policy: "minimal_flash"
 use_iota_embed: True
-scan_layers: False
+scan_layers: True
 async_checkpointing: False
 logits_dot_in_fp32: False
 profiler: ""

--- a/scripts/jax-maxtext/env_scripts/llama3_8b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/llama3_8b_env.sh
@@ -24,7 +24,18 @@
 #
 #################################################################################
 
-export XLA_FLAGS="--xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_graph_level=0 --xla_gpu_autotune_level=0 --xla_gpu_enable_latency_hiding_scheduler=TRUE --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_all_gather_combine_by_dim=FALSE --xla_gpu_memory_limit_slop_factor=95"
-export XLA_PYTHON_CLIENT_MEM_FRACTION=0.967
-export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH
+export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
+export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
+export NVTE_USE_HIPBLASLT=1
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export GPU_MAX_HW_QUEUES=2
+export HIP_FORCE_DEV_KERNARG=1
+export HSA_FORCE_FINE_GRAIN_PCIE=1
+export NVTE_FUSED_ATTN=1
+export NCCL_DEBUG=VERSION
 export NVTE_CK_USES_BWD_V3=1
+export NVTE_CK_USES_FWD_V3=1
+export NVTE_CK_IS_V3_ATOMIC_FP32=0
+export NVTE_CK_HOW_V3_BF16_CVT=2
+export NVTE_FUSED_ATTN_CK=1
+export NVTE_FUSED_ATTN_AOTRITON=0

--- a/scripts/jax-maxtext/env_scripts/mixtral_8x7b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/mixtral_8x7b_env.sh
@@ -24,7 +24,18 @@
 #
 #################################################################################
 
-export XLA_FLAGS="--xla_gpu_enable_triton_gemm=False --xla_gpu_enable_latency_hiding_scheduler=TRUE --xla_gpu_enable_cublaslt=True --xla_gpu_graph_level=0  --xla_gpu_autotune_level=5 --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_all_gather_combine_by_dim=FALSE --xla_gpu_memory_limit_slop_factor=95"
-export XLA_PYTHON_CLIENT_MEM_FRACTION=0.967
-export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH
+export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
+export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
+export NVTE_USE_HIPBLASLT=1
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export GPU_MAX_HW_QUEUES=2
+export HIP_FORCE_DEV_KERNARG=1
+export HSA_FORCE_FINE_GRAIN_PCIE=1
+export NVTE_FUSED_ATTN=1
+export NCCL_DEBUG=VERSION
 export NVTE_CK_USES_BWD_V3=1
+export NVTE_CK_USES_FWD_V3=1
+export NVTE_CK_IS_V3_ATOMIC_FP32=0
+export NVTE_CK_HOW_V3_BF16_CVT=2
+export NVTE_FUSED_ATTN_CK=1
+export NVTE_FUSED_ATTN_AOTRITON=0


### PR DESCRIPTION
Patch for Jax-Maxtext v25.7 using Jax version 0.6.0
The following update

- Fixes nanoo FP8 issue in v25.7 Jax 0.6.0
- Improves performance of select models

