### PR TITLE
Support HuggingFace Transformers 5.x migration by removing the deprecated --overwrite_output_dir flag 

### DIFF
--- a/scripts/huggingface_bert/run.sh
+++ b/scripts/huggingface_bert/run.sh
@@ -52,7 +52,6 @@ torchrun $HF_PATH/examples/pytorch/language-modeling/run_mlm.py \
      --max_steps 150 \
      --logging_steps 1 \
      --output_dir /tmp/test-mlm-bbu \
-     --overwrite_output_dir \
 	 --per_device_train_batch_size="$MAD_MODEL_BATCH_SIZE" \
      --fp16 \
      --skip_memory_metrics=True \

--- a/scripts/huggingface_gpt2/run.sh
+++ b/scripts/huggingface_gpt2/run.sh
@@ -75,7 +75,6 @@ torchrun --nproc_per_node="$MAD_RUNTIME_NGPUS" $HF_PATH/examples/pytorch/languag
 	--dataloader_num_workers 1 \
 	--skip_memory_metrics \
 	--per_device_train_batch_size="$MAD_MODEL_BATCH_SIZE" \
-	--overwrite_output_dir \
 	--max_steps 150 "$@" \
 	2>&1 | tee log.txt
 


### PR DESCRIPTION
## Motivation

both huggingface models (gpt2 and bert) are currently broken because of this error:

```
ValueError: Some specified arguments are not used by the HfArgumentParser: ['--overwrite_output_dir']
```

## Technical Details

Removed the deprecated tag --overwrite_output_dir flag

## Test Plan

Models were validated to have ran locally. Next steps are to run in CI after merge.

## Test Result

Models were validated to have ran locally.

## Submission Checklist

- [ X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
