### PR TITLE
pytorch-xdit:v25.13 release 

### DIFF
--- a/benchmark/xdit/README.md
+++ b/benchmark/xdit/README.md
@@ -40,3 +40,6 @@ latencies can be found from `results.csv` once the benchmark runs have finished.
 | pyt_xdit_wan_2_2               | [Wan 2.2](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B)                              |
 | pyt_xdit_flux                  | [Flux.1](https://huggingface.co/black-forest-labs/FLUX.1-dev)                         |
 | pyt_xdit_sd_3_5                | [Stable diffusion 3.5](https://huggingface.co/stabilityai/stable-diffusion-3.5-large) |
+| pyt_xdit_flux_kontext          | [Flux.1 Kontext](https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev)         |
+| pyt_xdit_flux_2                | [Flux.2](https://huggingface.co/black-forest-labs/FLUX.2-dev)                         |
+

--- a/docker/pyt_xdit.ubuntu.amd.Dockerfile
+++ b/docker/pyt_xdit.ubuntu.amd.Dockerfile
@@ -24,7 +24,6 @@
 # SOFTWARE.
 #
 #################################################################################
-ARG BASE_DOCKER=rocm/pytorch-xdit:v25.12
+ARG BASE_DOCKER=rocm/pytorch-xdit:v25.13
 FROM ${BASE_DOCKER} AS base
-
 RUN apt-get update && apt install -y lshw && rm -rf /var/lib/apt/lists/*

--- a/models.json
+++ b/models.json
@@ -2211,6 +2211,40 @@
     ],
     "args": "--workload stablediffusion_3_5",
     "multiple_results": "results.csv"
+  },
+  {
+    "name": "pyt_xdit_flux_kontext",
+    "dockerfile": "docker/pyt_xdit",
+    "scripts": "scripts/pyt_xdit/run.sh",
+    "n_gpus": "8",
+    "owner": "nsakkine@amd.com",
+    "training_precision": "",
+    "tags": [
+        "inference",
+        "diffusion",
+        "ti2i",
+        "pyt",
+        "xdit"
+    ],
+    "args": "--workload flux.kontext",
+    "multiple_results": "results.csv"
+  },
+  {
+    "name": "pyt_xdit_flux_2",
+    "dockerfile": "docker/pyt_xdit",
+    "scripts": "scripts/pyt_xdit/run.sh",
+    "n_gpus": "8",
+    "owner": "nsakkine@amd.com",
+    "training_precision": "",
+    "tags": [
+        "inference",
+        "diffusion",
+        "t2i",
+        "pyt",
+        "xdit"
+    ],
+    "args": "--workload flux2",
+    "multiple_results": "results.csv"
   }
 ]
 


### PR DESCRIPTION
Purpose is to add pytorch-xdit:v25.13 image to MAD workflows and to publish it.
Work here contains

- Dockerfile wrapping rocm/pytorch-xdit:v25.13
- a run script to execute selected diffusion model inference workloads
- updated models.json
- README instructions