### PR TITLE
jax-maxtext training v25.11

### DIFF
--- a/benchmark/jax_maxtext/README.md
+++ b/benchmark/jax_maxtext/README.md
@@ -10,13 +10,26 @@ AMD provides a ready-to-use Docker image for AMD Instinct MI300X and MI355X GPUs
 >Shardy is a new config in JAX 0.6.0. You might get related errors if it's not configured correctly. For now you can turn it off by setting `shardy=False` during the training run. You can also follow the [migration guide](https://docs.jax.dev/en/latest/shardy_jax_migration.html) to enable it.
 >
 
+>[!NOTE]
+>There are known issues of rocm/jax-training:maxtext-v25.11.
+> 1. Minor performance regression (< 4%) for bf16 quantization in llama models and Mixtral 8x7b. 
+> 2. You may potentially see minor loss spikes, or loss curve may have slightly higher convergence end value w.r.t the previous image.
+> 3. For FP8 training on MI355, many models will display a warning message like: `Warning: Latency not found for MI_M=16, MI_N=16, MI_K=128, mi_input_type=BFloat8Float8_fnuz. Returning latency value of 32 (really slow).` The compile step may take longer than usual, but training will run. We are currently investigating this and will fix for the next release.
+> 4. The built-in JAX profiler isn't working. See [Profiling with rocprofv3](#profiling-with-rocprofv3) for details on how to profile with rocprofv3.
+>
+
+>[!NOTE]
+>We have refreshed the image from the previous release `rocm/jax-training:maxtext-v25.9` as `rocm/jax-training:maxtext-v25.9.1`.
+>This should include a fix to address segmentation fault issues during the launch of the previous image.
+>
+
 | Software component | Version        |
 |--------------------|----------------|
-| ROCm               | 7.0.0         |
-| Jax                | 0.6.2          |
-| Python             | 3.10.18        |
-| Transformer Engine | 2.2.0.dev0+c91bac54 |
-| hipBLASLt          | 1.x.x          |
+| ROCm               | 7.1.0         |
+| Jax                | 0.7.1          |
+| Python             | 3.12.3        |
+| Transformer Engine | 2.4.0.dev0+281042de |
+| hipBLASLt          | 1.2.x          |
 
 
 ## Supported features and models
@@ -166,7 +179,7 @@ Download and launch the Docker image
 Use the following command to pull the Docker image from Docker Hub.
 
 ```
-docker pull rocm/jax-training:maxtext-v25.9
+docker pull rocm/jax-training:maxtext-v25.11
 ```
 ### Single Node Training examples
 
@@ -186,7 +199,7 @@ export HF_HOME=<Location of saved/cached HuggingFace models>
 Launch the Docker container.
 
 ```
-docker run -it --device /dev/dri --device /dev/kfd --network host --ipc host --group-add video --cap-add SYS_PTRACE --security-opt seccomp=unconfined --privileged -v $HOME:$HOME -v $HOME/.ssh:/root/.ssh -v $HF_HOME:/hf_cache -e HF_HOME=/hf_cache -e MAD_SECRETS_HFTOKEN=$MAD_SECRETS_HFTOKEN --shm-size 64G --name training_env rocm/jax-training:maxtext-v25.9
+docker run -it --device /dev/dri --device /dev/kfd --network host --ipc host --group-add video --cap-add SYS_PTRACE --security-opt seccomp=unconfined --privileged -v $HOME:$HOME -v $HOME/.ssh:/root/.ssh -v $HF_HOME:/hf_cache -e HF_HOME=/hf_cache -e MAD_SECRETS_HFTOKEN=$MAD_SECRETS_HFTOKEN --shm-size 64G --name training_env rocm/jax-training:maxtext-v25.11
 ```
 
 Execute the training_env container (optional if not already in the container)
@@ -409,3 +422,13 @@ Run the benchmark for multinode node traininig
 ```
 sbatch --export=ALL,IMAGE=<image_name> -N <num_nodes> llama3_70b_multinode.sh
 ```
