### PR TITLE
pytorch xdit:v26.2 release

### DIFF
--- a/benchmark/xdit/README.md
+++ b/benchmark/xdit/README.md
@@ -38,8 +38,10 @@ latencies can be found from `results.csv` once the benchmark runs have finished.
 | pyt_xdit_flux                  | [Flux.1](https://huggingface.co/black-forest-labs/FLUX.1-dev)                         |
 | pyt_xdit_flux_kontext          | [Flux.1 Kontext](https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev)         |
 | pyt_xdit_flux_2                | [Flux.2](https://huggingface.co/black-forest-labs/FLUX.2-dev)                         |
+| pyt_xdit_flux_2_klein          | [Flux.2 Klein](https://huggingface.co/black-forest-labs/FLUX.2-klein-9B)              |
 | pyt_xdit_hunyuanvideo          | [HunyuanVideo](https://huggingface.co/tencent/HunyuanVideo)                           |
 | pyt_xdit_hunyuanvideo_1_5      | [HunyuanVideo 1.5](https://huggingface.co/tencent/HunyuanVideo-1.5)                   |
+| pyt_xdit_ltx_2                 | [LTX-2](https://huggingface.co/Lightricks/LTX-2)                                      |
 | pyt_xdit_sd_3_5                | [Stable diffusion 3.5](https://huggingface.co/stabilityai/stable-diffusion-3.5-large) |
 | pyt_xdit_wan_2_1               | [Wan 2.1](https://huggingface.co/Wan-AI/Wan2.1-I2V-14B-720P)                          |
 | pyt_xdit_wan_2_2               | [Wan 2.2](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B)                              |

--- a/docker/pyt_xdit.ubuntu.amd.Dockerfile
+++ b/docker/pyt_xdit.ubuntu.amd.Dockerfile
@@ -24,7 +24,7 @@
 # SOFTWARE.
 #
 #################################################################################
-ARG BASE_DOCKER=rocm/pytorch-xdit:v26.1
+ARG BASE_DOCKER=rocm/pytorch-xdit:v26.2
 FROM ${BASE_DOCKER} AS base
 
 RUN apt-get update && apt install -y lshw && rm -rf /var/lib/apt/lists/*

--- a/models.json
+++ b/models.json
@@ -2125,6 +2125,76 @@
     ""
   },
   {
+    "name": "pyt_xdit_flux",
+    "dockerfile": "docker/pyt_xdit",
+    "scripts": "scripts/pyt_xdit/run.sh",
+    "n_gpus": "8",
+    "owner": "nsakkine@amd.com",
+    "training_precision": "",
+    "tags": [
+        "inference",
+        "diffusion",
+        "t2i",
+        "pyt",
+        "xdit"
+    ],
+    "args": "--workload flux",
+    "multiple_results": "results.csv"
+  },
+  {
+    "name": "pyt_xdit_flux_kontext",
+    "dockerfile": "docker/pyt_xdit",
+    "scripts": "scripts/pyt_xdit/run.sh",
+    "n_gpus": "8",
+    "owner": "nsakkine@amd.com",
+    "training_precision": "",
+    "tags": [
+        "inference",
+        "diffusion",
+        "ti2i",
+        "pyt",
+        "xdit"
+    ],
+    "args": "--workload flux_kontext",
+    "multiple_results": "results.csv"
+  },
+  {
+    "name": "pyt_xdit_flux_2",
+    "dockerfile": "docker/pyt_xdit",
+    "scripts": "scripts/pyt_xdit/run.sh",
+    "n_gpus": "8",
+    "owner": "nsakkine@amd.com",
+    "training_precision": "",
+    "tags": [
+        "inference",
+        "diffusion",
+        "t2i",
+        "ti2i",
+        "tmi2i",
+        "pyt",
+        "xdit"
+    ],
+    "args": "--workload flux2",
+    "multiple_results": "results.csv"
+  },
+  {
+    "name": "pyt_xdit_flux_2_klein",
+    "dockerfile": "docker/pyt_xdit",
+    "scripts": "scripts/pyt_xdit/run.sh",
+    "n_gpus": "8",
+    "owner": "nsakkine@amd.com",
+    "training_precision": "",
+    "tags": [
+        "inference",
+        "diffusion",
+        "t2i",
+        "pyt",
+        "xdit"
+    ],
+    "args": "--workload flux2_klein",
+    "multiple_results": "results.csv"
+  },
+  {
     "name": "pyt_xdit_hunyuanvideo",
     "dockerfile": "docker/pyt_xdit",
     "scripts": "scripts/pyt_xdit/run.sh",
@@ -2159,6 +2229,40 @@
     "multiple_results": "results.csv"
   },
   {
+    "name": "pyt_xdit_ltx_2",
+    "dockerfile": "docker/pyt_xdit",
+    "scripts": "scripts/pyt_xdit/run.sh",
+    "n_gpus": "8",
+    "owner": "nsakkine@amd.com",
+    "training_precision": "",
+    "tags": [
+        "inference",
+        "diffusion",
+        "t2v",
+        "pyt",
+        "xdit"
+    ],
+    "args": "--workload ltx2",
+    "multiple_results": "results.csv"
+  },
+  {
+    "name": "pyt_xdit_sd_3_5",
+    "dockerfile": "docker/pyt_xdit",
+    "scripts": "scripts/pyt_xdit/run.sh",
+    "n_gpus": "8",
+    "owner": "nsakkine@amd.com",
+    "training_precision": "",
+    "tags": [
+        "inference",
+        "diffusion",
+        "t2i",
+        "pyt",
+        "xdit"
+    ],
+    "args": "--workload stablediffusion_3_5",
+    "multiple_results": "results.csv"
+  },
+  {
     "name": "pyt_xdit_wan_2_1",
     "dockerfile": "docker/pyt_xdit",
     "scripts": "scripts/pyt_xdit/run.sh",
@@ -2190,74 +2294,6 @@
         "xdit"
     ],
     "args": "--workload wan2_2",
-    "multiple_results": "results.csv"
-  },
-  {
-    "name": "pyt_xdit_flux",
-    "dockerfile": "docker/pyt_xdit",
-    "scripts": "scripts/pyt_xdit/run.sh",
-    "n_gpus": "8",
-    "owner": "nsakkine@amd.com",
-    "training_precision": "",
-    "tags": [
-        "inference",
-        "diffusion",
-        "t2i",
-        "pyt",
-        "xdit"
-    ],
-    "args": "--workload flux",
-    "multiple_results": "results.csv"
-  },
-  {
-    "name": "pyt_xdit_sd_3_5",
-    "dockerfile": "docker/pyt_xdit",
-    "scripts": "scripts/pyt_xdit/run.sh",
-    "n_gpus": "8",
-    "owner": "nsakkine@amd.com",
-    "training_precision": "",
-    "tags": [
-        "inference",
-        "diffusion",
-        "t2i",
-        "pyt",
-        "xdit"
-    ],
-    "args": "--workload stablediffusion_3_5",
-    "multiple_results": "results.csv"
-  },
-  {
-    "name": "pyt_xdit_flux_kontext",
-    "dockerfile": "docker/pyt_xdit",
-    "scripts": "scripts/pyt_xdit/run.sh",
-    "n_gpus": "8",
-    "owner": "nsakkine@amd.com",
-    "training_precision": "",
-    "tags": [
-        "inference",
-        "diffusion",
-        "ti2i",
-        "pyt",
-        "xdit"
-    ],
-    "args": "--workload flux_kontext",
-    "multiple_results": "results.csv"
-  },
-  {
-    "name": "pyt_xdit_flux_2",
-    "dockerfile": "docker/pyt_xdit",
-    "scripts": "scripts/pyt_xdit/run.sh",
-    "n_gpus": "8",
-    "owner": "nsakkine@amd.com",
-    "training_precision": "",
-    "tags": [
-        "inference",
-        "diffusion",
-        "t2i",
-        "pyt",
-        "xdit"
-    ],
-    "args": "--workload flux2",
     "multiple_results": "results.csv"
   },
   {

--- a/scripts/pyt_xdit/run.sh
+++ b/scripts/pyt_xdit/run.sh
@@ -58,11 +58,17 @@ done
 
 SCRIPT="/app/.ci/run.py"
 BENCHMARK_CONFIGS="/app/.ci/benchmark_configs"
+ARCH=$(amd-smi static | grep TARGET_GRAPHICS_VERSION | head -1 | cut -d ':' -f 2 | xargs)
 
 CSV_OUTPUT_PATH="/outputs/results.csv"
 
 if [ ! -e $SCRIPT ]; then
     echo "'$SCRIPT' not found" >&2
+    exit 1
+fi
+
+if [ -z "$ARCH" ]; then
+    echo "Failed to get TARGET_GRAPHICS_VERSION from amd-smi" >&2
     exit 1
 fi
 
@@ -74,12 +80,16 @@ export HSA_NO_SCRATCH_RECLAIM=1
 
 # run workload
 echo "Run configurations:"
-python3 $SCRIPT --tag mad --dry-run ${BENCHMARK_CONFIGS}/${WORKLOAD}.yaml
-python3 $SCRIPT --tag mad --csv-output-path ${CSV_OUTPUT_PATH} ${BENCHMARK_CONFIGS}/${WORKLOAD}.yaml
+python3 $SCRIPT --tag mad --tag ${ARCH} --dry-run ${BENCHMARK_CONFIGS}/${WORKLOAD}.yaml
+python3 $SCRIPT --tag mad --tag ${ARCH} --csv-output-path ${CSV_OUTPUT_PATH} ${BENCHMARK_CONFIGS}/${WORKLOAD}.yaml
 
 if [ $? -ne 0 ]; then
   echo "Failed to run workload" >&2
   exit 1
 fi
+
+# Strip architecture suffixes from model column (e.g., ".gfx942", ".gfx950") in the MAD CSV output file
+awk -F, 'BEGIN{OFS=","} NR==1{print;next} {sub(/\.gfx(942|950)$/, "", $1); print}' \
+  "${CSV_OUTPUT_PATH}" > "${CSV_OUTPUT_PATH}.tmp" && mv "${CSV_OUTPUT_PATH}.tmp" "${CSV_OUTPUT_PATH}"
 
 cp ${CSV_OUTPUT_PATH} ../results.csv


### PR DESCRIPTION
Purpose is to add pytorch-xdit:v26.2 image to MAD workflows and to publish it.

Work here contains

- Dockerfile wrapping rocm/pytorch-xdit:v26.2
- a run script to execute selected diffusion model inference workloads
- updated models.json
- README instructions
