### PR TITLE
Enable large EP microbenchmarks & update blueprints section in ReadME.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,27 @@
 
 ## Overview
 
-MAD (Model Automation and Dashboarding) is a comprehensive AI/ML model automation platform that provides:
+MAD is a platform that consists of curated list of AI models that allow us to run on various GPU architectures seamlessly while tracking performance and generating dashboards for insights.
 
-- 🏗️ **Model Zoo**: Curated collection of AI/ML models
-- 🚀 **Automated Execution**: Run models across various GPU architectures
-- 📊 **Performance Tracking**: Historical performance data collection and analysis
-- 📈 **Dashboard Generation**: Visual tracking and reporting capabilities
+## Blueprints
 
-## DISCLAIMER
+This repository provides state-of-the-art deep learning recipes for training, inference and easy deployment on AMD Instinct GPUs.
+Below are blueprints of supported models along with their documentation.
 
-The information presented in this document is for informational purposes only and may contain technical inaccuracies, omissions, and typographical errors. The information contained herein is subject to change and may be rendered inaccurate for many reasons, including but not limited to product and roadmap changes, component and motherboard versionchanges, new model and/or product releases, product differences between differing manufacturers, software changes, BIOS flashes, firmware upgrades, or the like. Any computer system has risks of security vulnerabilities that cannot be completely prevented or mitigated.AMD assumes no obligation to update or otherwise correct or revise this information. However, AMD reserves the right to revise this information and to make changes from time to time to the content hereof without obligation of AMD to notify any person of such revisions or changes.THIS INFORMATION IS PROVIDED ‘AS IS.” AMD MAKES NO REPRESENTATIONS OR WARRANTIES WITH RESPECT TO THE CONTENTS HEREOF AND ASSUMES NO RESPONSIBILITY FOR ANY INACCURACIES, ERRORS, OR OMISSIONS THAT MAY APPEAR IN THIS INFORMATION. AMD SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR ANY PARTICULAR PURPOSE. IN NO EVENT WILL AMD BE LIABLE TO ANY PERSON FOR ANY RELIANCE, DIRECT, INDIRECT, SPECIAL, OR OTHER CONSEQUENTIAL DAMAGES ARISING FROM THE USE OF ANY INFORMATION CONTAINED HEREIN, EVEN IF AMD IS EXPRESSLY ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. AMD, the AMD Arrow logo, and combinations thereof are trademarks of Advanced Micro Devices, Inc. Other product names used in this publication are for identification purposes only and may be trademarks of their respective companies.
-
-© 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+| Blueprint | Description | Models |
+|-----------|-------------|--------|
+| [**xDiT diffusion inference**](benchmark/xdit/README.md) | Diffusion Transformer inference using xDiT | FLUX.1, FLUX.1 Kontext, FLUX.2, FLUX.2 Klein, HunyuanVideo, HunyuanVideo 1.5, LTX-2, Stable Diffusion 3.5, Wan 2.1, Wan 2.2, Z-Image Turbo |
+| [**JAX MaxText training**](benchmark/jax_maxtext/README.md) | Train LLMs on AMD Instinct GPUs using JAX MaxText | Llama 2 7B/70B, Llama 3/3.1 8B/70B, Llama 3.1 405B, Llama 3.3 70B, DeepSeek-V2-lite 16B, Mixtral-8x7B |
+| [**vLLM inference**](benchmark/vllm/README.md) | LLM Inference with vLLM on AMD Instinct GPUs | DeepSeek-R1, gpt-oss-20b/120b, Llama-2-70b, Llama-3.1-8b/405b, Llama-3.3-70b, Llama-4-Scout/Maverick, Mixtral-8x7b/8x22b, Phi-4, Qwen3-8b/32b/30b-a3b/235b-a22b |
+| [**SGLang inference**](benchmark/sglang/README.md) | LLM Inference with SGLang on AMD Instinct GPUs | DeepSeek-R1-Distill-Qwen-32B |
+| [**PyTorch training**](benchmark/pytorch_train/README.md) | Train LLMs on AMD Instinct GPUs using AMD's Primus | Llama 2/3/3.1/3.2/3.3/4, GPT-OSS 20B/120B, Qwen2/2.5/3, Flux, SDXL, DLRM, and others |
+| [**PyTorch inference**](benchmark/pytorch_inference/README.md) | Inference recipes for Multimodal, video and vision transformer models | Mochi video, Chai-1, CLIP (ViT-B-32), Wan2.1, Janus-Pro-7B, HunyuanVideo |
+| [**Megatron-LM training**](benchmark/megatron_lm/README.md) | Train LLMs on AMD Instinct GPUs using ROCm Megatron-LM | Llama 2 7B/70B, Llama 3/3.1 8B/70B, Llama 3.3 70B, DeepSeek-V2-lite, DeepSeek-V3, Mixtral 8x7B/8x22B, Qwen 2.5 7B/72B |
+| [**MPT-30B training (llm-foundry)**](benchmark/llm-foundry/mpt-30b/README.md) | LLM Training for Mosaic Pretrained Transformer (MPT) models using llm-foundry | MPT-30B |
+| [**PyTorch PEFT/FSDP fine-tuning**](scripts/pytorch_train/HF_PEFT_FSDP/README.md) | Finetuning a HF model with LoRA approach & FSDP strategy | Llama-2-70b-chat-hf |
+| [**Large EP microbenchmark**](scripts/large-ep-benchmark/README.md) | MoE Large Expert Paralellism with MoRI-EP & DeepEP communication microbenchmarks | no specific models |
+| [**vLLM disaggregated P/D inference**](scripts/vllm_dissag/README.MD) | Distributed Inference P/D disaggregation with vLLM | DeepSeek-V3, Llama-3.3-70B-Instruct-FP8-KV, Llama-3.1-405B-Instruct-FP8-KV, gpt-oss-120b |
+| [**SGLang disaggregated P/D inference**](scripts/sglang_disagg/README.MD) | Distributed Inference P/D disggregation with SGLang | Qwen3-32B, Llama-3.1-8B-Instruct, Llama-3.3-70B-Instruct-FP8-KV, Llama-3.1-405B-Instruct-FP8-KV, DeepSeek-V3, Mixtral-8x7B-v0.1 |
 
 ## Table of Contents
 