+
+## Profiling with rocprofv3
+
+If you need to collect a trace and the JAX profiler isn't working then you can use rocprofv3 as a temporary workaround like this:
+```
+rocprofv3 --hip-trace --kernel-trace --memory-copy-trace --rccl-trace --output-format pftrace -d ./v3_traces -- python3 app.py
+```
+- Just replace `python3 app.py` with any command line command that you want to run such as `./jax-maxtext_benchmark_report.sh -m Llama-2-7B`.
+- You can set the directory where you want the .json traces to be saved using `-d <TRACE_DIRECTORY>`
+- The resulting traces can be opened in perfetto: https://ui.perfetto.dev/

--- a/docker/jax_maxtext.ubuntu.amd.Dockerfile
+++ b/docker/jax_maxtext.ubuntu.amd.Dockerfile
@@ -21,7 +21,7 @@
 # SOFTWARE.
 #
 #################################################################################
-ARG BASE_DOCKER=rocm/jax-training:maxtext-v25.9
+ARG BASE_DOCKER=rocm/jax-training:maxtext-v25.11
 FROM $BASE_DOCKER
 
 USER root

--- a/scripts/jax-maxtext/env_scripts/deepseek2_env_16b.sh
+++ b/scripts/jax-maxtext/env_scripts/deepseek2_env_16b.sh
@@ -27,7 +27,7 @@
 export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
 export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
 export NVTE_USE_HIPBLASLT=1
-export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
 export GPU_MAX_HW_QUEUES=2
 export HIP_FORCE_DEV_KERNARG=1
 export HSA_FORCE_FINE_GRAIN_PCIE=1

--- a/scripts/jax-maxtext/env_scripts/gfx950_deepseek2_env_16b.sh
+++ b/scripts/jax-maxtext/env_scripts/gfx950_deepseek2_env_16b.sh
@@ -25,10 +25,11 @@
 #################################################################################
 
 export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
-export XLA_PYTHON_CLIENT_MEM_FRACTION=0.975	export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
-export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH	export NVTE_USE_HIPBLASLT=1
+export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
+export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH
+export NVTE_USE_HIPBLASLT=1
 export NVTE_CK_USES_BWD_V3=1
-export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=4 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
 export GPU_MAX_HW_QUEUES=2
 export HIP_FORCE_DEV_KERNARG=1
 export HSA_FORCE_FINE_GRAIN_PCIE=1

--- a/scripts/jax-maxtext/env_scripts/gfx950_llama2_70b.yml
+++ b/scripts/jax-maxtext/env_scripts/gfx950_llama2_70b.yml
@@ -27,6 +27,7 @@
 
 base_config: "base.yml"
 run_name: "llama2_70b_training"
+base_output_directory: "./"
 hardware: "gpu"
 steps: 30
 model_name: "llama2-70b"

--- a/scripts/jax-maxtext/env_scripts/gfx950_llama2_70b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/gfx950_llama2_70b_env.sh
@@ -25,10 +25,11 @@
 #################################################################################
 
 export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
-export XLA_PYTHON_CLIENT_MEM_FRACTION=0.975	export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
-export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH	export NVTE_USE_HIPBLASLT=1
+export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
+export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH
+export NVTE_USE_HIPBLASLT=1
 export NVTE_CK_USES_BWD_V3=1
-export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=4 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
 export GPU_MAX_HW_QUEUES=2
 export HIP_FORCE_DEV_KERNARG=1
 export HSA_FORCE_FINE_GRAIN_PCIE=1

--- a/scripts/jax-maxtext/env_scripts/gfx950_llama2_7b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/gfx950_llama2_7b_env.sh
@@ -25,10 +25,11 @@
 #################################################################################
 
 export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
-export XLA_PYTHON_CLIENT_MEM_FRACTION=0.975	export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
-export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH	export NVTE_USE_HIPBLASLT=1
+export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
+export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH
+export NVTE_USE_HIPBLASLT=1
 export NVTE_CK_USES_BWD_V3=1
-export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=4 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
 export GPU_MAX_HW_QUEUES=2
 export HIP_FORCE_DEV_KERNARG=1
 export HSA_FORCE_FINE_GRAIN_PCIE=1

--- a/scripts/jax-maxtext/env_scripts/gfx950_llama3.3_70b.yml
+++ b/scripts/jax-maxtext/env_scripts/gfx950_llama3.3_70b.yml
@@ -26,6 +26,7 @@
 
 base_config: "base.yml"
 run_name: "llama3.3_70b_training"
+base_output_directory: "./"
 hardware: "gpu"
 steps: 30
 model_name: "llama3.3-70b"

