### PR TITLE
pytorch-xdit:v26.1 release

### DIFF
--- a/benchmark/xdit/README.md
+++ b/benchmark/xdit/README.md
@@ -35,11 +35,12 @@ latencies can be found from `results.csv` once the benchmark runs have finished.
 
 | MAD model TAG                  | Model repository                                                                      |
 | -------------------------------| --------------------------------------------------------------------------------------|
-| pyt_xdit_hunyuanvideo          | [HunyuanVideo](https://huggingface.co/tencent/HunyuanVideo)                           |
-| pyt_xdit_wan_2_1               | [Wan 2.1](https://huggingface.co/Wan-AI/Wan2.1-I2V-14B-720P)                          |
-| pyt_xdit_wan_2_2               | [Wan 2.2](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B)                              |
 | pyt_xdit_flux                  | [Flux.1](https://huggingface.co/black-forest-labs/FLUX.1-dev)                         |
-| pyt_xdit_sd_3_5                | [Stable diffusion 3.5](https://huggingface.co/stabilityai/stable-diffusion-3.5-large) |
 | pyt_xdit_flux_kontext          | [Flux.1 Kontext](https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev)         |
 | pyt_xdit_flux_2                | [Flux.2](https://huggingface.co/black-forest-labs/FLUX.2-dev)                         |
-
+| pyt_xdit_hunyuanvideo          | [HunyuanVideo](https://huggingface.co/tencent/HunyuanVideo)                           |
+| pyt_xdit_hunyuanvideo_1_5      | [HunyuanVideo 1.5](https://huggingface.co/tencent/HunyuanVideo-1.5)                   |
+| pyt_xdit_sd_3_5                | [Stable diffusion 3.5](https://huggingface.co/stabilityai/stable-diffusion-3.5-large) |
+| pyt_xdit_wan_2_1               | [Wan 2.1](https://huggingface.co/Wan-AI/Wan2.1-I2V-14B-720P)                          |
+| pyt_xdit_wan_2_2               | [Wan 2.2](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B)                              |
+| pyt_xdit_z_image_turbo         | [Z-Image Turbo](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo)                      |

--- a/docker/pyt_xdit.ubuntu.amd.Dockerfile
+++ b/docker/pyt_xdit.ubuntu.amd.Dockerfile
@@ -24,6 +24,7 @@
 # SOFTWARE.
 #
 #################################################################################
-ARG BASE_DOCKER=rocm/pytorch-xdit:v25.13
+ARG BASE_DOCKER=rocm/pytorch-xdit:v26.1
 FROM ${BASE_DOCKER} AS base
+
 RUN apt-get update && apt install -y lshw && rm -rf /var/lib/apt/lists/*

--- a/models.json
+++ b/models.json
@@ -2142,6 +2142,23 @@
     "multiple_results": "results.csv"
   },
   {
+    "name": "pyt_xdit_hunyuanvideo_1_5",
+    "dockerfile": "docker/pyt_xdit",
+    "scripts": "scripts/pyt_xdit/run.sh",
+    "n_gpus": "8",
+    "owner": "nsakkine@amd.com",
+    "training_precision": "",
+    "tags": [
+        "inference",
+        "diffusion",
+        "t2v",
+        "pyt",
+        "xdit"
+    ],
+    "args": "--workload hunyuanvideo_1_5",
+    "multiple_results": "results.csv"
+  },
+  {
     "name": "pyt_xdit_wan_2_1",
     "dockerfile": "docker/pyt_xdit",
     "scripts": "scripts/pyt_xdit/run.sh",
@@ -2155,7 +2172,7 @@
         "pyt",
         "xdit"
     ],
-    "args": "--workload wan2.1",
+    "args": "--workload wan2_1",
     "multiple_results": "results.csv"
   },
   {
@@ -2172,7 +2189,7 @@
         "pyt",
         "xdit"
     ],
-    "args": "--workload wan2.2",
+    "args": "--workload wan2_2",
     "multiple_results": "results.csv"
   },
   {
@@ -2223,7 +2240,7 @@
         "pyt",
         "xdit"
     ],
-    "args": "--workload flux.kontext",
+    "args": "--workload flux_kontext",
     "multiple_results": "results.csv"
   },
   {
@@ -2241,6 +2258,23 @@
         "xdit"
     ],
     "args": "--workload flux2",
+    "multiple_results": "results.csv"
+  },
+  {
+    "name": "pyt_xdit_z_image_turbo",
+    "dockerfile": "docker/pyt_xdit",
+    "scripts": "scripts/pyt_xdit/run.sh",
+    "n_gpus": "2",
+    "owner": "nsakkine@amd.com",
+    "training_precision": "",
+    "tags": [
+        "inference",
+        "diffusion",
+        "t2i",
+        "pyt",
+        "xdit"
+    ],
+    "args": "--workload z_image_turbo",
     "multiple_results": "results.csv"
   }
 ]

--- a/scripts/pyt_xdit/run.sh
+++ b/scripts/pyt_xdit/run.sh
@@ -56,7 +56,10 @@ while true; do
   esac
 done
 
-SCRIPT="/app/.ci/run.${WORKLOAD}.sh"
+SCRIPT="/app/.ci/run.py"
+BENCHMARK_CONFIGS="/app/.ci/benchmark_configs"
+
+CSV_OUTPUT_PATH="/outputs/results.csv"
 
 if [ ! -e $SCRIPT ]; then
     echo "'$SCRIPT' not found" >&2
@@ -70,21 +73,13 @@ export HF_TOKEN=$MAD_SECRETS_HFTOKEN
 export HSA_NO_SCRATCH_RECLAIM=1
 
 # run workload
-echo "Run instructions:"
-bash $SCRIPT --help
 echo "Run configurations:"
-bash $SCRIPT --mad --dry-run
-RECORDS=$(bash $SCRIPT --mad)
+python3 $SCRIPT --tag mad --dry-run ${BENCHMARK_CONFIGS}/${WORKLOAD}.yaml
+python3 $SCRIPT --tag mad --csv-output-path ${CSV_OUTPUT_PATH} ${BENCHMARK_CONFIGS}/${WORKLOAD}.yaml
 
 if [ $? -ne 0 ]; then
   echo "Failed to run workload" >&2
   exit 1
 fi
 
-if [ $VERBOSE ]; then
-    echo "$RECORDS"
-fi
-
-# save results
-echo -e "model,performance,metric" > ../results.csv
-echo -e "$RECORDS"  >> ../results.csv
+cp ${CSV_OUTPUT_PATH} ../results.csv


### PR DESCRIPTION
Purpose is to add pytorch-xdit:v26.1 image to MAD workflows and to publish it.

Work here contains
- Dockerfile wrapping rocm/pytorch-xdit:v26.1
- a run script to execute selected diffusion model inference workloads
- updated models.json
- README instructions

