### PR TITLE
fix gpt-oss and qwen moe configs

### DIFF
--- a/scripts/vllm/configs/extended.csv
+++ b/scripts/vllm/configs/extended.csv
@@ -1,6 +1,6 @@
 model,benchmark,tp,in,out,bs,num_prompts,max_concurrency,datatype,max_num_seqs,max_num_batched_tokens,max_model_len,gpu_memory_utilization
 openai/gpt-oss-20b,throughput,1,128,2048,,1024,,bfloat16,1024,8192,8192,0.9
-openai/gpt-oss-20b,serving,1,128 2048,128 2048,,,1 8 32 128,bfloat16,1024,8192,8192,0.9
+openai/gpt-oss-20b,serving,1,128,2048,,,128,bfloat16,1024,8192,8192,0.9
 
 meta-llama/Llama-2-70b-chat-hf,throughput,8,128,2048,,1024,,float16,1024,4096,4096,0.9
 meta-llama/Llama-2-70b-chat-hf,serving,8,128,2048,,,128,float16,1024,4096,4096,0.9
@@ -41,8 +41,8 @@ Qwen/Qwen3-30B-A3B,serving,1,128,2048,,,128,float16,1024,40960,8192,0.9
 Qwen/Qwen3-30B-A3B-FP8,throughput,1,128,2048,,1024,,float8,1024,40960,8192,0.9
 Qwen/Qwen3-30B-A3B-FP8,serving,1,128,2048,,,128,float8,1024,40960,8192,0.9
 
-Qwen/Qwen3-235B-A22B,throughput,8,128,2048,,1024,,float16,1024,40960,8192,0.9
-Qwen/Qwen3-235B-A22B,serving,8,128,2048,,,128,float16,1024,40960,8192,0.9
+Qwen/Qwen3-235B-A22B,throughput,4,128,2048,,1024,,float16,1024,40960,8192,0.9
+Qwen/Qwen3-235B-A22B,serving,4,128,2048,,,128,float16,1024,40960,8192,0.9
 
-Qwen/Qwen3-235B-A22B-FP8,throughput,8,128,2048,,1024,,float8,1024,40960,8192,0.9
-Qwen/Qwen3-235B-A22B-FP8,serving,8,128,2048,,,128,float8,1024,40960,8192,0.9
+Qwen/Qwen3-235B-A22B-FP8,throughput,4,128,2048,,1024,,float8,1024,40960,8192,0.9
+Qwen/Qwen3-235B-A22B-FP8,serving,4,128,2048,,,128,float8,1024,40960,8192,0.9


### PR DESCRIPTION
## Motivation

- gpt-oss 20b is a P1 model and should just be running one config, similar to the other models in extended. csv
- Qwen 235B uses block-scaled gemms which in TP8 (1536 / 8 = 128) is not divisible by a power of 2 (i.e. 128), so we need to use TP4. In future releases we may add --enable-expert-parallel to enable TP8 TP+EP for this model.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