--- a/scripts/jax-maxtext/env_scripts/gfx950_llama3.3_70b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/gfx950_llama3.3_70b_env.sh
@@ -25,10 +25,11 @@
 #################################################################################
 
 export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
-export XLA_PYTHON_CLIENT_MEM_FRACTION=0.975	export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
-export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH	export NVTE_USE_HIPBLASLT=1
+export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
+export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH
+export NVTE_USE_HIPBLASLT=1
 export NVTE_CK_USES_BWD_V3=1
-export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=4 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
 export GPU_MAX_HW_QUEUES=2
 export HIP_FORCE_DEV_KERNARG=1
 export HSA_FORCE_FINE_GRAIN_PCIE=1

--- a/scripts/jax-maxtext/env_scripts/gfx950_llama3_70b.yml
+++ b/scripts/jax-maxtext/env_scripts/gfx950_llama3_70b.yml
@@ -26,6 +26,7 @@
 
 base_config: "base.yml"
 run_name: "llama3_70b_training"
+base_output_directory: "./"
 hardware: "gpu"
 steps: 30
 model_name: "llama3-70b"

--- a/scripts/jax-maxtext/env_scripts/gfx950_llama3_70b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/gfx950_llama3_70b_env.sh
@@ -25,10 +25,11 @@
 #################################################################################
 
 export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
-export XLA_PYTHON_CLIENT_MEM_FRACTION=0.975	export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
-export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH	export NVTE_USE_HIPBLASLT=1
+export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
+export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH
+export NVTE_USE_HIPBLASLT=1
 export NVTE_CK_USES_BWD_V3=1
-export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=4 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
 export GPU_MAX_HW_QUEUES=2
 export HIP_FORCE_DEV_KERNARG=1
 export HSA_FORCE_FINE_GRAIN_PCIE=1

--- a/scripts/jax-maxtext/env_scripts/gfx950_llama3_8b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/gfx950_llama3_8b_env.sh
@@ -25,10 +25,11 @@
 #################################################################################
 
 export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
-export XLA_PYTHON_CLIENT_MEM_FRACTION=0.975	export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
-export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH	export NVTE_USE_HIPBLASLT=1
+export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
+export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH
+export NVTE_USE_HIPBLASLT=1
 export NVTE_CK_USES_BWD_V3=1
-export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=4 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
 export GPU_MAX_HW_QUEUES=2
 export HIP_FORCE_DEV_KERNARG=1
 export HSA_FORCE_FINE_GRAIN_PCIE=1

--- a/scripts/jax-maxtext/env_scripts/gfx950_mixtral_8x7b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/gfx950_mixtral_8x7b_env.sh
@@ -25,10 +25,11 @@
 #################################################################################
 
 export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
-export XLA_PYTHON_CLIENT_MEM_FRACTION=0.975	export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
-export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH	export NVTE_USE_HIPBLASLT=1
+export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
+export LD_LIBRARY_PATH=/usr/local/lib/:/opt/rocm/lib:$LD_LIBRARY_PATH
+export NVTE_USE_HIPBLASLT=1
 export NVTE_CK_USES_BWD_V3=1
-export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=4 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
 export GPU_MAX_HW_QUEUES=2
 export HIP_FORCE_DEV_KERNARG=1
 export HSA_FORCE_FINE_GRAIN_PCIE=1

--- a/scripts/jax-maxtext/env_scripts/llama2_70b.yml
+++ b/scripts/jax-maxtext/env_scripts/llama2_70b.yml
@@ -27,6 +27,7 @@
 
 base_config: "base.yml"
 run_name: "llama2_70b_training"
+base_output_directory: "./"
 hardware: "gpu"
 steps: 30
 model_name: "llama2-70b"

--- a/scripts/jax-maxtext/env_scripts/llama2_70b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/llama2_70b_env.sh
@@ -27,7 +27,7 @@
 export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
 export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
 export NVTE_USE_HIPBLASLT=1
-export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
 export GPU_MAX_HW_QUEUES=2
 export HIP_FORCE_DEV_KERNARG=1
 export HSA_FORCE_FINE_GRAIN_PCIE=1

--- a/scripts/jax-maxtext/env_scripts/llama2_7b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/llama2_7b_env.sh
@@ -27,7 +27,7 @@
 export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
 export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
 export NVTE_USE_HIPBLASLT=1