@@ -55,6 +64,8 @@ The information presented in this document is for informational purposes only an
    ```bash
    madengine run --tags pyt_huggingface_bert
    ```
+
+
 
 ## Usage Guide
 
@@ -302,3 +313,10 @@ Runtime model configuration:
 | `MAD_MODEL_NAME` | Model name from `models.json` |
 | `MAD_MODEL_NUM_EPOCHS` | Training epochs |
 | `MAD_MODEL_BATCH_SIZE` | Batch size |
+
+## DISCLAIMER
+
+The information presented in this document is for informational purposes only and may contain technical inaccuracies, omissions, and typographical errors. The information contained herein is subject to change and may be rendered inaccurate for many reasons, including but not limited to product and roadmap changes, component and motherboard versionchanges, new model and/or product releases, product differences between differing manufacturers, software changes, BIOS flashes, firmware upgrades, or the like. Any computer system has risks of security vulnerabilities that cannot be completely prevented or mitigated.AMD assumes no obligation to update or otherwise correct or revise this information. However, AMD reserves the right to revise this information and to make changes from time to time to the content hereof without obligation of AMD to notify any person of such revisions or changes.THIS INFORMATION IS PROVIDED ‘AS IS.” AMD MAKES NO REPRESENTATIONS OR WARRANTIES WITH RESPECT TO THE CONTENTS HEREOF AND ASSUMES NO RESPONSIBILITY FOR ANY INACCURACIES, ERRORS, OR OMISSIONS THAT MAY APPEAR IN THIS INFORMATION. AMD SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR ANY PARTICULAR PURPOSE. IN NO EVENT WILL AMD BE LIABLE TO ANY PERSON FOR ANY RELIANCE, DIRECT, INDIRECT, SPECIAL, OR OTHER CONSEQUENTIAL DAMAGES ARISING FROM THE USE OF ANY INFORMATION CONTAINED HEREIN, EVEN IF AMD IS EXPRESSLY ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. AMD, the AMD Arrow logo, and combinations thereof are trademarks of Advanced Micro Devices, Inc. Other product names used in this publication are for identification purposes only and may be trademarks of their respective companies.
+
+© 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+

