### PR TITLE
pytorch-xdit:v25.11 release

### DIFF
--- a/benchmark/xdit/README.md
+++ b/benchmark/xdit/README.md
@@ -2,9 +2,9 @@
 
 rocm/pytorch-xdit images support several diffusion model inference workloads on gfx942
 and gfx950 series (AMD Instinct™ MI300X, MI308X, MI325X and MI350X, MI355X) GPUs. The
-image has ROCm 7.9.0 (preview, based on [TheRock](https://github.com/ROCm/TheRock)) and uses
+image has ROCm preview (based on [TheRock](https://github.com/ROCm/TheRock)) and uses
 [xDiT](https://github.com/xdit-project/xDiT) distributed diffusion model inference
-framework for high-performance text and video generation.
+framework for high-performance image and video generation.
 
 ## Setup
 
@@ -33,9 +33,9 @@ latencies can be found from `results.csv` once the benchmark runs have finished.
 
 ## Available models
 
-| MAD model TAG                  | Model repository                                              |
-| -------------------------------| --------------------------------------------------------------|
-| pyt_xdit_hunyuanvideo          | [HunyuanVideo](https://huggingface.co/tencent/HunyuanVideo)   |
-| pyt_xdit_wan_2_1               | [Wan 2.1](https://huggingface.co/Wan-AI/Wan2.1-I2V-14B-720P)  |
-| pyt_xdit_wan_2_2               | [Wan 2.2](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B)      |
-| pyt_xdit_flux                  | [Flux.1](https://huggingface.co/black-forest-labs/FLUX.1-dev) |
+| MAD model TAG                  | Model repository                                                                      |
+| -------------------------------| --------------------------------------------------------------------------------------|
+| pyt_xdit_hunyuanvideo          | [HunyuanVideo](https://huggingface.co/tencent/HunyuanVideo)                           |
+| pyt_xdit_wan_2_1               | [Wan 2.1](https://huggingface.co/Wan-AI/Wan2.1-I2V-14B-720P)                          |
+| pyt_xdit_wan_2_2               | [Wan 2.2](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B)                              |
+| pyt_xdit_flux                  | [Flux.1](https://huggingface.co/black-forest-labs/FLUX.1-dev)                         |

--- a/docker/pyt_xdit.ubuntu.amd.Dockerfile
+++ b/docker/pyt_xdit.ubuntu.amd.Dockerfile
@@ -24,7 +24,7 @@
 # SOFTWARE.
 #
 #################################################################################
-ARG BASE_DOCKER=rocm/pytorch-xdit:v25.10
+ARG BASE_DOCKER=rocm/pytorch-xdit:v25.11
 FROM ${BASE_DOCKER} AS base
 
 RUN apt-get update && apt install -y lshw && rm -rf /var/lib/apt/lists/*

--- a/scripts/pyt_xdit/run.sh
+++ b/scripts/pyt_xdit/run.sh
@@ -69,8 +69,11 @@ export HF_TOKEN=$MAD_SECRETS_HFTOKEN
 export HSA_NO_SCRATCH_RECLAIM=1
 
 # run workload
-cat "$SCRIPT"
-RECORDS=$(bash $SCRIPT)
+echo "Run instructions:"
+bash $SCRIPT --help
+echo "Run configurations:"
+bash $SCRIPT --mad --dry-run
+RECORDS=$(bash $SCRIPT --mad)
 
 if [ $? -ne 0 ]; then
   echo "Failed to run workload" >&2


### PR DESCRIPTION
Purpose is to add pytorch-xdit:v25.11 image to MAD workflows and to publish it.

Work here contains

- Dockerfile wrapping pytorch-xdit:v25.11
- a run script to execute selected diffusion model inference workloads
- README instructions