### PR TITLE
Fix pyt_mpt30b_training PYTORCH_VERSION

### DIFF
--- a/docker/pyt_mpt30b_training.ubuntu.amd.Dockerfile
+++ b/docker/pyt_mpt30b_training.ubuntu.amd.Dockerfile
@@ -13,7 +13,7 @@ RUN rm -rf /opt/conda/envs/py_3.10/lib/python3.10/site-packages/numpy*
 RUN apt-get remove -y python3-blinker
 
 RUN bash -c "set -x && \
-    export PYTORCH_VERSION=\$(python -c \"import torch; print(torch.__version__)\") && \
+    export PYTORCH_VERSION=\$(pip show torch | grep '^Version:' | awk '{print \$2}' | awk -F '\\+' '{print \$1}') && \
     export PYTORCHVISION_VERSION=\$(pip show torchvision | grep '^Version:' | awk '{print \$2}') && \
     if [[ \"\$PYTORCH_VERSION\" == 2.3* ]]; then \
         LLM_FOUNDRY_BRANCH=\"v0.11.0\"; \


### PR DESCRIPTION
 fix for SWDEV-564759 

RCA:
Issue at line, https://github.com/ROCm/MAD-private/blob/develop/docker/pyt_mpt30b_training.ubuntu.amd.Dockerfile#L16 

that comand will print torch version = torch==2.9.0+rocm7.2.0.git8b386d17 and passing that to https://github.com/mosaicml/composer/blob/v0.28.0/setup.py#L84  file at L84

sed -i 's/'\''torch>=.*/'\''torch==2.9.0+rocm7.2.0.git8b386d17'\'',/' setup.py

but  setup.py is expecting the torch version format as 2.9.0 which is mismatching with 2.9.0+rocm7.2.0.git8b386d17 and throwing the error.

Solution:
https://github.com/ROCm/MAD-private/blob/develop/docker/pyt_mpt30b_training.ubuntu.amd.Dockerfile#L16 
this line, strip the output of torch to 2.9.0 and remove extra "+rocm7.2.0.git8b386d17" then it will work.

Replace
export PYTORCH_VERSION=\$(python -c \"import torch; print(torch.__version__)\")
To
export PYTORCH_VERSION=\$(pip show torch | grep '^Version:' | awk '{print \$2}' | awk -F '\\+' '{print \$1}')
This will print in X.X.X format.