### PR TITLE
updated docker base container and set PYTHONPATH env for sglang_disagg_inf

### DIFF
--- a/docker/sglang_disagg_inference.ubuntu.amd.Dockerfile
+++ b/docker/sglang_disagg_inference.ubuntu.amd.Dockerfile
@@ -24,8 +24,10 @@
 # SOFTWARE.
 #
 #################################################################################
-ARG BASE_DOCKER=lmsysorg/sglang:v0.5.5.post3-rocm700-mi30x
+ARG BASE_DOCKER=lmsysorg/sglang:v0.5.9-rocm720-mi30x
 FROM $BASE_DOCKER
+
+ENV PYTHONPATH=$PYTHONPATH:/sgl-workspace/mori:/sgl-workspace/aiter:
 
 ARG GPU_ARCH=gfx942
 WORKDIR /sgl-workspace


### PR DESCRIPTION
## Motivation

Update Dockerfile for sglang_disagg to use the latest sgLang rocm720 as base container.

- Updated Dockerfile base image.
- Added PYTHONPATH env.

<!-- Explain the changes along with any relevant GitHub links. -->

- Submitted run with newly built container with DeepSeek-V3
- The run covered 2P2D case.

<!-- Explain any relevant testing done to verify this PR. -->

benchmark csv and logs files were generated in the run log directory.

<!-- Briefly summarize test outcomes. -->



- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