-export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
 export GPU_MAX_HW_QUEUES=2
 export HIP_FORCE_DEV_KERNARG=1
 export HSA_FORCE_FINE_GRAIN_PCIE=1

--- a/scripts/jax-maxtext/env_scripts/llama3.3_70b.yml
+++ b/scripts/jax-maxtext/env_scripts/llama3.3_70b.yml
@@ -26,6 +26,7 @@
 
 base_config: "base.yml"
 run_name: "llama3.3_70b_training"
+base_output_directory: "./"
 hardware: "gpu"
 steps: 30
 model_name: "llama3.3-70b"

--- a/scripts/jax-maxtext/env_scripts/llama3.3_70b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/llama3.3_70b_env.sh
@@ -27,7 +27,7 @@
 export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
 export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
 export NVTE_USE_HIPBLASLT=1
-export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
 export GPU_MAX_HW_QUEUES=2
 export HIP_FORCE_DEV_KERNARG=1
 export HSA_FORCE_FINE_GRAIN_PCIE=1

--- a/scripts/jax-maxtext/env_scripts/llama3_70b.yml
+++ b/scripts/jax-maxtext/env_scripts/llama3_70b.yml
@@ -26,6 +26,7 @@
 
 base_config: "base.yml"
 run_name: "llama3_70b_training"
+base_output_directory: "./"
 hardware: "gpu"
 steps: 30
 model_name: "llama3-70b"

--- a/scripts/jax-maxtext/env_scripts/llama3_70b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/llama3_70b_env.sh
@@ -27,7 +27,7 @@
 export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
 export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
 export NVTE_USE_HIPBLASLT=1
-export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
 export GPU_MAX_HW_QUEUES=2
 export HIP_FORCE_DEV_KERNARG=1
 export HSA_FORCE_FINE_GRAIN_PCIE=1

--- a/scripts/jax-maxtext/env_scripts/llama3_8b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/llama3_8b_env.sh
@@ -27,7 +27,7 @@
 export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
 export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
 export NVTE_USE_HIPBLASLT=1
-export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
 export GPU_MAX_HW_QUEUES=2
 export HIP_FORCE_DEV_KERNARG=1
 export HSA_FORCE_FINE_GRAIN_PCIE=1

--- a/scripts/jax-maxtext/env_scripts/mixtral_8x7b_env.sh
+++ b/scripts/jax-maxtext/env_scripts/mixtral_8x7b_env.sh
@@ -27,7 +27,7 @@
 export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1
 export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
 export NVTE_USE_HIPBLASLT=1
-export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
 export GPU_MAX_HW_QUEUES=2
 export HIP_FORCE_DEV_KERNARG=1
 export HSA_FORCE_FINE_GRAIN_PCIE=1