--- a/docker/large_ep_benchmark.ubuntu.amd.Dockerfile
+++ b/docker/large_ep_benchmark.ubuntu.amd.Dockerfile
@@ -1,0 +1,78 @@
+# CONTEXT {'gpu_vendor': 'AMD', 'guest_os': 'UBUNTU'}
+###############################################################################
+#
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#################################################################################
+ARG BASE_DOCKER=rocm/vllm-dev:base_torch2.10_triton3.6_rocm7.2_torch_build_20260216
+FROM $BASE_DOCKER
+
+ARG GPU_ARCH=gfx942
+WORKDIR /app
+
+RUN sed -i 's/http/https/g' /etc/apt/sources.list
+
+RUN apt-get update && \
+   apt-get install -y \
+    autoconf pkg-config \
+    libsqlite3-dev libfmt-dev libmsgpack-dev libsuitesparse-dev \
+    libibverbs-dev ibverbs-utils libtool libboost-all-dev \
+    libgrpc++-dev protobuf-compiler-grpc protobuf-compiler libprotobuf-dev \
+    libaio-dev liburing-dev pybind11-dev ninja-build libgflags-dev \
+    rdma-core infiniband-diags perftest openssh-server \
+    psmisc vim cmake-curses-gui
+
+RUN pip3 install "pybind11[global]" meson==0.64.0
+
+ARG GFX_COMPILATION_ARCH="gfx942"
+ARG NIC_COMPILATION_ARCH="cx7"
+
+WORKDIR /app
+RUN git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-systems.git && cd rocm-systems && \
+    git sparse-checkout set --cone projects/rocshmem && \
+    git checkout develop
+
+WORKDIR /app/rocm-systems/projects/rocshmem
+
+RUN mkdir -p /app/rocshmem-build
+WORKDIR /app/rocshmem-build
+RUN /app/rocm-systems/projects/rocshmem/scripts/build_configs/all_backends -DUSE_EXTERNAL_MPI=OFF -DGPU_TARGETS=$GFX_COMPILATION_ARCH
+
+WORKDIR /app
+RUN git clone https://github.com/ROCm/DeepEP.git
+WORKDIR /app/DeepEP
+RUN PYTORCH_ROCM_ARCH=$GFX_COMPILATION_ARCH  CFLAGS="-O3 -fPIC" CXXFLAGS="-O3 -fPIC --offload-arch=$GFX_COMPILATION_ARCH" HIP_CXX_FLAGS="-O3 -fPIC" \
+    python3 setup.py --variant rocm --nic $NIC_COMPILATION_ARCH build develop
+
+WORKDIR /app
+
+# not installing mori since its already installed in vllm container.
+RUN pip install tqdm prettytable
+RUN git clone --recursive $(grep '^MORI_REPO:' versions.txt | cut -d' ' -f2) && \
+    cd mori && \
+    git checkout $(grep '^MORI_BRANCH:' /app/versions.txt | cut -d' ' -f2) 
+
+RUN cd /app/mori && git log | head
+
+ENV ROCSHMEM_TEST_UUID=1 
+ENV ROCSHMEM_HEAP_SIZE=6442450944

