### PR TITLE
pytorch-xdit:v25.10 release

### DIFF
--- a/benchmark/xdit/README.md
+++ b/benchmark/xdit/README.md
@@ -1,0 +1,41 @@
+# xDiT Diffusion inference
+
+rocm/pytorch-xdit images support several diffusion model inference workloads on gfx942
+and gfx950 series (AMD Instinct™ MI300X, MI308X, MI325X and MI350X, MI355X) GPUs. The
+image has ROCm 7.9.0 (preview, based on [TheRock](https://github.com/ROCm/TheRock)) and uses
+[xDiT](https://github.com/xdit-project/xDiT) distributed diffusion model inference
+framework for high-performance text and video generation.
+
+## Setup
+
+Use
+
+```sh
+git clone https://github.com/ROCm/MAD
+cd MAD
+pip install -r requirements.txt
+```
+
+to clone the ROCm Model Automation and Dashboarding (MAD) repository to a local directory
+and install the required packages on the host machine.
+
+## Run MAD benchmarks
+
+Execute benchmarks with
+
+```sh
+MAD_SECRETS_HFTOKEN=HFTOKEN madengine run --tags TAG --live-output
+```
+
+where `HFTOKEN` is a valid Hugging Face token (note that some models are gated) and TAG
+a supported MAD model tag. See Available models section for more details. The inference
+latencies can be found from `results.csv` once the benchmark runs have finished.
+
+## Available models
+
+| MAD model TAG                  | Model repository                                              |
+| -------------------------------| --------------------------------------------------------------|
+| pyt_xdit_hunyuanvideo          | [HunyuanVideo](https://huggingface.co/tencent/HunyuanVideo)   |
+| pyt_xdit_wan_2_1               | [Wan 2.1](https://huggingface.co/Wan-AI/Wan2.1-I2V-14B-720P)  |
+| pyt_xdit_wan_2_2               | [Wan 2.2](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B)      |
+| pyt_xdit_flux                  | [Flux.1](https://huggingface.co/black-forest-labs/FLUX.1-dev) |

--- a/docker/pyt_xdit.ubuntu.amd.Dockerfile
+++ b/docker/pyt_xdit.ubuntu.amd.Dockerfile
@@ -1,0 +1,30 @@
+# CONTEXT {'gpu_vendor': 'AMD', 'guest_os': 'UBUNTU'}
+###############################################################################
+#
+# MIT License
+#
+# Copyright (c) Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#################################################################################
+ARG BASE_DOCKER=rocm/pytorch-xdit:v25.10
+FROM ${BASE_DOCKER} AS base
+
+RUN apt-get update && apt install -y lshw && rm -rf /var/lib/apt/lists/*

--- a/models.json
+++ b/models.json
@@ -2039,5 +2039,74 @@
     "timeout": -1,
     "args":
     ""
+  },
+  {
+    "name": "pyt_xdit_hunyuanvideo",
+    "dockerfile": "docker/pyt_xdit",
+    "scripts": "scripts/pyt_xdit/run.sh",
+    "n_gpus": "8",
+    "owner": "nsakkine@amd.com",
+    "training_precision": "",
+    "tags": [
+        "inference",
+        "diffusion",
+        "t2v",
+        "pyt",
+        "xdit"
+    ],
+    "args": "--workload hunyuanvideo",
+    "multiple_results": "results.csv"
+  },
+  {
+    "name": "pyt_xdit_wan_2_1",
+    "dockerfile": "docker/pyt_xdit",
+    "scripts": "scripts/pyt_xdit/run.sh",
+    "n_gpus": "8",
+    "owner": "nsakkine@amd.com",
+    "training_precision": "",
+    "tags": [
+        "inference",
+        "diffusion",
+        "i2v",
+        "pyt",
+        "xdit"
+    ],
+    "args": "--workload wan_2_1",
+    "multiple_results": "results.csv"
+  },
+  {
+    "name": "pyt_xdit_wan_2_2",
+    "dockerfile": "docker/pyt_xdit",
+    "scripts": "scripts/pyt_xdit/run.sh",
+    "n_gpus": "8",
+    "owner": "nsakkine@amd.com",
+    "training_precision": "",
+    "tags": [
+        "inference",
+        "diffusion",
+        "i2v",
+        "pyt",
+        "xdit"
+    ],
+    "args": "--workload wan_2_2",
+    "multiple_results": "results.csv"
+  },
+  {
+    "name": "pyt_xdit_flux",
+    "dockerfile": "docker/pyt_xdit",
+    "scripts": "scripts/pyt_xdit/run.sh",
+    "n_gpus": "8",
+    "owner": "nsakkine@amd.com",
+    "training_precision": "",
+    "tags": [
+        "inference",
+        "diffusion",
+        "t2i",
+        "pyt",
+        "xdit"
+    ],
+    "args": "--workload flux",
+    "multiple_results": "results.csv"
   }
 ]
+

--- a/scripts/pyt_xdit/run.sh
+++ b/scripts/pyt_xdit/run.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+###############################################################################
+#
+# MIT License
+#
+# Copyright (c) Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#################################################################################
+OPTIONS=$(getopt -o w:v --long workload:,verbose -- "$@")
+
+if [ $? -ne 0 ]; then
+  echo "Failed to parse options." >&2
+  exit 1
+fi
+
+eval set -- "$OPTIONS"
+
+# Parse options
+while true; do
+  case "$1" in
+    -w|--workload)
+      WORKLOAD="$2"
+      shift 2
+      ;;
+    -v|--verbose)
+      VERBOSE=true
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT="/app/.ci/run.${WORKLOAD}.sh"
+
+if [ ! -e $SCRIPT ]; then
+    echo "'$SCRIPT' not found" >&2
+    exit 1
+fi
+
+# set HF_TOKEN
+export HF_TOKEN=$MAD_SECRETS_HFTOKEN
+
+# temporary fix to handle host ROCm version <6.4.2
+export HSA_NO_SCRATCH_RECLAIM=1
+
+# run workload
+cat "$SCRIPT"
+RECORDS=$(bash $SCRIPT)
+
+if [ $? -ne 0 ]; then
+  echo "Failed to run workload" >&2
+  exit 1
+fi
+
+if [ $VERBOSE ]; then
+    echo "$RECORDS"
+fi
+
+# save results
+echo -e "model,performance,metric" > ../results.csv
+echo -e "$RECORDS"  >> ../results.csv


### PR DESCRIPTION
Purpose is to add pytorch-xdit:v25.10 image to MAD workflows and to publish it.

Work here contains

- Dockerfile wrapping pytorch-xdit:v25.10
- a run script to execute selected diffusion model inference workloads
- updated models.json