--- a/scripts/jax-maxtext/jax-maxtext_benchmark_report.py
+++ b/scripts/jax-maxtext/jax-maxtext_benchmark_report.py
@@ -47,6 +47,18 @@ parser.add_argument("--input",
 parser.add_argument("--output",
                         type=str,
                         help="path to output file")
+parser.add_argument("--batch_size",
+                        type=str,
+                        help="batch size")
+parser.add_argument("--seq_len",
+                        type=str,
+                        help="sequence length")
+parser.add_argument("--device",
+                        type=str,
+                        help="device name")
+parser.add_argument("--num_gpus",
+                        type=str,
+                        help="number of GPUs")
 
 # read arguments
 args = parser.parse_args()
@@ -73,14 +85,14 @@ if args.model == "Llama-3.1-8B" or args.model == "Llama-3.1-70B" or \
     tok_per_s_per_gpu = find_match(input_file, "Tokens/s/device:", 10)
     TFLOPS_per_gpu = find_match(input_file, "TFLOP/s/device:", 10)
     data = [
-        {'model': args.model, 'performance': tok_per_s_per_gpu, 'metric': 'tok_per_s_per_gpu'},
-        {'model': args.model, 'performance': TFLOPS_per_gpu, 'metric': 'TFLOPS_per_gpu'}
+        {'model': args.model, 'performance': tok_per_s_per_gpu, 'metric': 'tok_per_s_per_gpu', 'mode': args.mode, 'precision': args.quantization, 'batch_size': args.batch_size, 'seq_len': args.seq_len, 'device': args.device, 'num_gpus': args.num_gpus},
+        {'model': args.model, 'performance': TFLOPS_per_gpu, 'metric': 'TFLOPS_per_gpu', 'mode': args.mode, 'precision': args.quantization, 'batch_size': args.batch_size, 'seq_len': args.seq_len, 'device': args.device, 'num_gpus': args.num_gpus}
     ]
 
 with open(output_file, mode='w', newline='') as file:
     print("Preparing to write performance data...")
     print("Data: ", data)
-    writer = csv.DictWriter(file, fieldnames=['model','performance','metric'])
+    writer = csv.DictWriter(file, fieldnames=['model','performance','metric','mode','precision','batch_size','seq_len','device','num_gpus'])
     writer.writeheader()
     writer.writerows(data)
     print("Completed writing to output file")

--- a/scripts/jax-maxtext/jax-maxtext_benchmark_report.sh
+++ b/scripts/jax-maxtext/jax-maxtext_benchmark_report.sh
@@ -37,6 +37,12 @@ while getopts "m:q:" opt; do
     esac
 done
 
+# Set default values for additional parameters
+MODE="pretrain"
+NNODES=1 # default to 1 node
+GPUS_PER_NODE=8 # default to 8 GPUs per node
+NUM_GPUS=$((NNODES*GPUS_PER_NODE))
+
 echo "=hyper params start="
 echo $MODEL_REPO
 echo $QUANTIZATION
@@ -48,6 +54,18 @@ else
   PERF_LOG="$(pwd)/../perf_${MODEL_REPO}_${QUANTIZATION}.csv"
 fi
 perf_script="$(pwd)/jax-maxtext_benchmark_report.py"
+
+# Run rocminfo and grep for "AMD Instinct"
+DEVICE=$(/opt/rocm/bin/rocminfo | grep "AMD Instinct" | head -n1 | awk '{print $5}')
+if [ -z "$DEVICE" ]; then
+  ARCH=$(/opt/rocm/bin/rocminfo | grep -o 'gfx942\|gfx950' | head -n 1 | tr -d '[:space:]')
+  case "$ARCH" in
+    "gfx942") DEVICE="MI300X" ;;
+    "gfx950") DEVICE="MI355X" ;;
+    *) DEVICE="" ;;
+  esac
+fi             
+echo "GPU DEVICE name: $DEVICE"
 
 MAXTEXT="/workspace/maxtext"
 MAXTEXT_DIR="/workspace/maxtext/MaxText"
@@ -76,14 +94,23 @@ execute_training(){
   echo $config_file
   cat $config_file
 
+  yaml() {
+      python3 -c "import yaml;print(yaml.safe_load(open('$1'))$2)"
+  }
+
+  per_device_batch_size=$(yaml $config_file "['per_device_batch_size']")
+  max_target_length==$(yaml $config_file "['max_target_length']")
+  echo $per_device_batch_size
+  echo $max_target_length
+
   # execute
   source $env_file
   python -m MaxText.train $config_file \
   quantization=$3 2>&1 |& tee -a  $2.log
   if [ -z "$3" ]; then
-    python3 $perf_script --model $MODEL_REPO --input $MAXTEXT/$2.log --output $PERF_LOG
+    python3 $perf_script --model $MODEL_REPO --input $MAXTEXT/$2.log --output $PERF_LOG --mode $MODE --quantization bf16 --batch_size $per_device_batch_size --seq_len $max_target_length --device $DEVICE --num_gpus $NUM_GPUS
   else
-    python3 $perf_script --model $MODEL_REPO --input $MAXTEXT/$2.log --output $PERF_LOG --quantization $3
+    python3 $perf_script --model $MODEL_REPO --input $MAXTEXT/$2.log --output $PERF_LOG --mode $MODE --quantization $3 --batch_size $per_device_batch_size --seq_len $max_target_length --device $DEVICE --num_gpus $NUM_GPUS
   fi
 
 }


### PR DESCRIPTION
New docker rocm/jax-training:maxtext-v25.11   
 ROCm 7.1.0
    JAX 0.7.1
    Python 3.12.3
    TransformerEngine 2.4.0.dev0+281042de
    HipBLASLt

Refreshed previous release rocm/jax-training:maxtext-v25.9 as rocm/jax-training:maxtext-v25.9.1

    Added fix to TE to address segmentation fault issue