--- a/scripts/large-ep-benchmark/README.md
+++ b/scripts/large-ep-benchmark/README.md
@@ -1,0 +1,122 @@
+# Large EP Microbenchmarking (MoRI-EP & DeepEP)
+
+## Overview
+
+These scripts run microbenchmarks for **MoRI-EP** (MoRI collective engine) and **DeepEP** (expert-parallel / MoE communication) on a Slurm cluster with AMD Instinct accelerators and InfiniBand (CX7) networking. The benchmarks validate collective performance and low-latency behavior in both intranode and internode configurations.
+
+The Docker image is built from the MAD repository and is intended for use on clusters with **Mellanox CX7** NICs and compatible AMD GPUs (e.g., gfx942). You can adjust the Dockerfile for different NICs or GPU architectures as needed.
+
+## Why this benchmarking?
+
+- **Validate communication stacks** — Before running large training or inference workloads (e.g., MoE models, distributed LLMs), microbenchmarks confirm that MoRI and DeepEP collectives achieve expected throughput and latency on your cluster. Regressions in drivers, ROCm, or NIC firmware show up here first.
+- **Tune and qualify hardware** — Results help tune environment variables (e.g., `ROCSHMEM_HEAP_SIZE`, `IBDEVICES`), compare NIC/GPU configurations, and qualify new nodes or fabrics (intranode vs internode, normal vs low-latency paths).
+- **Regression and CI** — These scripts can be used in CI or release validation to ensure that updates to MoRI, DeepEP, rocSHMEM, or the ROCm stack do not degrade collective performance.
+- **Research and development** — Microbenchmark data supports optimization of collective algorithms, FP8/low-latency paths, and scaling studies across nodes.
+
+## MoRI and DeepEP: background and links
+
+### MoRI (Modular RDMA Interface)
+
+**MoRI** is a communication backend for the ROCm platform that optimizes **inter-node collective operations** on GPU clusters. It uses RDMA (Remote Direct Memory Access) for efficient GPU-to-GPU communication across nodes and supports standard collectives. MoRI is used in distributed inference (e.g., with SGLang / vLLM on AMD Instinct).
+
+| Resource | Link |
+|----------|------|
+| **MoRI (GitHub)** | [ROCm/mori](https://github.com/ROCm/mori) |
+
+### DeepEP and rocSHMEM
+
+**DeepEP** is a high-performance communication library for **Mixture-of-Experts (MoE)** and **expert parallelism**, providing GPU **all-to-all** primitives with optional FP8/BF16 support. The AMD ROCm version uses xGMI/Infinity Fabric for intranode communication and InfiniBand/RoCE for internode communication. DeepEP builds on **rocSHMEM** (ROCm OpenSHMEM), an intra-kernel networking library that provides GPU-centric, OpenSHMEM-like APIs and a symmetric heap on GPU memory, enabling better communication–computation overlap than host-driven networking.
+
+| Resource | Link |
+|----------|------|
+| **DeepEP (GitHub)** | [ROCm/DeepEP](https://github.com/ROCm/DeepEP) |
+| **rocSHMEM — What is rocSHMEM? (ROCm docs)** | [rocSHMEM introduction](https://rocm.docs.amd.com/projects/rocSHMEM/en/latest/introduction.html) |
+| **rocSHMEM (GitHub)** | [ROCm/ROC_SHMEM](https://github.com/ROCm/rocm-systems/tree/develop/projects/rocshmem) |
+
+## Benchmarks Covered
+
+| Scope       | Mode        | DeepEP | MoRI-EP |
+|------------|-------------|--------|---------|
+| Intranode  | Normal      | ✅     | ✅      |
+| Intranode  | Low latency | ✅     | ✅      |
+| Internode  | Normal      | ✅     | ✅      |
+| Internode  | Low latency | ✅     | ✅      |
+
+- **Intranode**: Single-node multi-process collectives.
+- **Internode**: Multi-node collectives over InfiniBand.
+- **Low latency**: FP8/low-latency collective paths (e.g., rocSHMEM heap and MoRI FP8).
+
+## Prerequisites
+
+- Slurm cluster with AMD Instinct nodes.
+- **CX7** (or compatible) InfiniBand NICs; scripts assume InfiniBand devices are available.
+- Docker available on compute nodes (or use a container runtime configured for your cluster).
+
+## How to Run
+
+### 1. Build the Docker image
+
+Build from the **MAD repository root** (not from this script directory). The default Dockerfile targets **gfx942** and **CX7**; edit `docker/large_ep_benchmark.ubuntu.amd.Dockerfile` if your cluster uses a different GPU arch or NIC.
+
+```bash
+# From MAD repository root
+docker build -f docker/large_ep_benchmark.ubuntu.amd.Dockerfile -t ep-benchmarking:latest .
+```
+
+### 2. Set environment variables
+
+| Variable       | Description                          | Example              |
+|----------------|--------------------------------------|----------------------|
+| `DOCKER_IMAGE` | Docker image to run on the cluster   | `ep-benchmarking:latest` |
+| `IBDEVICES`    | InfiniBand device(s) for rocSHMEM   | `mlx5_0` (default)   |
+
+Optional:
+
+- `LOG_PATH`: Directory for benchmark logs (default: `./logs` in the current working directory).
+
+### 3. Submit the Slurm job
+
+Navigate to the scripts directory and submit the job. The script supports **1 to N nodes**; Slurm allocates the nodes and the job runs both intranode and internode tests when multiple nodes are requested.
+
+```bash
+cd scripts/large-ep-benchmark
+
+export DOCKER_IMAGE=ep-benchmarking:latest
+export IBDEVICES=mlx5_0
+
+sbatch -p <partition> -N <num-nodes> run_benchmark.sbatch
+```
+
+**Examples:**
+
+- Single node (intranode only):
+  ```bash
+  sbatch -p <partition> -N 1 run_benchmark.sbatch
+  ```
+
+- Multi-node (intranode and internode):
+  ```bash
+  sbatch -p <partition> -N 4 run_benchmark.sbatch
+  ```
+
+>[!NOTE]
+> Ensure the partition and account allow the requested number of nodes and that compute nodes have Docker (or the configured container runtime) and access to the built image (e.g., via a registry or shared image path).
+
+## Output and logs
+
+- Slurm stdout/stderr: `ep_bench_slurm_job.out` and `ep_bench_slurm_job.err` in the directory where `sbatch` was run.
+- Benchmark logs are written under `LOG_PATH` (default: `./logs`), including:
+  - `ep_bench_results.log` — main run log
+  - `intranode_results.log` / `mori_intranode_results.log` — intranode DeepEP and MoRI
+  - `internode_<rank>.txt`, `low-latency-<rank>.log` — internode and low-latency results
+
+
+## Summary
+
+| Step | Action |
+|------|--------|
+| 1    | Build image from MAD root: `docker build -f docker/large_ep_benchmark.ubuntu.amd.Dockerfile -t ep-benchmarking:latest .` |
+| 2    | Set `DOCKER_IMAGE` and `IBDEVICES` (and optionally `LOG_PATH`) |
+| 3    | From `scripts/large-ep-benchmark`, run: `sbatch -p <partition> -N <num-nodes> run_benchmark.sbatch` |
+
+For different GPU architectures or NICs, update the Dockerfile and rebuild before submitting jobs.

--- a/scripts/large-ep-benchmark/run_benchmark.sbatch
+++ b/scripts/large-ep-benchmark/run_benchmark.sbatch
@@ -1,0 +1,127 @@
+#!/bin/bash
+#SBATCH --job-name=ep-benchmarking
+#SBATCH -N 1
+#SBATCH --ntasks-per-node=1
+#SBATCH --time=04:00:00         # Set a time limit for the job (HH:MM:SS)
+#SBATCH --output="ep_bench_slurm_job.out"
+#SBATCH --error="ep_bench_slurm_job.err"
+
+USER_NAME=$(whoami)
+PWD=$(pwd)
+LOG_PATH=${LOG_PATH:-"${PWD}/logs"}
+DOCKER_IMAGE=${DOCKER_IMAGE:-ep-benchmarking:latest}
+IBDEVICES=${IBDEVICES:-mlx5_0}
+
+# ------------------------
+# SLURM Environment Variables
+# ------------------------
+echo "SLURM_JOB_ID: $SLURM_JOB_ID"
+echo "SLURM_JOB_NODELIST: $SLURM_JOB_NODELIST"
+echo "SLURM_NNODES: $SLURM_NNODES"
+echo "SLURM_NTASKS: $SLURM_NTASKS"
+echo "SLURM_TASKS_PER_NODE: $SLURM_TASKS_PER_NODE"
+echo "SLURM_JOB_CPUS_PER_NODE: $SLURM_JOB_CPUS_PER_NODE"
+echo "ulimit: $(ulimit -a)"
+echo ""
+
+# Node information
+USER_NAME=$(whoami)
+MASTER_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+MASTER_ADDR=$(srun --nodes=1 -t 00:20:00 -w $MASTER_NODE bash -c "hostname -I")
+MASTER_ADDR=$(echo "$MASTER_ADDR" | awk 'NR==1 {print $1}')
+MASTER_PORT=2373  # Choose an open port
+
+NODELIST=$(scontrol show hostnames $SLURM_JOB_NODELIST)
+IPS=()
+
+for NODE in $NODELIST; do
+    IP=$(srun --nodes=1 -t 00:20:00 -w $NODE bash -c "hostname -I")
+    IP=$(echo "$IP" | awk 'NR==1 {print $1}')
+    IPS+=("$IP")
+done
+
+echo "${IPS[*]}" | sed 's/ /,/g'
+
+export MAD_REPO="$(pwd)"
+export MAD_REPO_PATH="/root/mad-repo"
+
+echo "----- Inside -----"
+echo "${MAD_REPO}"
+echo "${MAD_REPO_PATH}"
+echo "${MAD_REPO_EP_SCRIPTS}"
+
+timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
+
+NNODES=$SLURM_NNODES
+
+echo "MASTER_NODE is ${MASTER_NODE}"
+echo "MASTER_ADDR is ${MASTER_ADDR}"
+echo "MASTER_PORT is ${MASTER_PORT}"
+echo "NNODES is ${NNODES}"
+
+if [ ! -d "$LOG_PATH" ]; then
+    mkdir -p "$LOG_PATH"
+    echo "Created directory: $LOG_PATH"
+else
+    echo "Directory already exists: $LOG_PATH"
+fi
+
+export LOG_PATH=$LOG_PATH
+export DOCKER_IMAGE=$DOCKER_IMAGE
+export IBDEVICES=$IBDEVICES
+export SLURM_JOB_NODELIST=$SLURM_JOB_NODELIST
+export NNODES=$NNODES
+export MASTER_ADDR=$MASTER_ADDR
+export MASTER_PORT=$MASTER_PORT
+export IPADDRS="$(echo "${IPS[*]}" | sed 's/ /,/g')"
+
+srun bash -c '
+echo "Rank $SLURM_PROCID on $(hostname)";
+docker stop ep-bench;
+sleep 10;
+docker rm ep-bench;
+sleep 10;
+docker stop $(docker ps -aq) && docker rm $(docker ps -aq);
+sleep 30;
+docker pull $DOCKER_IMAGE;    
+docker run --rm \
+    --device /dev/dri \
+    --device /dev/kfd \
+    --device /dev/infiniband \
+    --network host \
+    --ipc host \
+    --group-add video \
+    --cap-add SYS_PTRACE \
+    --privileged=true \
+    --security-opt seccomp=unconfined \
+    --ulimit memlock=-1:-1 \
+    -v $HOME:$HOME \
+    -v /shared_inference/models:/data \
+    -v $HOME/.ssh:/root/.ssh \
+    -v /dev/infiniband:/dev/infiniband \
+    -v /sys/class/infiniband:/sys/class/infiniband:ro \
+    -v /sys/class/net:/sys/class/net:ro \
+    -v /sys/bus/pci:/sys/bus/pci:ro \
+    --shm-size 64G \
+    -v ${LOG_PATH}:/run_logs \
+    -v $MAD_REPO:$MAD_REPO_PATH \
+    -e SLURM_JOB_ID=$SLURM_JOB_ID \
+    -e SLURM_JOB_NODELIST=$SLURM_JOB_NODELIST \
+    -e NODE_RANK=$SLURM_PROCID \
+    -e MASTER_ADDR=$MASTER_ADDR \
+    -e MASTER_PORT=$MASTER_PORT \
+    -e NNODES=$NNODES \
+    -e IPADDRS=$IPADDRS \
+    -e IBDEVICES=$IBDEVICES \
+    -e MAD_REPO_PATH=$MAD_REPO_PATH \
+    -e MAD_REPO_EP_SCRIPTS=$MAD_REPO_EP_SCRIPTS \
+    --entrypoint /bin/bash \
+    --name ep-bench \
+    $DOCKER_IMAGE -c "
+        echo Inside docker container ....
+        echo ${MAD_REPO_PATH}
+        $MAD_REPO_PATH/run_ep_bench.sh 2>&1 | tee /run_logs/ep_bench_results.log
+"    
+'
+
+srun bash -c 'docker stop ep-bench; docker rm ep-bench;'

--- a/scripts/large-ep-benchmark/run_ep_bench.sh
+++ b/scripts/large-ep-benchmark/run_ep_bench.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# set -x
+
+MASTER_ADDR="${MASTER_ADDR:-localhost}"
+MASTER_PORT="${MASTER_PORT:-2373}"
+NODE_RANK="${NODE_RANK:-0}"
+NNODES="${NNODES:-1}"
+IPADDRS="${IPADDRS:-localhost}"
+IBDEVICES="${IBDEVICES:-mlx5_0}"
+
+host_ip=$(hostname -I | awk '{print $1}')
+host_name=$(hostname)
+
+#echo "Waiting at the container creation barrier on $host_name"
+#python $MAD_REPO_PATH/utils/socket_barrier.py --local-ip ${host_ip} --local-port 2200 --enable-port --node-ips ${IPADDRS} --node-ports 2200
+
+echo "$IPADDRS"
+echo "$IBDEVICES"
+
+SERVER_IP=$(echo "$IPADDRS" | awk -F',' '{print $1}')
+echo "Server IP is - ${SERVER_IP}"
+echo "Node Rank is ${NODE_RANK}"
+
+echo "-------EP benchamrking --------"
+
+DEEPEP_PATH="/app/DeepEP"
+cd $DEEPEP_PATH
+MORI_PATH="/app/mori"
+if [ "$NNODES" -eq 1 ]; then
+    echo "Total number of nodes - ${NNODES}"
+    python tests/test_intranode.py 2>&1 | tee /run_logs/intranode_results.log
+    #python tests/test_intranode.py
+    sleep 20;
+    
+    export ROCSHMEM_USE_IB_HCA=$IBDEVICES
+    export ROCSHMEM_HEAP_SIZE=4147483648
+    python tests/test_low_latency.py 2>&1 | tee /run_logs/low_latency_1N_results.log 
+
+    echo "----- Performing Intranode MoRI -----"
+    cd $MORI_PATH
+    export PYTHONPATH=$PYTHONPATH:$MORI_PATH
+    export GLOO_SOCKET_IFNAME=$(ip route | grep '^default' | awk '{print $NF}' | head -n 1)
+    python tests/python/ops/bench_dispatch_combine.py 2>&1 | tee /run_logs/mori_intranode_results.log
+
+    echo "----- Performing low latency mori ----"
+    python tests/python/ops/bench_dispatch_combine.py --dtype fp8_e4m3_fnuz 2>&1 | tee /run_logs/mori_1N_ll_results.log
+
+else
+    LOG_FILE=internode_${NODE_RANK}.txt
+    export MASTER_ADDR=$MASTER_ADDR
+    export RANK=$NODE_RANK
+    export WORLD_SIZE=$NNODES
+    export ROCSHMEM_MAX_NUM_CONTEXTS=64
+ 
+    echo "Total number of nodes - ${NNODES}"
+    echo "Master Address - $MASTER_ADDR"
+    echo "Node Rank - $NODE_RANK"
+    echo "NNODES - $NNODES"
+
+    echo "----- Running internode tests -----"
+    
+    python tests/test_internode.py 2>&1 | tee /run_logs/$LOG_FILE
+    sleep 20;
+
+    echo "----- Running low latency tests -----"
+    export ROCSHMEM_HEAP_SIZE=$((3*1024*1024*1024))
+    export ROCSHMEM_MAX_NUM_CONTEXTS=144
+    #export ROCSHMEM_BACKEND=gda
+    #export ROCSHMEM_DISABLE_MIXED_IPC=0
+    #export ROCSHMEM_USE_IB_HCA=$IBDEVICES
+    python tests/test_low_latency.py 2>&1 | tee /run_logs/low-latency-${NODE_RANK}.log
+    sleep 20;
+
+    echo "---- Running mori internode tests -------"
+    cd $MORI_PATH
+    export GLOO_SOCKET_IFNAME=$(ip route | grep '^default' | awk '{print $NF}' | head -n 1)
+    torchrun --nnodes=$NNODES \
+        --node_rank=$NODE_RANK \
+        --nproc_per_node=1 \
+        --master_addr=$MASTER_ADDR \
+        --master_port=$MASTER_PORT \
+        examples/ops/dispatch_combine/test_dispatch_combine_internode.py --cmd bench 2>&1 | tee /run_logs/mori_${LOG_FILE}
+    sleep 20;
+
+    echo "----- Running mori low latency test -----"
+    torchrun --nnodes=$NNODES \
+        --node_rank=$NODE_RANK \
+        --nproc_per_node=1 \
+        --master_addr=$MASTER_ADDR \
+        --master_port=$MASTER_PORT \
+        examples/ops/dispatch_combine/test_dispatch_combine_internode.py --cmd bench --kernel-type v1_ll 2>&1 | tee /run_logs/mori_ll_${LOG_FILE}
+fi
+
+exit 0

--- a/scripts/large-ep-benchmark/utils/socket_barrier.py
+++ b/scripts/large-ep-benchmark/utils/socket_barrier.py
@@ -1,0 +1,74 @@
+import socket
+import time
+import threading
+import argparse
+
+# Parse command-line arguments
+parser = argparse.ArgumentParser(description="Optionally open and close a port on the local node.")
+parser.add_argument("--local-ip", required=False, help="Local IP address to bind the server.")
+parser.add_argument("--local-port", type=int, required=False, help="Port number to bind the server.")
+parser.add_argument("--enable-port", action="store_true", help="Enable opening and closing of local port.")
+parser.add_argument("--node-ips", required=True, help="Comma-separated list of node IPs.")
+parser.add_argument("--node-ports", required=True, help="Comma-separated list of ports to check.")
+args = parser.parse_args()
+
+# Parse node IPs and ports from command-line arguments
+NODE_IPS = [ip.strip() for ip in args.node_ips.split(",") if ip.strip()]
+NODE_PORTS = [int(port.strip()) for port in args.node_ports.split(",") if port.strip()]
+
+# Ensure port list matches node list or default to using the same port for all nodes
+if len(NODE_PORTS) == 1:
+    NODE_PORTS *= len(NODE_IPS)
+elif len(NODE_PORTS) != len(NODE_IPS):
+    print("Error: Number of ports must match number of node IPs or only one port should be given for all.")
+    exit(1)
+
+server_socket = None  # Global server socket reference
+
+def is_port_open(ip, port):
+    """Check if a given IP and port are accessible."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(2)  # Avoid long wait times
+        return s.connect_ex((ip, port)) == 0
+
+def wait_for_all_ports():
+    """Wait until all nodes have opened the specified ports."""
+    while True:
+        all_open = all(is_port_open(ip, port) for ip, port in zip(NODE_IPS, NODE_PORTS))
+        if all_open:
+            break
+        print("Waiting for nodes. . .", flush=True)
+        time.sleep(5)
+
+def open_port():
+    """Open a listening socket on the current node."""
+    global server_socket
+    server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server_socket.bind((args.local_ip, args.local_port))
+    server_socket.listen(5)
+    print(f"Port {args.local_port} is now open on {args.local_ip}.")
+    while True:
+        conn, addr = server_socket.accept()
+        conn.close()
+
+def close_port():
+    """Close the opened port."""
+    global server_socket
+    if server_socket:
+        server_socket.close()
+        print(f"Port {args.local_port} has been closed on {args.local_ip}.")
+
+if __name__ == "__main__":
+    if not NODE_IPS:
+        print("Error: NODE_IPS argument is empty or not set.")
+        exit(1)
+
+    if args.enable_port:
+        threading.Thread(target=open_port, daemon=True).start()
+
+    wait_for_all_ports()
+
+    if args.enable_port:
+        time.sleep(120)
+        close_port()

--- a/scripts/large-ep-benchmark/utils/socket_wait.py
+++ b/scripts/large-ep-benchmark/utils/socket_wait.py
@@ -1,0 +1,24 @@
+import socket
+import time
+import argparse
+
+def is_port_open(host, port, timeout=2):
+    """Check if a given host and port are accessible."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(timeout)
+        return s.connect_ex((host, port)) == 0
+
+def wait_while_port_open(host, port, check_interval=5):
+    """Wait while the remote port remains open."""
+    print(f"Waiting while port {port} on {host} is open...")
+    while is_port_open(host, port):
+        time.sleep(check_interval)
+    print(f"Port {port} on {host} is now closed.")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Wait while a remote port remains open.")
+    parser.add_argument("--remote-ip", required=True, help="Remote server IP address.")
+    parser.add_argument("--remote-port", type=int, required=True, help="Remote port number.")
+    args = parser.parse_args()
+
+    wait_while_port_open(args.remote_ip, args.remote_port)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

The purpose of this PR is to enable the Large EP microbenchmarks using two different EP libraries - DeepEP & MoRI-EP.
This PR also aims to update the main level readme with the blueprints section. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

The following changes were added. 

*   A dockerfile which has a default ROCm 7.2 public vllm image and build instructions to build DeepEP & MoRI.
*   A slrum script which can launch the docker containers and run the benchmarks.
*   A generic benchmarkfile which can be used to run the EP benchmarking on intranode (1N) & internode (2N) for both normal and low latency EP strategies.

## Test Plan

The current dockerfile is defaulted to gfx942 and CX7 NIC. If you wish to use a different NIC, please update the build argument accordingly. 
Follow the detailed instructions in scripts/large-ep-benchamrks/README.md file. 

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
