### PR TITLE
Add KV cache internode transfer benchmark (RIXL, Mori, Mooncake)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Below are blueprints of supported models along with their documentation.
 | [**Large EP microbenchmark**](scripts/large-ep-benchmark/README.md) | MoE Large Expert Paralellism with MoRI-EP & DeepEP communication microbenchmarks | no specific models |
 | [**vLLM disaggregated P/D inference**](scripts/vllm_dissag/README.MD) | Distributed Inference P/D disaggregation with vLLM | DeepSeek-V3, Llama-3.3-70B-Instruct-FP8-KV, Llama-3.1-405B-Instruct-FP8-KV, gpt-oss-120b |
 | [**SGLang disaggregated P/D inference**](scripts/sglang_disagg/README.MD) | Distributed Inference P/D disggregation with SGLang | Qwen3-32B, Llama-3.1-8B-Instruct, Llama-3.3-70B-Instruct-FP8-KV, Llama-3.1-405B-Instruct-FP8-KV, DeepSeek-V3, Mixtral-8x7B-v0.1 |
+| [**KVCache Transfer Bench**](scripts/kvcache_transfer_bench/README.md) | Inter-node Transfer Benchmark | no specific models |
 
 ## Table of Contents
 

--- a/scripts/kvcache_transfer_bench/Dockerfile
+++ b/scripts/kvcache_transfer_bench/Dockerfile
@@ -1,0 +1,189 @@
+#
+# Single-stage build: Mooncake + MORI + RIXL + nixlbench
+#   docker build -f Dockerfile -t kv-cache-unified:latest .
+#
+ARG BASE_IMAGE=rocm/vllm-dev:base_torch2.10_triton3.6_rocm7.2_torch_build_20260216
+FROM ${BASE_IMAGE} AS base
+
+ENV WORKSPACE_DIR=/workspace
+
+RUN sed -i 's/http:/https:/g' /etc/apt/sources.list && \
+    sed -i 's/http:/https:/g' /etc/apt/sources.list.d/*.list || true
+
+RUN if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
+        sed -i 's/http:/https:/g' /etc/apt/sources.list.d/ubuntu.sources || true; \
+    fi
+
+# Install dependencies for KV cache calculator, report generation, Mori, Mooncake, RIXL
+RUN pip3 install --no-cache-dir \
+    transformers \
+    accelerate \
+    pyyaml \
+    tabulate \
+    plotly \
+    kaleido \
+    pandas \
+    meson \
+    auditwheel \
+    patchelf \
+    tomlkit \
+    setuptools \
+    wheel
+
+RUN apt-get update && \
+    apt-get install -y \
+    git \
+    cython3 \
+    ibverbs-utils \
+    ibverbs-providers \
+    rdmacm-utils \
+    libibverbs1 \
+    libibverbs-dev \
+    librdmacm1 \
+    librdmacm-dev \
+    openmpi-bin \
+    libopenmpi-dev \
+    libpci-dev \
+    cmake \
+    libdw1 \
+    locales \
+    autoconf \
+    libtool \
+    pkg-config \
+    libgrpc-dev \
+    libgrpc++-dev \
+    libprotobuf-dev \
+    protobuf-compiler-grpc \
+    libcpprest-dev \
+    libaio-dev \
+    libgflags-dev \
+    libgoogle-glog-dev \
+    libgtest-dev \
+    libjsoncpp-dev \
+    libnuma-dev \
+    libunwind-dev \
+    libboost-all-dev \
+    libssl-dev \
+    libcurl4-openssl-dev \
+    libhiredis-dev \
+    liburing-dev \
+    libjemalloc-dev \
+    libmsgpack-dev \
+    libzstd-dev \
+    libasio-dev \
+    libyaml-cpp-dev \
+    pybind11-dev \
+    wget \
+    unzip \
+    python3 \
+    python3-pip \
+    python3-dev \
+    build-essential \
+    ninja-build \
+    libc-bin \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install prettytable cmake setuptools setuptools-scm pytest-assume
+
+WORKDIR ${WORKSPACE_DIR}
+
+# ========== MOONCAKE ==========
+ARG MOONCAKE_REPO="https://github.com/kvcache-ai/Mooncake.git"
+
+RUN git clone ${MOONCAKE_REPO} mooncake && \
+    cd mooncake && \
+    echo "Mooncake: $(git rev-parse HEAD)" >> ${WORKSPACE_DIR}/shas.txt && \
+    ./dependencies.sh -y && \
+    mkdir -p build && cd build && \
+    cmake .. -DBUILD_SHARED_LIBS=ON -DUSE_HIP=ON -DUSE_HTTP=ON -DUSE_ETCD=ON -DSTORE_USE_ETCD=ON && \
+    export PATH="/usr/local/go/bin:${PATH}" && \
+    make -j16 && \
+    make install
+
+RUN cd ${WORKSPACE_DIR}/mooncake && \
+    export PATH="/usr/local/go/bin:${PATH}" && \
+    export LD_LIBRARY_PATH="${WORKSPACE_DIR}/mooncake/build/mooncake-asio:${LD_LIBRARY_PATH}" && \
+    ./scripts/build_wheel.sh
+
+RUN pip install uv && uv pip install --system ${WORKSPACE_DIR}/mooncake/mooncake-wheel/dist/*.whl
+
+RUN TEBENCH="${WORKSPACE_DIR}/mooncake/build/mooncake-transfer-engine/benchmark/tebench" && \
+    if [ -f "$TEBENCH" ]; then cp "$TEBENCH" /usr/local/bin/; fi
+
+ENV MOONCAKE_VERSION="built-from-source-rocm"
+ENV PATH=/usr/local/go/bin:${PATH}
+ENV PYTHONPATH=/usr/local/lib/python3.12/dist-packages
+
+# ========== MORI ==========
+RUN git clone --recursive https://github.com/ROCm/mori.git
+WORKDIR ${WORKSPACE_DIR}/mori
+RUN pip3 install . --no-build-isolation
+ENV PYTHONPATH=/workspace/mori:/usr/local/lib/python3.12/dist-packages
+
+# ========== UCX + RIXL ==========
+WORKDIR ${WORKSPACE_DIR}
+ARG RIXL_BRANCH="f33a5599"
+ARG RIXL_REPO="https://github.com/ROCm/RIXL.git"
+ARG UCX_BRANCH="da3fac2a"
+ARG UCX_REPO="https://github.com/ROCm/ucx.git"
+ENV ROCM_PATH=/opt/rocm
+ENV UCX_HOME=${WORKSPACE_DIR}/ucx
+ENV RIXL_HOME=${WORKSPACE_DIR}/rixl
+
+RUN git clone ${UCX_REPO} && cd ucx && git checkout ${UCX_BRANCH} && \
+    ./autogen.sh && mkdir build && cd build && \
+    ../configure --prefix=${UCX_HOME} --enable-shared --disable-static \
+        --disable-doxygen-doc --enable-optimizations --enable-devel-headers \
+        --with-rocm=/opt/rocm --with-verbs --with-dm --enable-mt && \
+    make -j && make install
+
+ENV PATH=${UCX_HOME}/bin:${PATH}
+ENV LD_LIBRARY_PATH=${UCX_HOME}/lib:${LD_LIBRARY_PATH}
+
+RUN git clone ${RIXL_REPO} ${RIXL_HOME} && cd ${RIXL_HOME} && git checkout ${RIXL_BRANCH} && \
+    meson setup build --prefix=${RIXL_HOME} -Ducx_path=${UCX_HOME} -Drocm_path=${ROCM_PATH} && \
+    cd build && ninja && ninja install
+
+RUN cd ${RIXL_HOME} && mkdir -p install && \
+    ./contrib/build-wheel.sh \
+        --output-dir ${RIXL_HOME}/install \
+        --rocm-dir ${ROCM_PATH} \
+        --ucx-plugins-dir ${UCX_HOME}/lib/ucx \
+        --nixl-plugins-dir ${RIXL_HOME}/lib/x86_64-linux-gnu/plugins
+
+RUN pip install ${RIXL_HOME}/install/*.whl
+ENV _RIXL_INSTALL_DIR=${RIXL_HOME}/install
+ENV _NIXLBENCH_INSTALL_DIR=${RIXL_HOME}/
+ENV _ROCM_DIR=/opt/rocm
+
+RUN python -c "import site; print(site.getsitepackages()[0])" > /tmp/sitepk.txt && \
+    SP=$(cat /tmp/sitepk.txt) && \
+    echo "import rixl, sys; sys.modules['nixl'] = rixl" > ${SP}/nixl_alias.pth && \
+    python -c "import nixl; print('nixl alias OK')"
+
+# ========== etcd + etcd-cpp ==========
+RUN wget -q https://github.com/etcd-io/etcd/releases/download/v3.6.0-rc.5/etcd-v3.6.0-rc.5-linux-amd64.tar.gz -O /tmp/etcd.tar.gz && \
+    mkdir -p /usr/local/bin/etcd && \
+    tar -xf /tmp/etcd.tar.gz -C /usr/local/bin/etcd --strip-components=1 && rm /tmp/etcd.tar.gz
+ENV PATH=${PATH}:/usr/local/bin/etcd/
+
+RUN git clone https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3.git && \
+    cd etcd-cpp-apiv3 && mkdir build && cd build && \
+    cmake -DCMAKE_FIND_ROOT_PATH=/usr/grpc .. && make -j && make install
+
+# ========== nixlbench ==========
+RUN cd ${RIXL_HOME}/benchmark/nixlbench && \
+    export CXXFLAGS="-Wno-error" && \
+    meson setup build \
+        -Dnixl_path=${RIXL_HOME} \
+        -Drocm_path=${ROCM_PATH} \
+        -Duse_rocm=true \
+        -Dprefix=/usr/local \
+        --buildtype=release && \
+    cd build && ninja && ninja install
+
+ENV PATH=/usr/local/bin:${PATH}
+ENV LD_LIBRARY_PATH=${RIXL_HOME}/lib/x86_64-linux-gnu:${UCX_HOME}/lib:${LD_LIBRARY_PATH}
+
+# ========== Final ==========
+RUN echo "Image ready: Mooncake + MORI + RIXL + nixlbench"

--- a/scripts/kvcache_transfer_bench/README.md
+++ b/scripts/kvcache_transfer_bench/README.md
@@ -1,0 +1,222 @@
+# KV Cache Transfer Performance Benchmark
+
+This benchmark measures KV cache transfer throughput across multiple backends (RIXL, Mori, Mooncake) on a two-node cluster with InfiniBand (Slurm, Kubernetes, or bare-metal).
+
+## Overview
+
+- **Backends**: RIXL, Mori, Mooncake (ROCm KV transfer engines)
+- **Environment**: 2 nodes, Docker containers, InfiniBand (`mlx5_0` by default)
+- **What it produces**: A sweep from `--start-size` through `--stop-size`, with JSON per backend, a merged CSV, and an interactive HTML report that compares backends across transfer sizes
+
+## Prerequisites
+
+- Two nodes with network connectivity (Slurm, Kubernetes, or bare-metal)
+- Docker with InfiniBand device access
+- ROCm-capable GPUs (for vLLM/KV cache estimator)
+
+## Result files
+
+Benchmark outputs are usually under `shared/results_<job_id>/` (path may differ if you set paths manually).
+
+
+| Artifact                                                          | Description                                                                      |
+| ----------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `results_rixl.json`, `results_mori.json`, `results_mooncake.json` | Raw throughput JSON from each backend                                            |
+| `results_merged.json`                                             | Single merged file combining all backends (normalized)                           |
+| `results_merged.csv`                                              | Pivot table: transfer size vs throughput per backend                             |
+| `report.html`                                                     | Interactive HTML report (tables + Plotly charts)                                 |
+| `kv_cache_estimator.csv`                                          | Optional; from the KV cache estimator, used to overlay model sizes on the report |
+
+
+The Slurm flow runs `merge_results.py` on the initiator so `results_merged.json`, `results_merged.csv`, and `report.html` are produced automatically. To regenerate manually, run `python scripts/merge_results.py --input-dir <results_dir>`; for KV-cache overlays, use the example in section 4 (after appending models).
+
+## Quick Start
+
+### 1. Build Docker Image
+
+From the `kvcache_transfer_bench` directory:
+
+```bash
+docker build --network=host -f Dockerfile -t kv-cache-unified:latest .
+```
+
+To push to Docker Hub:
+
+```bash
+docker tag kv-cache-unified:latest <your-repo>/kv-cache-transfer-bench:latest
+docker push <your-repo>/kv-cache-transfer-bench:latest
+```
+
+### 2. Run the Benchmark via Slurm
+
+Submit the launcher from the `kvcache_transfer_bench` directory (so `SLURM_SUBMIT_DIR` points at this repo). Pass [Slurm options](https://slurm.schedmd.com/sbatch.html) to `sbatch` first, then the script path, then benchmark options:
+
+```bash
+cd kvcache_transfer_bench
+sbatch [sbatch options] scripts/slurm_launcher.slrum [benchmark options]
+```
+
+**Benchmark options** (passed after the script name; forwarded by the launcher to `run_node.sh`):
+
+
+| Option           | Default          | Description                                                                                    |
+| ---------------- | ---------------- | ---------------------------------------------------------------------------------------------- |
+| `--docker-image` | *(required)*     | Image to `docker pull` and run on both nodes (e.g. `kv-cache-unified:latest` or registry path) |
+| `--start-size`   | 4096             | Minimum transfer size (bytes)                                                                  |
+| `--stop-size`    | 1073741824 (1GB) | Maximum transfer size (bytes)                                                                  |
+| `--backends`     | all              | Comma-separated: `rixl,mori,mooncake` or `all`                                                 |
+| `--ibdevice`     | mlx5_0           | InfiniBand device                                                                              |
+| `--sync-port`    | 9999             | TCP port for target/initiator sync                                                             |
+
+
+**Slurm options** (passed to `sbatch` before the script):
+
+
+| Option       | Description                                                         |
+| ------------ | ------------------------------------------------------------------- |
+| `--nodelist` | Comma-separated node names (e.g. `node-hostname-1,node-hostname-2`) |
+| `-t`         | Time limit (e.g. `-t 08:00:00`); required on some clusters          |
+| `-N 2`       | Number of nodes (default in `scripts/slurm_launcher.slrum`)         |
+
+
+**Example:**
+
+```bash
+# Run on specific nodes (pass -t if your cluster requires a runtime limit)
+sbatch -t 08:00:00 --nodelist=node-hostname-1,node-hostname-2 \
+  scripts/slurm_launcher.slrum --docker-image <your-repo>/kv-cache-unified:latest
+
+# Or let Slurm pick any 2 nodes
+sbatch -t 08:00:00 -N 2 scripts/slurm_launcher.slrum --docker-image <your-repo>/kv-cache-unified:latest
+```
+
+**Run on already allocated nodes:** If you have an interactive allocation (e.g. via `salloc`), run the launcher directly. It will use `SLURM_NODELIST` from your current session:
+
+```bash
+# 1. Allocate 2 nodes
+salloc -N 2 -n 2 --ntasks-per-node=1 --time=08:00:00
+
+# 2. From the allocation shell, run the benchmark
+cd kvcache_transfer_bench
+bash scripts/slurm_launcher.slrum --docker-image <your-repo>/kv-cache-unified:latest
+```
+
+### 3. Run on Non-Slurm Clusters (e.g. Kubernetes, Bare-Metal)
+
+On clusters without Slurm (Kubernetes, bare-metal, etc.), you can run `run_node.sh` on each node separately. Both nodes must have:
+
+- The benchmark code (or Docker image) available
+- **Shared storage** (NFS, PVC, etc.) so both nodes see the same `shared/` folder
+- Network connectivity and InfiniBand between nodes
+- Docker with device access (if using the container)
+
+**Role detection:** The script compares `hostname` with `NODE1`. If they match, it runs as **target**; otherwise as **initiator**. Ensure hostnames resolve correctly between nodes.
+
+#### Bare-Metal: run_node.sh directly
+
+`run_node.sh` accepts command-line arguments.
+
+**run_node.sh arguments:**
+
+
+| Argument               | Required | Default                           | Description                                    |
+| ---------------------- | -------- | --------------------------------- | ---------------------------------------------- |
+| `--node1`              | yes      | —                                 | Hostname of the **target** node                |
+| `--node2`              | yes      | —                                 | Hostname of the **initiator** node             |
+| `--kv-cache-test-path` | no       | /workspace/kvcache_transfer_bench | Path to benchmark inside container             |
+| `--shared-folder`      | no       | (kv-cache-test-path)              | Base path; appends `/shared/results_<JOB_ID>`  |
+| `--backends`           | no       | all                               | Comma-separated: `rixl,mori,mooncake` or `all` |
+| `--start-size`         | no       | 4096                              | Minimum transfer size (bytes)                  |
+| `--stop-size`          | no       | 1073741824                        | Maximum transfer size (bytes)                  |
+| `--ibdevice`           | no       | mlx5_0                            | InfiniBand device                              |
+| `--sync-port`          | no       | 9999                              | TCP port for target/initiator sync             |
+
+
+**Example** (run on each node; `JOB_ID` from env for bare-metal):
+
+```bash
+docker run --rm --device /dev/dri --device /dev/kfd --device /dev/infiniband \
+  --network host --hostname $(hostname) --add-host "$(hostname):$(hostname -I | awk '{print $1}')" \
+  --ipc host --group-add video --cap-add SYS_PTRACE --privileged=true \
+  --security-opt seccomp=unconfined --ulimit memlock=-1:-1 \
+  -v /sys:/sys \
+  -v /path/to/kvcache_transfer_bench:/workspace/kvcache_transfer_bench --shm-size 64G \
+  -e JOB_ID \
+  <your-docker-image> /workspace/kvcache_transfer_bench/scripts/run_node.sh \
+    --node1 node-target.example.com --node2 node-initiator.example.com \
+    --kv-cache-test-path /workspace/kvcache_transfer_bench \
+    --shared-folder /workspace/kvcache_transfer_bench \
+    --backends rixl,mori,mooncake --start-size 4096 --stop-size 1073741824 --ibdevice mlx5_0
+```
+
+### 4. Generate KV Cache Estimator Data (Optional)
+
+To add model-specific KV cache sizes to the report, run the estimator with a YAML config. The config defines model path, concurrency, seq-lengths, tp, pp, ep, dp, and dtype.
+
+```bash
+python kv_cache_estimator.py --config <config.yaml> [--output-dir <dir>] [--verify-vllm] [--append]
+```
+
+**Config fields:**
+
+
+| Field                              | Description                                  |
+| ---------------------------------- | -------------------------------------------- |
+| `model.name`                       | Model path (HuggingFace or local)            |
+| `model.concurrency`                | Space-separated: 1 2 4 8 16 32 64 128        |
+| `model.seq-length`                 | Space-separated: 1024 2048 4096 8192         |
+| `model.tp`                         | Tensor parallel sizes: 1 8                   |
+| `model.pp`, `model.ep`, `model.dp` | Pipeline, expert, data parallel (default: 1) |
+| `model.kv_cache_dtype`             | `fp8`, `bfloat16`, or `auto`                 |
+
+
+**Example config** (`llama_70b_config.yaml`):
+
+```yaml
+model:
+  name: "/shared_inference/models/amd/Llama-3.3-70B-Instruct-FP8-KV"
+  concurrency: 1
+  tp: 8   # Tensor parallel size (number of GPUs per model shard)
+  seq-length: 1024
+  kv_cache_dtype: "auto"
+  pp: 1
+  ep: 1
+  dp: 1
+```
+
+```bash
+# Single model (e.g. DeepSeek-R1)
+python kv_cache_estimator.py --config deepseek_r1_config.yaml --output-dir kv_cache_results_all
+
+# Custom output directory
+python kv_cache_estimator.py --config qwen3_8b_config.yaml --output-dir kv_cache_results_qwen
+
+# Append to existing CSV (for multiple models)
+python kv_cache_estimator.py --config qwen3_8b_config.yaml --output-dir kv_cache_results_all --append
+```
+
+**After appending models**, copy `kv_cache_estimator.csv` into the benchmark results directory (the same folder as `results_rixl.json`, etc., e.g. `shared/results_<job_id>/`), then regenerate the merged JSON, CSV, and HTML so the report includes every row in the CSV:
+
+```bash
+python scripts/merge_results.py --input-dir <results_dir> --kv-cache-estimator-file <results_dir>/kv_cache_estimator.csv
+```
+
+## Project Structure
+
+```
+kvcache_transfer_bench/
+├── README.md
+├── Dockerfile                    # Unified image (RIXL + Mori + Mooncake)
+├── kv_cache_estimator.py       # KV cache size calculator & vLLM verifier
+├── scripts/
+│   ├── merge_results.py        # Merge JSON results, generate CSV + HTML report
+│   ├── run_node.sh             # Per-node benchmark runner (target/initiator)
+│   └── slurm_launcher.slrum    # Slurm batch launcher (use with sbatch)
+├── backends/
+│   ├── common/                 # Shared utilities (sync, helpers)
+│   ├── rixl/                   # RIXL initiator/target benchmarks
+│   ├── mori/                   # Mori initiator/target benchmarks
+│   └── mooncake/               # Mooncake initiator/target benchmarks
+└── shared/                     # Results (shared/results_<JOB_ID>/)
+```
+

--- a/scripts/kvcache_transfer_bench/backends/common/sync_socket.py
+++ b/scripts/kvcache_transfer_bench/backends/common/sync_socket.py
@@ -1,0 +1,200 @@
+"""
+Socket-based synchronization for KV cache benchmarks.
+
+Provides SocketSyncTarget (target/server side) and SocketSyncInitiator
+(initiator/client side) that coordinate benchmark phases over a persistent
+TCP connection using newline-delimited JSON messages.
+
+Used by all backends for inter-node coordination during benchmarks.
+
+The sync TCP port defaults to 9999. Override via the ``port`` argument or
+``--sync-port`` on benchmark CLIs (RIXL/Mori/Mooncake target/initiator scripts).
+"""
+
+import json
+import socket
+import sys
+import time
+from typing import Optional
+
+DEFAULT_SYNC_PORT = 9999
+
+
+def get_sync_port(port: Optional[int] = None) -> int:
+    """Return ``port`` if set, otherwise ``DEFAULT_SYNC_PORT``."""
+    return DEFAULT_SYNC_PORT if port is None else port
+
+
+class SocketSyncTarget:
+    """Target-side sync: listens for one initiator, then exchanges messages."""
+
+    def __init__(self, port: Optional[int] = None):
+        self._port = get_sync_port(port)
+        self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server.bind(("0.0.0.0", self._port))
+        self._server.listen(1)
+        self._conn = None
+        self._rfile = None
+        self._wfile = None
+
+    def wait_for_connection(self, timeout=180):
+        """Block until the initiator connects."""
+        print(f"[sync-socket] Target listening on port {self._port}, waiting for initiator...")
+        self._server.settimeout(timeout)
+        try:
+            self._conn, addr = self._server.accept()
+        except socket.timeout:
+            print(f"[sync-socket] Timed out after {timeout}s waiting for initiator", file=sys.stderr)
+            sys.exit(1)
+        self._conn.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        self._rfile = self._conn.makefile("r")
+        self._wfile = self._conn.makefile("w")
+        print(f"[sync-socket] Initiator connected from {addr}")
+
+    def signal_target_ready(self, size, port=None, **extra):
+        msg = {"event": "target_ready", "size": size}
+        if port is not None:
+            msg["port"] = port
+        msg.update(extra)
+        self._send(msg)
+        print(f"[sync-socket] Sent target_ready for size {size}")
+
+    def wait_for_initiator_done(self, size, timeout=180):
+        print(f"[sync-socket] Waiting for initiator_done (size {size})...")
+        msg = self._recv(timeout)
+        if msg is None:
+            print(f"[sync-socket] Timed out waiting for initiator_done (size {size})", file=sys.stderr)
+            sys.exit(1)
+        if msg.get("event") != "initiator_done" or msg.get("size") != size:
+            print(f"[sync-socket] Unexpected message: {msg}", file=sys.stderr)
+            sys.exit(1)
+        print(f"[sync-socket] Initiator done with size {size}")
+
+    def signal_target_done(self, size):
+        self._send({"event": "target_done", "size": size})
+        print(f"[sync-socket] Sent target_done for size {size}")
+
+    def cleanup(self, start_size, end_size):
+        pass
+
+    def close(self):
+        for f in (self._rfile, self._wfile):
+            if f:
+                try:
+                    f.close()
+                except Exception:
+                    pass
+        if self._conn:
+            try:
+                self._conn.close()
+            except Exception:
+                pass
+        try:
+            self._server.close()
+        except Exception:
+            pass
+
+    def _send(self, msg):
+        self._wfile.write(json.dumps(msg) + "\n")
+        self._wfile.flush()
+
+    def _recv(self, timeout=180):
+        self._conn.settimeout(timeout)
+        try:
+            line = self._rfile.readline()
+        except socket.timeout:
+            return None
+        if not line:
+            return None
+        return json.loads(line)
+
+
+class SocketSyncInitiator:
+    """Initiator-side sync: connects to target, then exchanges messages."""
+
+    def __init__(self, host, port: Optional[int] = None):
+        self._host = host
+        self._port = get_sync_port(port)
+        self._sock = None
+        self._rfile = None
+        self._wfile = None
+
+    def connect(self, timeout=180):
+        """Retry connecting to the target's sync server until it is up."""
+        print(f"[sync-socket] Connecting to target {self._host}:{self._port}...")
+        deadline = time.time() + timeout
+        interval = 0.5
+        while True:
+            try:
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.settimeout(5)
+                s.connect((self._host, self._port))
+                s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                self._sock = s
+                self._rfile = s.makefile("r")
+                self._wfile = s.makefile("w")
+                print(f"[sync-socket] Connected to target")
+                return
+            except (OSError, socket.error):
+                s.close()
+                if time.time() >= deadline:
+                    print(f"[sync-socket] Timed out after {timeout}s connecting to target", file=sys.stderr)
+                    sys.exit(1)
+                time.sleep(interval)
+                interval = min(interval * 1.5, 5)
+
+    def wait_for_target_ready(self, size, timeout=180):
+        """Block until target sends target_ready. Returns the full message dict."""
+        print(f"[sync-socket] Waiting for target_ready (size {size})...")
+        msg = self._recv(timeout)
+        if msg is None:
+            print(f"[sync-socket] Timed out waiting for target_ready (size {size})", file=sys.stderr)
+            sys.exit(1)
+        if msg.get("event") != "target_ready" or msg.get("size") != size:
+            print(f"[sync-socket] Unexpected message: {msg}", file=sys.stderr)
+            sys.exit(1)
+        print(f"[sync-socket] Target ready for size {size}")
+        return msg
+
+    def send_initiator_done(self, size):
+        self._send({"event": "initiator_done", "size": size})
+        print(f"[sync-socket] Sent initiator_done for size {size}")
+
+    def wait_for_target_done(self, size, timeout=180):
+        print(f"[sync-socket] Waiting for target_done (size {size})...")
+        msg = self._recv(timeout)
+        if msg is None:
+            print(f"[sync-socket] Timed out waiting for target_done (size {size})", file=sys.stderr)
+            sys.exit(1)
+        if msg.get("event") != "target_done" or msg.get("size") != size:
+            print(f"[sync-socket] Unexpected message: {msg}", file=sys.stderr)
+            sys.exit(1)
+        print(f"[sync-socket] Target done with size {size}")
+
+    def close(self):
+        for f in (self._rfile, self._wfile):
+            if f:
+                try:
+                    f.close()
+                except Exception:
+                    pass
+        if self._sock:
+            try:
+                self._sock.close()
+            except Exception:
+                pass
+
+    def _send(self, msg):
+        self._wfile.write(json.dumps(msg) + "\n")
+        self._wfile.flush()
+
+    def _recv(self, timeout=180):
+        self._sock.settimeout(timeout)
+        try:
+            line = self._rfile.readline()
+        except socket.timeout:
+            return None
+        if not line:
+            return None
+        return json.loads(line)

--- a/scripts/kvcache_transfer_bench/backends/common/utils.py
+++ b/scripts/kvcache_transfer_bench/backends/common/utils.py
@@ -1,0 +1,117 @@
+"""
+Shared utilities for KV cache benchmark backends.
+
+Provides common functions used across mooncake, rixl, and mori backends
+to avoid code duplication.
+"""
+
+import json
+import socket as sock
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+
+def resolve_hostname(hostname: str) -> str:
+    """Resolve hostname to IP address. Returns hostname unchanged on failure."""
+    try:
+        return sock.gethostbyname(hostname)
+    except sock.gaierror:
+        return hostname
+
+
+def generate_test_sizes(start_size: int, end_size: int) -> List[int]:
+    """Generate sizes from start_size to end_size (inclusive), doubling each time."""
+    if start_size > end_size:
+        return [start_size]  # single size if range reversed
+    sizes = []
+    size = start_size
+    while size <= end_size:
+        sizes.append(size)
+        if size == end_size:
+            break
+        size *= 2
+    return sizes
+
+
+def append_result_to_file(results_path: Path, metadata: Dict[str, Any], result_entry: Dict[str, Any]) -> None:
+    """Append a single result entry to the results JSON file.
+    Creates the file with metadata on first call; appends on subsequent calls.
+    """
+    if results_path.exists():
+        with open(results_path) as f:
+            data = json.load(f)
+        data["results"].append(result_entry)
+    else:
+        data = {"metadata": metadata, "results": [result_entry]}
+    with open(results_path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def collect_version_info(
+    backend_name: str,
+    version_tries: List[Callable[[], Optional[str]]],
+    pytorch_version: Optional[str] = None,
+    rocm_version: Optional[str] = None,
+) -> Dict[str, str]:
+    """Collect version info for benchmark metadata.
+    version_tries: list of callables that return version string (e.g. from importlib.metadata).
+    """
+    backend_version = "unknown"
+    for _try in version_tries:
+        try:
+            v = _try()
+            if v:
+                backend_version = v
+                break
+        except Exception:
+            pass
+
+    if pytorch_version is None:
+        try:
+            import torch
+            pytorch_version = torch.__version__
+        except Exception:
+            pytorch_version = "unknown"
+
+    if rocm_version is None or rocm_version == "unknown":
+        try:
+            import torch
+            rocm_version = getattr(torch.version, "hip", None) or "unknown"
+        except Exception:
+            rocm_version = "unknown"
+        if rocm_version == "unknown":
+            for _path in ("/opt/rocm/.info/version", "/opt/rocm/version"):
+                try:
+                    rocm_version = open(_path).read().strip()
+                    break
+                except Exception:
+                    pass
+
+    return {
+        "version_info": {
+            backend_name: backend_version,
+            "pytorch": pytorch_version,
+            "rocm": rocm_version,
+        }
+    }
+
+
+def add_common_bench_args(parser, default_shared: str = "shared", include_append: bool = False) -> None:
+    """Add common benchmark arguments to an argparse parser."""
+    parser.add_argument("--start_size", type=int, required=True, help="Starting buffer size in bytes")
+    parser.add_argument("--end_size", type=int, required=True, help="Ending buffer size in bytes")
+    parser.add_argument("--target_node", type=str, default=None,
+                        help="Target node hostname (default: TARGET_IP env or current hostname)")
+    parser.add_argument("--initiator_node", type=str, default=None,
+                        help="Initiator node hostname (informational only)")
+    parser.add_argument("--shared_folder", type=str, default=default_shared,
+                        help="Shared folder for coordination")
+    parser.add_argument(
+        "--sync-port",
+        type=int,
+        default=9999,
+        help="TCP port for inter-node benchmark sync (default: 9999)",
+    )
+    if include_append:
+        parser.add_argument("--append_results", action="store_true",
+                            help="Append results to existing file instead of overwriting")

--- a/scripts/kvcache_transfer_bench/backends/mooncake/initiator_bench.py
+++ b/scripts/kvcache_transfer_bench/backends/mooncake/initiator_bench.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""
+Mooncake Benchmark - Initiator Node
+Same approach as mori/rixl: shared-folder coordination, read target port and metadata port from shared folder.
+Per size: initializes Mooncake TransferEngine, allocates VRAM, runs benchmark (WorkerThreads), computes throughput,
+writes per-size result and appends to results_mooncake.json.
+CLI args match rixl/mori; other params (protocol, device, threads, etc.) are hardcoded or from env.
+"""
+
+import argparse
+import gc
+import os
+import statistics
+import sys
+import time
+import socket as sock
+import threading
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from datetime import datetime, timezone
+
+# Add parent to path for common imports
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from common.utils import (
+    add_common_bench_args,
+    append_result_to_file,
+    collect_version_info,
+    generate_test_sizes,
+    resolve_hostname,
+)
+
+SHARED_DIR = None
+
+
+class WorkerThread:
+    """Worker thread for running Mooncake VRAM-to-VRAM transfers (inlined from former mooncake_bench_engine)."""
+
+    def __init__(self, worker_id, engine, target_session_id, local_buffer_ptr,
+                 remote_buffer_ptr, block_size, batch_size, operation,
+                 warmup_iters=0, num_iters=None):
+        self.worker_id = worker_id
+        self.engine = engine
+        self.target_session_id = target_session_id
+        self.local_buffer_ptr = local_buffer_ptr
+        self.remote_buffer_ptr = remote_buffer_ptr
+        self.block_size = block_size
+        self.batch_size = batch_size
+        self.operation = operation
+        self.warmup_iters = warmup_iters
+        self.num_iters = num_iters
+        self.batch_count = 0
+        self.durations = []  # per-iteration durations (seconds)
+        self.running = True
+
+    def _do_one_write_sync(self):
+        """Submit one write, wait for completion. Returns duration in seconds or None on error."""
+        t0 = time.perf_counter()
+        batch_id = self.engine.transfer_submit_write(
+            self.target_session_id,
+            self.local_buffer_ptr,
+            self.remote_buffer_ptr,
+            self.block_size,
+        )
+        if batch_id < 0:
+            return None
+        while True:
+            status = self.engine.transfer_check_status(batch_id)
+            if status != 0:
+                break
+            time.sleep(0.0001)
+        t1 = time.perf_counter()
+        return (t1 - t0) if status == 1 else None
+
+    def run(self):
+        use_iters = self.num_iters is not None and self.num_iters > 0
+        num_to_run = self.num_iters if use_iters else 999999
+        end_time = time.time() + 60 if not use_iters else 0
+
+        # Warmup phase (sync: one at a time, wait for completion)
+        for _ in range(self.warmup_iters):
+            if self.operation == "read":
+                self.engine.transfer_sync_read(
+                    self.target_session_id,
+                    self.local_buffer_ptr,
+                    self.remote_buffer_ptr,
+                    self.block_size,
+                )
+            else:
+                self._do_one_write_sync()
+
+        # Benchmark: one iteration, wait for completion, next (same as RIXL)
+        iters_done = 0
+        while iters_done < num_to_run and (use_iters or time.time() < end_time) and self.running:
+            if self.operation == "read":
+                t0 = time.perf_counter()
+                ret = self.engine.transfer_sync_read(
+                    self.target_session_id,
+                    self.local_buffer_ptr,
+                    self.remote_buffer_ptr,
+                    self.block_size,
+                )
+                t1 = time.perf_counter()
+                if ret >= 0:
+                    self.batch_count += 1
+                    self.durations.append(t1 - t0)
+                    iters_done += 1
+                else:
+                    break
+            else:
+                d = self._do_one_write_sync()
+                if d is not None:
+                    self.batch_count += 1
+                    self.durations.append(d)
+                    iters_done += 1
+                else:
+                    break
+
+try:
+    import torch
+    from mooncake.engine import TransferEngine
+    _MOONCAKE_AVAILABLE = True
+except Exception:
+    _MOONCAKE_AVAILABLE = False
+    torch = None
+    TransferEngine = None
+
+
+def delete_engine_metadata(metadata_url, session_id):
+    """Delete all stale metadata keys for a session from the metadata server.
+
+    Mooncake's initialize() registers multiple keys per session:
+      - mooncake/rpc_meta/<session_id>  (RPC endpoint info)
+      - mooncake/ram/<session_id>       (RDMA NIC topology)
+    The C++ destructor sends DELETEs on teardown, but Python GC is unreliable for
+    triggering it between loop iterations (internal refs may prevent collection).
+    Worse, if the old destructor runs AFTER the new engine registers the same keys,
+    it deletes the new engine's keys — causing 404s during transfers.
+    This function manually sends DELETEs as a robust pre-cleanup step.
+    """
+    for prefix in ("mooncake/rpc_meta", "mooncake/ram"):
+        key = f"{prefix}/{session_id}"
+        url = f"{metadata_url}?key={urllib.parse.quote(key, safe='')}"
+        try:
+            req = urllib.request.Request(url, method="DELETE")
+            urllib.request.urlopen(req, timeout=5)
+            print(f"  Deleted stale metadata key: {key}")
+        except Exception:
+            pass  # Key may not exist yet, or already deleted — that's fine
+
+
+def main():
+    global SHARED_DIR
+
+    parser = argparse.ArgumentParser(description="Mooncake Benchmark Initiator (same args as rixl/mori)")
+    add_common_bench_args(parser, default_shared="shared", include_append=True)
+    args = parser.parse_args()
+
+    # Hardcoded / from env (same style as rixl/mori)
+    protocol = "rdma"
+    device_name = os.environ.get("IBDEVICES", "mlx5_0")
+    gpu_id = 0
+    threads = 1
+    batch_size = 1
+    operation = "write"
+    warmup_iters = 100
+    num_iters = 128
+
+    SHARED_DIR = Path(args.shared_folder)
+    target_node = args.target_node or os.environ.get("TARGET_IP", "localhost")
+    test_sizes = generate_test_sizes(args.start_size, args.end_size)
+
+    hostname = sock.gethostname()
+    log_path = os.environ.get("LOG_PATH", ".")
+    os.makedirs(log_path, exist_ok=True)
+
+    print("=" * 60)
+    print("Mooncake Benchmark - INITIATOR")
+    print("=" * 60)
+    print(f"Hostname: {hostname}")
+    print(f"Node ID: {hostname}")
+    print(f"Target: {target_node} (port per size from shared folder)")
+    print(f"Start size: {args.start_size} bytes ({args.start_size / (1024*1024):.2f} MB)")
+    print(f"End size: {args.end_size} bytes ({args.end_size / (1024*1024):.2f} MB)")
+    print(f"GPU ID: {gpu_id}, Operation: {operation}, Threads: {threads}, Warmup: {warmup_iters}, Iterations: {num_iters}")
+    print(f"Shared folder: {SHARED_DIR}")
+    print("=" * 60 + "\n")
+
+    SHARED_DIR.mkdir(parents=True, exist_ok=True)
+
+    from common.sync_socket import SocketSyncInitiator
+
+    print(f"Sync port: {args.sync_port}")
+    sync = SocketSyncInitiator(host=resolve_hostname(target_node), port=args.sync_port)
+    sync.connect()
+
+    # Collect version info for metadata
+    metadata = collect_version_info(
+        "mooncake",
+        [
+            lambda: __import__("importlib.metadata", fromlist=["version"]).version("mooncake-transfer-engine-non-cuda"),
+            lambda: __import__("importlib.metadata", fromlist=["version"]).version("mooncake-transfer-engine"),
+            lambda: __import__("importlib.metadata", fromlist=["version"]).version("mooncake"),
+            lambda: __import__("mooncake").__version__,
+            lambda: os.environ.get("MOONCAKE_VERSION"),
+            lambda: open("/etc/mooncake_version").read().strip(),
+        ],
+    )
+
+    results_path = SHARED_DIR / "results_mooncake.json"
+
+    # Buffer size: 2x the largest test size, minimum 2 GB.  A large registered
+    # RDMA memory region allows the NIC to pipeline DMA across 12 worker threads
+    # instead of serializing them through a region equal to the block size.
+    max_test_size = max(test_sizes)
+    MIN_BUFFER_SIZE = 2_147_483_648  # 2 GB
+    buffer_size = max(max_test_size * 2, MIN_BUFFER_SIZE)
+
+    print(f"Test sizes: {test_sizes}")
+    print(f"Number of test sizes: {len(test_sizes)}")
+    print(f"Buffer size: {buffer_size} bytes ({buffer_size / (1024**3):.2f} GB)\n")
+
+    print(f"Starting benchmark with {len(test_sizes)} sizes\n")
+
+    # Keep references to old engines so their C++ destructors don't run during
+    # the loop.  The initiator uses the bare hostname as session_id, so every
+    # iteration registers the *same* metadata keys (mooncake/rpc_meta/<host>,
+    # mooncake/ram/<host>).  If we let the old destructor fire while a new
+    # engine owns those keys, the destructor deletes the NEW engine's keys and
+    # transfers fail with 404.  Preventing collection avoids the race entirely.
+    _old_engines = []
+
+    # Pre-allocate ONE large VRAM buffer that persists across all sizes.
+    buffer_tensor = None
+    buffer_ptr = 0
+    buffer_len = 0
+    if _MOONCAKE_AVAILABLE and torch is not None and torch.cuda.is_available():
+        device = torch.device(f"cuda:{gpu_id}")
+        buffer_tensor = torch.empty(buffer_size, dtype=torch.uint8, device=device)
+        buffer_ptr = buffer_tensor.data_ptr()
+        buffer_len = buffer_tensor.nbytes
+        print(f"Pre-allocated {buffer_size} byte VRAM buffer on {device}: ptr={buffer_ptr}\n")
+
+    for current_size in test_sizes:
+        print("\n" + "=" * 60)
+        print(f"Testing size: {current_size} bytes ({current_size / (1024*1024):.2f} MB)")
+        print("=" * 60 + "\n")
+
+        sync_info = sync.wait_for_target_ready(current_size)
+        metadata_port = sync_info.get("metadata_port", 8000)
+        target_port = sync_info["port"]
+        metadata_url = f"http://{target_node}:{metadata_port}/metadata"
+        target_session_id = f"{target_node}:{target_port}"
+        # Allow target's metadata registration to be visible before fetching
+        time.sleep(2)
+        out_file = os.path.join(log_path, f"mooncake_result_{current_size}.json")
+        throughput_gbs = 0.0
+        all_durations = []
+        avg_gbs = min_gbs = max_gbs = std_gbs = 0.0
+        engine = None
+
+        if buffer_tensor is not None:
+            try:
+                delete_engine_metadata(metadata_url, hostname)
+
+                engine = TransferEngine()
+                ret = engine.initialize(hostname, metadata_url, protocol, device_name)
+                if ret != 0:
+                    print(f"ERROR: Failed to initialize TransferEngine: {ret}", file=sys.stderr)
+                else:
+                    remote_buffer_ptr = 0
+                    for _ in range(30):
+                        remote_buffer_ptr = engine.get_first_buffer_address(target_session_id)
+                        if remote_buffer_ptr != 0:
+                            break
+                        time.sleep(1)
+                    if remote_buffer_ptr == 0:
+                        print(f"ERROR: Target buffer not found for {target_session_id}", file=sys.stderr)
+                    else:
+                        ret = engine.register_memory(buffer_ptr, buffer_len)
+                        if ret != 0:
+                            print(f"ERROR: Failed to register local VRAM: {ret}", file=sys.stderr)
+                        else:
+                            workers = []
+                            thread_objs = []
+                            for i in range(threads):
+                                worker = WorkerThread(
+                                    worker_id=i,
+                                    engine=engine,
+                                    target_session_id=target_session_id,
+                                    local_buffer_ptr=buffer_ptr,
+                                    remote_buffer_ptr=remote_buffer_ptr,
+                                    block_size=current_size,
+                                    batch_size=batch_size,
+                                    operation=operation,
+                                    warmup_iters=warmup_iters,
+                                    num_iters=num_iters,
+                                )
+                                workers.append(worker)
+                                thread_objs.append(threading.Thread(target=worker.run))
+                            for t in thread_objs:
+                                t.start()
+                            for t in thread_objs:
+                                t.join()
+                            all_durations = []
+                            for w in workers:
+                                all_durations.extend(w.durations)
+                            total_batch_count = sum(w.batch_count for w in workers)
+                            total_bytes = total_batch_count * current_size
+                            bandwidths_gbs = [current_size / (d * 1e9) for d in all_durations] if all_durations else []
+                            avg_gbs = statistics.mean(bandwidths_gbs) if len(bandwidths_gbs) >= 1 else 0.0
+                            min_gbs = min(bandwidths_gbs) if bandwidths_gbs else 0.0
+                            max_gbs = max(bandwidths_gbs) if bandwidths_gbs else 0.0
+                            std_gbs = statistics.stdev(bandwidths_gbs) if len(bandwidths_gbs) >= 2 else 0.0
+                            throughput_gbs = avg_gbs
+                            print(f"Bandwidth (GB/s): avg={avg_gbs:.4f} min={min_gbs:.4f} max={max_gbs:.4f} std={std_gbs:.4f}")
+                            engine.unregister_memory(buffer_ptr)
+            except KeyboardInterrupt:
+                sync.send_initiator_done(current_size)
+                sys.exit(130)
+            except Exception as e:
+                print(f"ERROR: Benchmark failed for size {current_size}: {e}", file=sys.stderr)
+            finally:
+                if engine is not None:
+                    _old_engines.append(engine)
+                engine = None
+                delete_engine_metadata(metadata_url, hostname)
+                time.sleep(2)
+        else:
+            if not _MOONCAKE_AVAILABLE:
+                print("Mooncake/CUDA not available; skipping VRAM benchmark.", file=sys.stderr)
+
+        result_entry = {
+            "backend": "mooncake",
+            "timestamp_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "test_parameters": {
+                "size_bytes": current_size,
+                "size_mb": current_size / (1024 * 1024),
+                "warmup_iters": warmup_iters,
+                "num_iters": num_iters,
+                "operation": operation,
+            },
+            "configuration": {
+                "protocol": protocol,
+                "threads": threads,
+                "batch_size": batch_size,
+                "device_name": device_name,
+                "buffer_size": buffer_size,
+            },
+            "results": {
+                "durations_s": all_durations,
+                "bandwidth_gbs_avg": round(avg_gbs, 4),
+                "bandwidth_gbs_min": round(min_gbs, 4),
+                "bandwidth_gbs_max": round(max_gbs, 4),
+                "bandwidth_gbs_std": round(std_gbs, 4),
+            },
+            "success": throughput_gbs > 0,
+        }
+        append_result_to_file(results_path, metadata, result_entry)
+        print(f"  Result appended to {results_path}")
+
+        sync.send_initiator_done(current_size)
+        sync.wait_for_target_done(current_size)
+        print(f"✓ Both nodes completed size {current_size}\n")
+        time.sleep(1)
+
+    _old_engines.clear()
+    if buffer_tensor is not None:
+        del buffer_tensor
+    gc.collect()
+
+    print("\n" + "=" * 60)
+    print("All test sizes completed successfully!")
+    print(f"Results file: {results_path}")
+    print("=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kvcache_transfer_bench/backends/mooncake/target_bench.py
+++ b/scripts/kvcache_transfer_bench/backends/mooncake/target_bench.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Mooncake Benchmark - Target Node
+Same approach as mori/rixl: shared-folder coordination, one port per size, per-size run then teardown.
+Starts metadata server once; for each size: allocates VRAM, registers with Mooncake TransferEngine,
+signals ready, waits for initiator_done, then cleans up.
+CLI args match rixl/mori; other params (protocol, device, gpu_id, ports) are hardcoded or from env.
+"""
+
+import argparse
+import gc
+import os
+import sys
+import time
+import socket as sock
+import subprocess
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from common.utils import add_common_bench_args, generate_test_sizes, resolve_hostname
+
+SHARED_DIR = None
+_metadata_proc = None
+
+# Mooncake VRAM/engine (optional; target runs without if unavailable)
+try:
+    import torch
+    from mooncake.engine import TransferEngine
+    _MOONCAKE_AVAILABLE = True
+except Exception:
+    _MOONCAKE_AVAILABLE = False
+    torch = None
+    TransferEngine = None
+
+
+def delete_engine_metadata(metadata_url, session_id):
+    """Delete all stale metadata keys for a session from the metadata server.
+
+    Mooncake's initialize() registers multiple keys per session:
+      - mooncake/rpc_meta/<session_id>  (RPC endpoint info)
+      - mooncake/ram/<session_id>       (RDMA NIC topology)
+    The C++ destructor sends DELETEs on teardown, but Python GC is unreliable for
+    triggering it between loop iterations (internal refs may prevent collection).
+    Worse, if the old destructor runs AFTER the new engine registers the same keys,
+    it deletes the new engine's keys — causing 404s during transfers.
+    This function manually sends DELETEs as a robust pre-cleanup step.
+    """
+    for prefix in ("mooncake/rpc_meta", "mooncake/ram"):
+        key = f"{prefix}/{session_id}"
+        url = f"{metadata_url}?key={urllib.parse.quote(key, safe='')}"
+        try:
+            req = urllib.request.Request(url, method="DELETE")
+            urllib.request.urlopen(req, timeout=5)
+            print(f"  Deleted stale metadata key: {key}")
+        except Exception:
+            pass  # Key may not exist yet, or already deleted — that's fine
+
+
+def stop_metadata_server():
+    global _metadata_proc
+    if _metadata_proc is not None and _metadata_proc.poll() is None:
+        _metadata_proc.terminate()
+        try:
+            _metadata_proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            _metadata_proc.kill()
+        _metadata_proc = None
+        print("✓ Metadata server stopped")
+
+
+def main():
+    global SHARED_DIR, _metadata_proc
+
+    parser = argparse.ArgumentParser(description="Mooncake Benchmark Target (same args as rixl/mori)")
+    add_common_bench_args(parser, default_shared="shared")
+    args = parser.parse_args()
+
+    SHARED_DIR = Path(args.shared_folder)
+    test_sizes = generate_test_sizes(args.start_size, args.end_size)
+    hostname = sock.gethostname()
+    target_node = args.target_node or hostname
+    # Hardcoded / from env (same style as rixl/mori)
+    metadata_port = 8000
+    port_base = 15000
+    protocol = "rdma"
+    device_name = os.environ.get("IBDEVICES", "mlx5_0")
+    gpu_id = 0
+    metadata_url = f"http://{target_node}:{metadata_port}/metadata"
+
+    # Do not stop metadata server in atexit: Mooncake engine destructors run at
+    # interpreter shutdown (after atexit), so we stop the server via a delayed killer.
+
+    print("=" * 60)
+    print("Mooncake Benchmark - TARGET")
+    print("=" * 60)
+    print(f"Hostname: {hostname}")
+    print(f"Target Node: {target_node}")
+    if args.initiator_node:
+        print(f"Initiator Node: {args.initiator_node}")
+    print(f"Start size: {args.start_size} bytes ({args.start_size / (1024*1024):.2f} MB)")
+    print(f"End size: {args.end_size} bytes ({args.end_size / (1024*1024):.2f} MB)")
+    print(f"Metadata port: {metadata_port}")
+    print(f"Target port range: {port_base}..{port_base + len(test_sizes) - 1} (one per size)")
+    print(f"GPU ID: {gpu_id}")
+    print(f"Shared folder: {SHARED_DIR}")
+    print("=" * 60 + "\n")
+
+    SHARED_DIR.mkdir(parents=True, exist_ok=True)
+
+    from common.sync_socket import SocketSyncTarget
+
+    print(f"Sync port: {args.sync_port}")
+    sync = SocketSyncTarget(port=args.sync_port)
+    sync.wait_for_connection()
+
+    # If port is still in use (e.g. previous run's delayed killer hasn't run yet), wait for it
+    for _ in range(35):
+        try:
+            with sock.socket(sock.AF_INET, sock.SOCK_STREAM) as probe:
+                probe.settimeout(1)
+                probe.connect(("127.0.0.1", metadata_port))
+        except (OSError, sock.error):
+            # Port not in use (connection refused) -> we can start
+            break
+        print("Metadata port in use; waiting 1s for previous run's server to stop...")
+        time.sleep(1)
+    else:
+        print("WARNING: Metadata port still in use after 35s; starting server anyway (may fail).", file=sys.stderr)
+
+    # Start metadata server once
+    _metadata_proc = subprocess.Popen(
+        [sys.executable, "-m", "mooncake.http_metadata_server", "--port", str(metadata_port)],
+        env=os.environ,
+    )
+    time.sleep(2)
+    if _metadata_proc.poll() is not None:
+        print("ERROR: Metadata server exited early", file=sys.stderr)
+        sys.exit(1)
+    print(f"Metadata server started on port {metadata_port}\n")
+
+    # Buffer size: 2x the largest test size, minimum 2 GB.  A large registered
+    # RDMA memory region lets the NIC pipeline DMA from multiple initiator
+    # threads instead of serializing them through a region equal to block_size.
+    max_test_size = max(test_sizes)
+    MIN_BUFFER_SIZE = 2_147_483_648  # 2 GB
+    buffer_size = max(max_test_size * 2, MIN_BUFFER_SIZE)
+
+    # Pre-allocate ONE large VRAM buffer that persists across all sizes.
+    buffer_tensor = None
+    buffer_ptr = 0
+    buffer_len = 0
+    if _MOONCAKE_AVAILABLE and torch.cuda.is_available():
+        device = torch.device(f"cuda:{gpu_id}")
+        buffer_tensor = torch.empty(buffer_size, dtype=torch.uint8, device=device)
+        buffer_ptr = buffer_tensor.data_ptr()
+        buffer_len = buffer_tensor.nbytes
+        print(f"Pre-allocated {buffer_size} byte VRAM buffer on {device}: ptr={buffer_ptr}")
+
+    print(f"Buffer size: {buffer_size} bytes ({buffer_size / (1024**3):.2f} GB)")
+    print(f"Starting benchmark with {len(test_sizes)} sizes\n")
+
+    for size_index, current_size in enumerate(test_sizes):
+        target_port = port_base + size_index
+        print("\n" + "=" * 60)
+        print(f"Testing size: {current_size} bytes ({current_size / (1024*1024):.2f} MB)")
+        print("=" * 60 + "\n")
+
+        engine = None
+        if buffer_tensor is not None:
+            os.environ["MC_LEGACY_RPC_PORT_BINDING"] = "1"
+            session_id = f"{hostname}:{target_port}"
+
+            delete_engine_metadata(metadata_url, session_id)
+
+            engine = TransferEngine()
+            ret = engine.initialize(session_id, metadata_url, protocol, device_name)
+            if ret != 0:
+                print(f"ERROR: Failed to initialize TransferEngine: {ret}", file=sys.stderr)
+                sync.signal_target_ready(current_size, port=target_port, metadata_port=metadata_port)
+                sync.wait_for_initiator_done(current_size)
+                sync.signal_target_done(current_size)
+                continue
+            ret = engine.register_memory(buffer_ptr, buffer_len)
+            if ret != 0:
+                print(f"ERROR: Failed to register VRAM buffer: {ret}", file=sys.stderr)
+                sync.signal_target_ready(current_size, port=target_port, metadata_port=metadata_port)
+                sync.wait_for_initiator_done(current_size)
+                sync.signal_target_done(current_size)
+                continue
+            print(f"VRAM buffer registered: ptr={buffer_ptr}, length={buffer_len}")
+            # Allow metadata server to process registration before initiator fetches
+            time.sleep(2)
+
+        sync.signal_target_ready(current_size, port=target_port, metadata_port=metadata_port)
+        print(f"Target ready for size {current_size} (port={target_port}). Waiting for initiator...\n")
+
+        sync.wait_for_initiator_done(current_size)
+
+        if engine is not None:
+            try:
+                engine.unregister_memory(buffer_ptr)
+            except Exception:
+                pass
+            del engine
+            engine = None
+            gc.collect()
+            delete_engine_metadata(metadata_url, session_id)
+            time.sleep(1)
+
+        sync.signal_target_done(current_size)
+        print(f"✓ Both nodes completed size {current_size}\n")
+        time.sleep(2)
+
+    if buffer_tensor is not None:
+        del buffer_tensor
+    gc.collect()
+    meta_pid = _metadata_proc.pid if _metadata_proc is not None else None
+    if meta_pid is not None:
+        _DELAY_KILL_SEC = 10
+        subprocess.Popen(
+            ["sh", "-c", f"sleep {_DELAY_KILL_SEC} && kill {meta_pid} 2>/dev/null || true"],
+            start_new_session=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        print(f"✓ Metadata server will be stopped in {_DELAY_KILL_SEC}s.")
+        print(f"  If you re-run the benchmark before then, wait for port {metadata_port} to be free.")
+
+    print("\n" + "=" * 60)
+    print("All test sizes completed successfully!")
+    print("=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kvcache_transfer_bench/backends/mori/initiator_bench.py
+++ b/scripts/kvcache_transfer_bench/backends/mori/initiator_bench.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+MORI Benchmark - Initiator Node (node_rank=1 = TARGET in mori terms)
+
+Runs one torchrun per size (like RIXL/Mooncake): for each size, sync with
+target, run MORI benchmark with --sweep-start-size=X --sweep-max-size=X,
+--iters=128, --warmup-iters=100. MORI does warmup + active iterations
+internally (one transfer at a time). Target parses output and writes results.
+"""
+
+import argparse
+import os
+import sys
+import socket as sock
+import subprocess
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from common.utils import add_common_bench_args, generate_test_sizes, resolve_hostname
+
+SHARED_DIR = None
+NUM_ITERS = 128
+MAX_BUFFER_SIZE = 1073741824  # 1 GB — 2 GB (2^31) overflows signed int32 in RDMA paths
+
+
+def main():
+    global SHARED_DIR
+
+    parser = argparse.ArgumentParser(description="MORI Benchmark Initiator")
+    add_common_bench_args(parser, default_shared="/shared", include_append=True)
+    args = parser.parse_args()
+
+    SHARED_DIR = Path(args.shared_folder)
+    target_node = args.target_node or os.environ.get("TARGET_IP", "localhost")
+    master_addr = resolve_hostname(target_node)
+    mori_root = os.environ.get("MORI_ROOT", "/workspace/mori")
+    mori_bench = os.path.join(mori_root, "tests", "python", "io", "benchmark.py")
+    if not os.path.isfile(mori_bench):
+        print(f"ERROR: MORI benchmark not found: {mori_bench}", file=sys.stderr)
+        sys.exit(1)
+
+    hostname = sock.gethostname()
+    initiator_ip = resolve_hostname(os.environ.get("NODE2", hostname))
+
+    if args.end_size > MAX_BUFFER_SIZE:
+        print(f"WARNING: Clamping sweep to {MAX_BUFFER_SIZE} bytes "
+              f"(2 GB overflows signed int32 in RDMA paths)")
+        args.end_size = MAX_BUFFER_SIZE
+
+    test_sizes = generate_test_sizes(args.start_size, args.end_size)
+
+    print(f"{'='*60}")
+    print("MORI Benchmark - INITIATOR (per-size, warmup+active in MORI)")
+    print(f"{'='*60}")
+    print(f"Hostname:     {hostname}")
+    print(f"Local IP:     {initiator_ip}")
+    print(f"Target:       {target_node} (IP: {master_addr})")
+    print(f"Sweep:        {args.start_size} .. {args.end_size} bytes")
+    print(f"Test sizes:   {test_sizes}")
+    print(f"Buffer alloc: {args.end_size} bytes (max size, reused for all)")
+    print(f"Iterations:   {NUM_ITERS} per size")
+    print(f"Op type:      write")
+    print(f"Shared folder: {SHARED_DIR}")
+    print(f"MORI_ROOT:    {mori_root}")
+    print(f"{'='*60}\n")
+
+    SHARED_DIR.mkdir(parents=True, exist_ok=True)
+
+    from common.sync_socket import SocketSyncInitiator
+
+    print(f"Sync port:    {args.sync_port}")
+    sync = SocketSyncInitiator(host=resolve_hostname(target_node), port=args.sync_port)
+    sync.connect()
+
+    env = os.environ.copy()
+    env.setdefault("GLOO_SOCKET_IFNAME", "eth0")
+    env["PYTHONPATH"] = f"{mori_root}:{env.get('PYTHONPATH', '')}"
+
+    last_size = args.start_size
+    try:
+        for size_index, current_size in enumerate(test_sizes):
+            master_port = 29500 + size_index
+
+            print(f"\n{'='*60}")
+            print(f"Testing size: {current_size} bytes ({current_size / (1024*1024):.2f} MB)")
+            print(f"{'='*60}\n")
+
+            sync_info = sync.wait_for_target_ready(current_size)
+            master_port = sync_info.get("port", master_port)
+
+            cmd = [
+                "torchrun",
+                "--nnodes=2",
+                "--node_rank=1",
+                "--nproc_per_node=1",
+                f"--master_addr={master_addr}",
+                f"--master_port={master_port}",
+                mori_bench,
+                f"--host={initiator_ip}",
+                "--op-type=write",
+                f"--buffer-size={args.end_size}",
+                "--transfer-batch-size=1",
+                "--enable-sess",
+                "--enable-batch-transfer",
+                "--all",
+                f"--sweep-start-size={current_size}",
+                f"--sweep-max-size={current_size}",
+                "--num-initiator-dev=1",
+                "--num-target-dev=1",
+                "--num-worker-threads=1",
+                f"--iters={NUM_ITERS}",
+                "--poll_cq_mode=polling",
+                "--log-level=info",
+            ]
+            print(f"Command: {' '.join(cmd)}\n")
+
+            ret = subprocess.run(cmd, env=env, cwd=mori_root, capture_output=True, text=True)
+            if ret.stdout:
+                print(ret.stdout)
+            if ret.returncode != 0:
+                is_barrier_failure = ret.stderr and (
+                    "dist.barrier" in ret.stderr or "Connection reset by peer" in ret.stderr
+                )
+                if is_barrier_failure:
+                    print(f"  Warning: torchrun exited {ret.returncode} due to post-benchmark "
+                          "barrier failure (benchmark data transfer likely succeeded)",
+                          file=sys.stderr)
+                else:
+                    if ret.stderr:
+                        print(ret.stderr, file=sys.stderr)
+                    sync.send_initiator_done(current_size)
+                    sys.exit(ret.returncode)
+
+            last_size = current_size
+            sync.send_initiator_done(current_size)
+            sync.wait_for_target_done(current_size)
+
+    except KeyboardInterrupt:
+        try:
+            sync.send_initiator_done(last_size)
+        except Exception:
+            pass
+        sys.exit(130)
+
+    print(f"\n{'='*60}")
+    print("All sizes completed successfully!")
+    print(f"{'='*60}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kvcache_transfer_bench/backends/mori/target_bench.py
+++ b/scripts/kvcache_transfer_bench/backends/mori/target_bench.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+MORI Benchmark - Target Node (node_rank=0 = INITIATOR in mori terms)
+
+Runs one torchrun per size (like RIXL/Mooncake): for each size, signal ready,
+run MORI benchmark with --iters=128 --warmup-iters=100, parse results, write
+in RIXL-style format (bandwidth_gbs_avg) for merge_results.
+"""
+
+import argparse
+import json
+import os
+import sys
+import socket as sock
+import subprocess
+from pathlib import Path
+from datetime import datetime, timezone
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from common.utils import add_common_bench_args, append_result_to_file, collect_version_info, generate_test_sizes, resolve_hostname
+
+SHARED_DIR = None
+NUM_ITERS = 128
+MAX_BUFFER_SIZE = 1073741824  # 1 GB — 2 GB (2^31) overflows signed int32 in RDMA paths
+
+
+def parse_mori_output_all(output: str) -> list:
+    """Parse ALL rows from the MORI benchmark PrettyTable output."""
+    results = []
+    for line in (output or "").strip().split("\n"):
+        if "+" in line or "MsgSize" in line or "Initiator Rank" in line or not line.strip():
+            continue
+        if "|" in line:
+            parts = [p.strip() for p in line.split("|") if p.strip()]
+            if len(parts) >= 7:
+                try:
+                    results.append({
+                        "msg_size_bytes": int(parts[0]),
+                        "batch_size": int(parts[1]),
+                        "total_size_mb": float(parts[2]),
+                        "max_bandwidth_gbps": float(parts[3]),
+                        "avg_bandwidth_gbps": float(parts[4]),
+                        "min_latency_us": float(parts[5]),
+                        "avg_latency_us": float(parts[6]),
+                    })
+                except (ValueError, IndexError):
+                    continue
+    return results
+
+
+def main():
+    global SHARED_DIR
+
+    parser = argparse.ArgumentParser(description="MORI Benchmark Target")
+    add_common_bench_args(parser, default_shared="/shared", include_append=True)
+    args = parser.parse_args()
+
+    SHARED_DIR = Path(args.shared_folder)
+    mori_root = os.environ.get("MORI_ROOT", "/workspace/mori")
+    mori_bench = os.path.join(mori_root, "tests", "python", "io", "benchmark.py")
+    if not os.path.isfile(mori_bench):
+        print(f"ERROR: MORI benchmark not found: {mori_bench}", file=sys.stderr)
+        sys.exit(1)
+
+    hostname = sock.gethostname()
+    target_node = args.target_node or hostname
+    master_addr = resolve_hostname(target_node)
+
+    original_end_size = args.end_size
+    if args.end_size > MAX_BUFFER_SIZE:
+        print(f"WARNING: Clamping sweep to {MAX_BUFFER_SIZE} bytes "
+              f"(2 GB overflows signed int32 in RDMA paths)")
+        args.end_size = MAX_BUFFER_SIZE
+
+    test_sizes = generate_test_sizes(args.start_size, args.end_size)
+
+    print(f"{'='*60}")
+    print("MORI Benchmark - TARGET (per-size, warmup+active in MORI)")
+    print(f"{'='*60}")
+    print(f"Hostname:     {hostname}")
+    print(f"Target Node:  {target_node} (IP: {master_addr})")
+    if args.initiator_node:
+        print(f"Initiator:    {args.initiator_node}")
+    print(f"Sweep:        {args.start_size} .. {args.end_size} bytes")
+    print(f"Test sizes:   {test_sizes}")
+    print(f"Iterations:   {NUM_ITERS} per size")
+    print(f"Shared folder: {SHARED_DIR}")
+    print(f"MORI_ROOT:    {mori_root}")
+    print(f"{'='*60}\n")
+
+    SHARED_DIR.mkdir(parents=True, exist_ok=True)
+
+    from common.sync_socket import SocketSyncTarget
+
+    print(f"Sync port:    {args.sync_port}")
+    sync = SocketSyncTarget(port=args.sync_port)
+    sync.wait_for_connection()
+
+    metadata = collect_version_info(
+        "mori",
+        [
+            lambda: __import__("importlib.metadata", fromlist=["version"]).version("mori"),
+            lambda: __import__("mori").__version__,
+            lambda: os.environ.get("MORI_VERSION"),
+        ],
+    )
+    results_path = SHARED_DIR / "results_mori.json"
+
+    env = os.environ.copy()
+    env.setdefault("GLOO_SOCKET_IFNAME", "eth0")
+    env["PYTHONPATH"] = f"{mori_root}:{env.get('PYTHONPATH', '')}"
+
+    last_size = args.start_size
+    try:
+        for size_index, current_size in enumerate(test_sizes):
+            master_port = 29500 + size_index
+
+            print(f"\n{'='*60}")
+            print(f"Testing size: {current_size} bytes ({current_size / (1024*1024):.2f} MB)")
+            print(f"{'='*60}\n")
+
+            sync.signal_target_ready(current_size, port=master_port)
+            print("Waiting for initiator to connect...\n")
+
+            cmd = [
+                "torchrun",
+                "--nnodes=2",
+                "--node_rank=0",
+                "--nproc_per_node=1",
+                f"--master_addr={master_addr}",
+                f"--master_port={master_port}",
+                mori_bench,
+                f"--host={master_addr}",
+                "--op-type=write",
+                f"--buffer-size={args.end_size}",
+                "--transfer-batch-size=1",
+                "--enable-sess",
+                "--enable-batch-transfer",
+                "--all",
+                f"--sweep-start-size={current_size}",
+                f"--sweep-max-size={current_size}",
+                "--num-initiator-dev=1",
+                "--num-target-dev=1",
+                "--num-qp-per-transfer=1",
+                "--num-worker-threads=1",
+                f"--iters={NUM_ITERS}",
+                "--poll_cq_mode=polling",
+                "--log-level=info",
+            ]
+
+            print(f"Command: {' '.join(cmd)}\n")
+
+            ret = subprocess.run(cmd, env=env, cwd=mori_root, capture_output=True, text=True)
+            if ret.stdout:
+                print(ret.stdout)
+
+            all_metrics = parse_mori_output_all(ret.stdout or "")
+
+            if ret.returncode != 0:
+                if all_metrics:
+                    print(f"  Warning: torchrun exited {ret.returncode} but valid metrics found",
+                          file=sys.stderr)
+                else:
+                    print(f"  ERROR: torchrun exited {ret.returncode}", file=sys.stderr)
+                    if ret.stderr:
+                        for line in ret.stderr.strip().splitlines()[-15:]:
+                            print(f"    {line}", file=sys.stderr)
+                    sync.signal_target_done(current_size)
+                    sys.exit(ret.returncode)
+
+            if all_metrics:
+                m = all_metrics[0]
+                avg_gbs = round(m["avg_bandwidth_gbps"], 4)
+                print(f"  Size={m['msg_size_bytes']:>12}  Avg BW={m['avg_bandwidth_gbps']:.2f} GB/s  "
+                      f"Max BW={m['max_bandwidth_gbps']:.2f} GB/s  Avg Lat={m['avg_latency_us']:.2f} us")
+
+                result_entry = {
+                    "backend": "mori",
+                    "timestamp_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "test_parameters": {
+                        "size_bytes": m["msg_size_bytes"],
+                        "size_mb": m["msg_size_bytes"] / (1024 * 1024),
+                        "num_iters": NUM_ITERS,
+                        "operation": "write",
+                    },
+                    "results": {
+                        "bandwidth_gbs_avg": avg_gbs,
+                        "bandwidth_gbs_min": avg_gbs,  # MORI doesn't report per-iter; use avg
+                        "bandwidth_gbs_max": round(m["max_bandwidth_gbps"], 4),
+                        "bandwidth_gbs_std": 0.0,  # MORI doesn't report std
+                    },
+                    "success": True,
+                }
+                append_result_to_file(results_path, metadata, result_entry)
+                print(f"  Result appended to {results_path}")
+
+            last_size = current_size
+            sync.signal_target_done(current_size)
+            sync.wait_for_initiator_done(current_size)
+
+    except KeyboardInterrupt:
+        try:
+            sync.signal_target_done(last_size)
+        except Exception:
+            pass
+        sys.exit(130)
+
+    print(f"\n{'='*60}")
+    print("All sizes completed successfully!")
+    print(f"Results file: {results_path}")
+    print(f"{'='*60}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kvcache_transfer_bench/backends/rixl/initiator_bench.py
+++ b/scripts/kvcache_transfer_bench/backends/rixl/initiator_bench.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""
+RIXL Benchmark - Initiator Node (Simplified)
+Simplified initiator benchmark with hardcoded values
+"""
+
+import argparse
+import os
+import statistics
+import sys
+import time
+import socket as sock
+from pathlib import Path
+from datetime import datetime, timezone
+
+import torch
+from nixl._api import nixl_agent, nixl_agent_config
+from nixl.logging import get_logger
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from common.utils import (
+    add_common_bench_args,
+    append_result_to_file,
+    collect_version_info,
+    generate_test_sizes,
+    resolve_hostname,
+)
+
+logger = get_logger(__name__)
+
+# Shared directory for coordination (set from --shared_folder in main)
+SHARED_DIR = None
+
+
+def main():
+    global SHARED_DIR
+
+    parser = argparse.ArgumentParser(description='RIXL Benchmark Initiator (Simplified)')
+    add_common_bench_args(parser, default_shared="/shared", include_append=True)
+    args = parser.parse_args()
+
+    # Set shared directory from argument (must match target)
+    SHARED_DIR = Path(args.shared_folder)
+
+    # Target address: --target_node takes precedence over TARGET_IP env
+    target_node = args.target_node or os.environ.get('TARGET_IP', 'localhost')
+
+    # Target uses 15473+; initiator listener uses a separate range to avoid "Address already in use"
+    INITIATOR_PORT_BASE = 15573
+    GPU_ID = 0
+    OPERATION = 'WRITE'
+    NUM_ITERS = 128  # timed iterations per size
+    WARMUP_ITERS = 100
+
+    # etcd runs on target node; use same port as target_bench.py (2379)
+    ETCD_PORT = 2379
+    etcd_endpoint = f"http://{target_node}:{ETCD_PORT}"
+    os.environ['NIXL_ETCD_ENDPOINTS'] = etcd_endpoint
+
+    # Resolve target IP for connections
+    target_ip = resolve_hostname(target_node)
+    hostname = sock.gethostname()
+
+    print(f"{'='*60}")
+    print(f"RIXL Benchmark - INITIATOR (Simplified)")
+    print(f"{'='*60}")
+    print(f"Hostname: {hostname}")
+    print(f"Node ID: {hostname}")
+    print(f"Target: {target_node} (IP: {target_ip}, port per size from shared folder)")
+    print(f"Start size: {args.start_size} bytes ({args.start_size / (1024*1024):.2f} MB)")
+    print(f"End size: {args.end_size} bytes ({args.end_size / (1024*1024):.2f} MB)")
+    print(f"GPU ID: {GPU_ID}")
+    print(f"Operation: {OPERATION}")
+    print(f"Warmup iterations: {WARMUP_ITERS}, Timed iterations: {NUM_ITERS}")
+    print(f"etcd endpoint: {etcd_endpoint}")
+    print(f"Shared folder: {SHARED_DIR}")
+    print(f"{'='*60}\n")
+
+    # Ensure shared directory exists
+    SHARED_DIR.mkdir(parents=True, exist_ok=True)
+
+    from common.sync_socket import SocketSyncInitiator
+
+    print(f"Sync port: {args.sync_port}")
+    sync = SocketSyncInitiator(host=resolve_hostname(target_node), port=args.sync_port)
+    sync.connect()
+
+    # Collect version info for metadata
+    metadata = collect_version_info(
+        "rixl",
+        [
+            lambda: __import__("importlib.metadata", fromlist=["version"]).version("rixl"),
+            lambda: __import__("importlib.metadata", fromlist=["version"]).version("nixl"),
+            lambda: __import__("rixl").__version__,
+            lambda: __import__("nixl").__version__,
+            lambda: os.environ.get("RIXL_VERSION"),
+        ],
+        pytorch_version=torch.__version__,
+    )
+
+    results_path = SHARED_DIR / "results_rixl.json"
+
+    # Generate test sizes
+    test_sizes = generate_test_sizes(args.start_size, args.end_size)
+    print(f"Test sizes: {test_sizes}")
+    print(f"Number of test sizes: {len(test_sizes)}\n")
+
+
+    # Check if CUDA/ROCm is available
+    if not torch.cuda.is_available():
+        logger.error("PyTorch CUDA/ROCm is not available!")
+        logger.error("Make sure ROCm is installed and PyTorch is built with ROCm support.")
+        sys.exit(1)
+
+    # Set device to specified GPU
+    device = torch.device(f'cuda:{GPU_ID}')
+    torch.set_default_device(device)
+
+    logger.info(f"Using GPU device: {device}")
+    logger.info(f"GPU Name: {torch.cuda.get_device_name(GPU_ID)}")
+
+    print(f"\n{'='*60}")
+    print(f"Starting benchmark with {len(test_sizes)} sizes")
+    print(f"{'='*60}\n")
+
+    # Iterate through each test size (fresh listener port per size to avoid bind "Address already in use")
+    for size_index, current_size in enumerate(test_sizes):
+        initiator_port = INITIATOR_PORT_BASE + size_index
+
+        print(f"\n{'='*60}")
+        print(f"Testing size: {current_size} bytes ({current_size / (1024*1024):.2f} MB)")
+        print(f"{'='*60}\n")
+
+        # Wait for target to be ready for this size
+        sync_info = sync.wait_for_target_ready(current_size)
+        target_port = sync_info["port"]
+
+        # Create nixl agent config for this size (unique listener port per size)
+        config = nixl_agent_config(True, True, initiator_port)
+
+        # Initialize agent in initiator mode
+        logger.info("Initializing RIXL agent in initiator mode...")
+        agent = nixl_agent("initiator", config)
+
+        # Fetch remote metadata and send local metadata
+        logger.info(f"Fetching remote metadata from target {target_node}:{target_port}...")
+        agent.fetch_remote_metadata("target", target_ip, target_port)
+        agent.send_local_metadata(target_ip, target_port)
+
+        # Wait for target to send its descriptors
+        logger.info("Waiting for target descriptors...")
+        notifs = []
+        max_wait = 30
+        wait_time = 0
+        while len(notifs) == 0 and wait_time < max_wait:
+            notifs = agent.get_new_notifs()
+            if len(notifs) == 0:
+                time.sleep(0.5)
+                wait_time += 0.5
+
+        if len(notifs) == 0:
+            logger.error(f"Timeout waiting for target descriptors after {max_wait}s")
+            sync.send_initiator_done(current_size)
+            continue
+
+        logger.info("Received target descriptors.")
+        target_descs = agent.deserialize_descs(notifs["target"][0])
+
+        # Ensure remote metadata has arrived
+        logger.info("Waiting for remote metadata to be ready...")
+        ready = False
+        wait_time = 0
+        while not ready and wait_time < max_wait:
+            ready = agent.check_remote_metadata("target")
+            if not ready:
+                time.sleep(0.5)
+                wait_time += 0.5
+
+        if not ready:
+            logger.error(f"Remote metadata not ready after {max_wait}s")
+            sync.send_initiator_done(current_size)
+            continue
+
+        logger.info("Remote metadata ready.")
+
+        # Allocate local buffer for current size
+        logger.info(f"Allocating {current_size} bytes in VRAM on GPU {GPU_ID}...")
+        tensor = torch.zeros(current_size, dtype=torch.uint8, device=device)
+
+        # Register GPU memory with RIXL
+        logger.info("Registering GPU memory with RIXL agent...")
+        reg_descs = agent.register_memory([tensor])
+
+        if not reg_descs:
+            logger.error("Memory registration failed.")
+            sync.send_initiator_done(current_size)
+            sys.exit(1)
+
+        logger.info("GPU memory registered successfully.")
+
+        # Prepare initiator descriptors
+        initiator_descs = reg_descs.trim()
+
+        # Create transfer handle
+        logger.info(f"Creating transfer handle for {OPERATION} operation...")
+        xfer_handle = agent.initialize_xfer(
+            OPERATION,
+            initiator_descs,
+            target_descs,
+            "target",
+            b"UUID"
+        )
+
+        if not xfer_handle:
+            logger.error("Failed to create transfer handle")
+            agent.deregister_memory(reg_descs)
+            del tensor
+            sync.send_initiator_done(current_size)
+            sys.exit(1)
+
+        logger.info("Transfer handle created successfully.")
+
+        # Warmup phase
+        print(f"Warming up ({WARMUP_ITERS} iterations)...")
+        state = "DONE"  # so post-loop "if state == ERR" is always defined
+        for i in range(WARMUP_ITERS):
+            state = agent.transfer(xfer_handle)
+            if state == "ERR":
+                logger.error(f"Transfer error during warmup iteration {i}")
+                break
+
+            # Wait for completion
+            while True:
+                state = agent.check_xfer_state(xfer_handle)
+                if state == "ERR":
+                    logger.error(f"Transfer error state during warmup")
+                    break
+                elif state == "DONE":
+                    break
+
+            if state == "ERR":
+                break
+
+        if state == "ERR":
+            agent.release_xfer_handle(xfer_handle)
+            agent.deregister_memory(reg_descs)
+            del tensor
+            sync.send_initiator_done(current_size)
+            sys.exit(1)
+
+        print(f"Starting benchmark ({NUM_ITERS} iterations)...\n")
+
+        # Benchmark: one iteration, wait for completion, next (sync like RIXL)
+        durations = []
+        transfer_count = 0
+
+        for _ in range(NUM_ITERS):
+            t0 = time.perf_counter()
+            state = agent.transfer(xfer_handle)
+
+            if state == "ERR":
+                logger.error("Transfer error")
+                break
+
+            # Wait for completion
+            while True:
+                state = agent.check_xfer_state(xfer_handle)
+                if state == "ERR":
+                    logger.error("Transfer error state")
+                    break
+                elif state == "DONE":
+                    transfer_count += 1
+                    break
+
+            if state == "ERR":
+                break
+
+            t1 = time.perf_counter()
+            durations.append(t1 - t0)
+
+        # Compute bandwidth per iteration (GB/s = bytes / duration / 1e9)
+        bandwidths_gbs = [current_size / (d * 1e9) for d in durations] if durations else []
+        avg_gbs = statistics.mean(bandwidths_gbs) if len(bandwidths_gbs) >= 1 else 0.0
+        min_gbs = min(bandwidths_gbs) if bandwidths_gbs else 0.0
+        max_gbs = max(bandwidths_gbs) if bandwidths_gbs else 0.0
+        std_gbs = statistics.stdev(bandwidths_gbs) if len(bandwidths_gbs) >= 2 else 0.0
+
+        total_bytes = transfer_count * current_size
+        actual_duration = sum(durations)
+
+        print(f"\n{'='*60}")
+        print(f"Size {current_size} bytes: {transfer_count} iterations")
+        print(f"Total data: {total_bytes / (1024*1024*1024):.2f} GB")
+        print(f"Bandwidth (GB/s): avg={avg_gbs:.4f} min={min_gbs:.4f} max={max_gbs:.4f} std={std_gbs:.4f}")
+        print(f"{'='*60}\n")
+
+        result_entry = {
+            "backend": "rixl",
+            "timestamp_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "test_parameters": {
+                "size_bytes": current_size,
+                "size_mb": current_size / (1024 * 1024),
+                "warmup_iters": WARMUP_ITERS,
+                "num_iters": NUM_ITERS,
+                "operation": OPERATION,
+                "gpu_id": GPU_ID,
+            },
+            "configuration": {
+                "etcd_endpoint": etcd_endpoint,
+            },
+            "results": {
+                "total_operations": transfer_count,
+                "durations_s": durations,
+                "bandwidth_gbs_avg": round(avg_gbs, 4),
+                "bandwidth_gbs_min": round(min_gbs, 4),
+                "bandwidth_gbs_max": round(max_gbs, 4),
+                "bandwidth_gbs_std": round(std_gbs, 4),
+            },
+            "success": transfer_count > 0,
+        }
+        append_result_to_file(results_path, metadata, result_entry)
+        print(f"  Result appended to {results_path}")
+
+        # Cleanup for this size
+        agent.release_xfer_handle(xfer_handle)
+        agent.deregister_memory(reg_descs)
+        del tensor
+
+        # Cleanup agent for this size
+        agent.remove_remote_agent("target")
+        agent.invalidate_local_metadata(target_ip, target_port)
+
+        # Signal that initiator is done with this size
+        sync.send_initiator_done(current_size)
+
+        # Wait for target to finish this size
+        sync.wait_for_target_done(current_size)
+
+        print(f"✓ Both nodes completed size {current_size}\n")
+
+        # Small delay before next size
+        time.sleep(1)
+
+    print(f"\n{'='*60}")
+    print(f"All test sizes completed successfully!")
+    print(f"Results file: {results_path}")
+    print(f"{'='*60}\n")
+
+    logger.info("Benchmark complete. Exiting.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kvcache_transfer_bench/backends/rixl/target_bench.py
+++ b/scripts/kvcache_transfer_bench/backends/rixl/target_bench.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""
+RIXL Benchmark - Target Node (Simplified)
+Simplified target benchmark with hardcoded values and embedded etcd server
+"""
+
+import argparse
+import atexit
+import os
+import signal
+import subprocess
+import sys
+import time
+import socket as sock
+from pathlib import Path
+
+import torch
+from nixl._api import nixl_agent, nixl_agent_config
+from nixl.logging import get_logger
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from common.utils import add_common_bench_args, generate_test_sizes
+
+logger = get_logger(__name__)
+
+# Global etcd process reference
+etcd_process = None
+
+# Shared directory for coordination (will be set from arguments)
+SHARED_DIR = None
+
+
+def start_etcd_server(hostname, etcd_port, etcd_peer_port):
+    """Start etcd server in background"""
+    global etcd_process
+
+    logger.info(f"Starting etcd server on {hostname}:{etcd_port}...")
+    print(f"Starting etcd server...")
+    print(f"  Client URL: http://{hostname}:{etcd_port}")
+    print(f"  Peer URL: http://{hostname}:{etcd_peer_port}")
+
+    # Create a temporary data directory for etcd
+    import tempfile
+    etcd_data_dir = tempfile.mkdtemp(prefix='etcd_data_')
+    logger.info(f"etcd data directory: {etcd_data_dir}")
+
+    try:
+        # Use 0.0.0.0 to bind to all interfaces, advertise the actual hostname
+        etcd_process = subprocess.Popen([
+            'etcd',
+            '--data-dir', etcd_data_dir,
+            '--listen-client-urls', f'http://0.0.0.0:{etcd_port}',
+            '--advertise-client-urls', f'http://{hostname}:{etcd_port}',
+            '--listen-peer-urls', f'http://0.0.0.0:{etcd_peer_port}',
+            '--initial-advertise-peer-urls', f'http://{hostname}:{etcd_peer_port}',
+            '--initial-cluster', f'default=http://{hostname}:{etcd_peer_port}',
+            '--log-level', 'error'
+        ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+        # Wait for etcd to start
+        time.sleep(5)
+
+        if etcd_process.poll() is not None:
+            # Process exited, capture error output
+            stdout, stderr = etcd_process.communicate(timeout=1)
+            logger.error("etcd process failed to start!")
+            logger.error(f"etcd stdout: {stdout}")
+            logger.error(f"etcd stderr: {stderr}")
+            print(f"etcd error output:\n{stderr}")
+            return False
+
+        logger.info("✓ etcd server started successfully")
+        print("✓ etcd server started successfully\n")
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to start etcd: {e}")
+        return False
+
+
+def stop_etcd_server():
+    """Stop etcd server and clear process reference."""
+    global etcd_process
+    if etcd_process:
+        logger.info("Stopping etcd server...")
+        print("Stopping etcd server...")
+        etcd_process.terminate()
+        try:
+            etcd_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            etcd_process.kill()
+        etcd_process = None
+        logger.info("✓ etcd server stopped")
+        print("✓ etcd server stopped")
+
+
+def run_etcd_server(hostname, etcd_port=2379, etcd_peer_port=2380, register_atexit=True):
+    """
+    Configure environment for etcd and start the etcd server.
+    When register_atexit is True, registers stop_etcd_server for process exit.
+    Returns True if etcd started successfully, False otherwise.
+    """
+    etcd_endpoint = f"http://{hostname}:{etcd_port}"
+    os.environ["NIXL_ETCD_ENDPOINTS"] = etcd_endpoint
+    if register_atexit:
+        atexit.register(stop_etcd_server)
+    return start_etcd_server(hostname, etcd_port, etcd_peer_port)
+
+
+def main():
+    global SHARED_DIR
+
+    parser = argparse.ArgumentParser(description='RIXL Benchmark Target (Simplified)')
+    add_common_bench_args(parser, default_shared="/shared")
+    args = parser.parse_args()
+
+    # Set shared directory from argument
+    SHARED_DIR = Path(args.shared_folder)
+    # Generate test sizes
+    test_sizes = generate_test_sizes(args.start_size, args.end_size)
+    print(f"Test sizes: {test_sizes}")
+    print(f"Number of test sizes: {len(test_sizes)}\n")
+
+    # Base port; each size uses base + index to avoid "Address already in use" after restart
+    PORT_BASE = 15473
+    GPU_ID = 0
+    DEVICE_NAME = None  # auto-discovery
+    ETCD_PORT = 2379
+    ETCD_PEER_PORT = 2380
+
+    hostname = sock.gethostname()
+    target_node = args.target_node if args.target_node else hostname
+    etcd_endpoint = f"http://{target_node}:{ETCD_PORT}"
+
+    print(f"{'='*60}")
+    print(f"RIXL Benchmark - TARGET (Simplified)")
+    print(f"{'='*60}")
+    print(f"Hostname: {hostname}")
+    print(f"Target Node: {target_node}")
+    if args.initiator_node:
+        print(f"Initiator Node: {args.initiator_node}")
+    print(f"Start size: {args.start_size} bytes ({args.start_size / (1024*1024):.2f} MB)")
+    print(f"End size: {args.end_size} bytes ({args.end_size / (1024*1024):.2f} MB)")
+    print(f"Port range: {PORT_BASE}..{PORT_BASE + len(test_sizes) - 1} (one per size)")
+    print(f"GPU ID: {GPU_ID}")
+    print(f"RDMA Device: {DEVICE_NAME or 'auto-discovery'}")
+    print(f"etcd endpoint: {etcd_endpoint}")
+    print(f"Shared folder: {SHARED_DIR}")
+    print(f"{'='*60}\n")
+
+    # Ensure shared directory exists
+    SHARED_DIR.mkdir(parents=True, exist_ok=True)
+
+    from common.sync_socket import SocketSyncTarget
+
+    print(f"Sync port: {args.sync_port}")
+    sync = SocketSyncTarget(port=args.sync_port)
+    sync.wait_for_connection()
+
+    # Check if CUDA/ROCm is available (once)
+    if not torch.cuda.is_available():
+        logger.error("PyTorch CUDA/ROCm is not available!")
+        logger.error("Make sure ROCm is installed and PyTorch is built with ROCm support.")
+        sys.exit(1)
+
+    device = torch.device(f'cuda:{GPU_ID}')
+    torch.set_default_device(device)
+    logger.info(f"Using GPU device: {device}")
+    logger.info(f"GPU Name: {torch.cuda.get_device_name(GPU_ID)}")
+
+    # Start etcd once for the entire sweep (avoids per-size restart overhead / port TIME_WAIT)
+    if not run_etcd_server(target_node, ETCD_PORT, ETCD_PEER_PORT):
+        logger.error("Failed to start etcd server. Exiting.")
+        sys.exit(1)
+
+    print(f"\n{'='*60}")
+    print(f"Starting benchmark with {len(test_sizes)} sizes")
+    print(f"{'='*60}\n")
+
+    for size_index, current_size in enumerate(test_sizes):
+        port = PORT_BASE + size_index
+        print(f"\n{'='*60}")
+        print(f"Testing size: {current_size} bytes ({current_size / (1024*1024):.2f} MB)")
+        print(f"{'='*60}\n")
+
+        config = nixl_agent_config(True, True, port)
+        logger.info("Initializing RIXL agent in target mode...")
+        agent = nixl_agent("target", config)
+
+        # Allocate VRAM buffer for current size
+        logger.info(f"Allocating {current_size} bytes in VRAM on GPU {GPU_ID}...")
+        tensor = torch.zeros(current_size, dtype=torch.uint8, device=device)
+
+        # Register GPU memory with RIXL
+        logger.info("Registering GPU memory with RIXL agent...")
+        reg_descs = agent.register_memory([tensor])
+
+        if not reg_descs:
+            logger.error("Memory registration failed.")
+            sync.signal_target_done(current_size)
+            sys.exit(1)
+
+        logger.info("GPU memory registered successfully.")
+        target_descs = reg_descs.trim()
+        target_desc_str = agent.get_serialized_descs(target_descs)
+
+        print(f"\nTarget ready for size {current_size}")
+        print(f"Listening on: {target_node}:{port}")
+        print(f"GPU buffer allocated on: cuda:{GPU_ID}")
+
+        sync.signal_target_ready(current_size, port=port)
+        print(f"Waiting for initiator to connect...\n")
+
+        # Wait for transfer to complete for this size
+        notif_sent = False
+        transfer_complete = False
+        try:
+            while not transfer_complete:
+                try:
+                    if not notif_sent:
+                        ready = agent.check_remote_metadata("initiator")
+                        if ready:
+                            logger.info("Initiator metadata detected. Sending target descriptors...")
+                            agent.send_notif("initiator", target_desc_str)
+                            notif_sent = True
+                            print("Descriptors sent to initiator. Waiting for transfers...")
+
+                    if notif_sent and not transfer_complete:
+                        if agent.check_remote_xfer_done("initiator", b"UUID"):
+                            logger.info("Transfer completed successfully!")
+                            transfer_complete = True
+                            print(f"\n✓ Transfer complete for size {current_size}")
+
+                    time.sleep(0.1)
+
+                except Exception as e:
+                    error_str = str(e)
+                    if "REMOTE_DISCONNECT" in error_str or "nixlRemoteDisconnectError" in str(type(e)):
+                        logger.warning("Initiator disconnected. Resetting and waiting for next connection...")
+                        print("\n⚠️  Initiator disconnected. Ready for new connection.\n")
+                        notif_sent = False
+                        time.sleep(1)
+                    else:
+                        logger.error(f"Error during transfer: {e}")
+                        print(f"Error: {e}")
+                        notif_sent = False
+                        time.sleep(1)
+
+        except KeyboardInterrupt:
+            print("\n\nShutting down...")
+            agent.deregister_memory(reg_descs)
+            del tensor
+            stop_etcd_server()
+            sys.exit(0)
+
+        agent.deregister_memory(reg_descs)
+        del tensor
+
+        sync.signal_target_done(current_size)
+        sync.wait_for_initiator_done(current_size)
+
+        print(f"✓ Both nodes completed size {current_size}\n")
+
+        time.sleep(1)
+
+    stop_etcd_server()
+
+    print(f"\n{'='*60}")
+    print(f"All test sizes completed successfully!")
+    print(f"{'='*60}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kvcache_transfer_bench/kv_cache_estimator.py
+++ b/scripts/kvcache_transfer_bench/kv_cache_estimator.py
@@ -1,0 +1,1688 @@
+#!/usr/bin/env python3
+"""
+KV Cache Calculator, Estimator, and vLLM Runtime Inspector
+
+Combined module providing:
+- Theoretical KV cache calculation (MHA, GQA, MQA, MLA, Sliding Window, MoE)
+- Estimation with layer-by-layer details
+- vLLM runtime verification
+
+Usage:
+------
+  python kv_cache_estimator.py --config <config.yaml> [--output-dir DIR] [--verify-vllm] [--append]
+
+  Config YAML (required): model.name, model.concurrency, model.tp, model.seq-length, model.kv_cache_dtype, model.pp
+"""
+
+import sys
+import os
+import json
+import csv
+import gc
+import math
+import argparse
+import datetime
+import platform
+from typing import Dict, Optional, Tuple, List, Any
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+
+def _ensure_int_bytes(x) -> int:
+    """Convert byte count to int. Uses ceil for fractional bytes (e.g. mxfp4=0.5)."""
+    return int(math.ceil(x)) if isinstance(x, float) else int(x)
+
+from transformers import AutoConfig
+
+# V0: exposes cache_engine.gpu_cache via model_executor.workers.
+# V1: exposes KVCacheConfig via engine_core.scheduler.kv_cache_config (Option A: config from get_kv_cache_configs).
+# Set VLLM_USE_V1=1 to use V1 engine; extraction will use scheduler config when V0 path unavailable.
+if "VLLM_USE_V1" not in os.environ:
+    os.environ["VLLM_USE_V1"] = "0"
+
+# Optional heavy imports (for vLLM features)
+try:
+    import torch
+except ImportError:
+    torch = None
+try:
+    from vllm import LLM, SamplingParams
+except ImportError:
+    LLM = None
+    SamplingParams = None
+
+# vLLM block size (constant)
+BLOCK_SIZE = 16
+
+# vLLM CacheConfig accepts: auto, fp8, fp8_e4m3, fp8_e5m2, fp8_inc
+# Map config kv_cache_dtype to vLLM's format
+VLLM_KV_CACHE_DTYPES = frozenset({"auto", "fp8", "fp8_e4m3", "fp8_e5m2", "fp8_inc"})
+
+# Aliases: config value -> vLLM value (for alternate spellings)
+VLLM_KV_CACHE_DTYPE_ALIASES = {
+    "fp8-e4m3": "fp8_e4m3",
+    "fp8-e5m2": "fp8_e5m2",
+    "e4m3": "fp8_e4m3",
+    "e5m2": "fp8_e5m2",
+}
+
+
+def _vllm_kv_cache_dtype(dtype: str) -> str:
+    """Map config kv_cache_dtype to vLLM-accepted kv_cache_dtype.
+    vLLM accepts: auto, fp8, fp8_e4m3, fp8_e5m2, fp8_inc.
+    Supports 'auto' (pass through), fp8 variants, and maps unsupported dtypes to 'auto'.
+    """
+    if not dtype:
+        return "auto"
+    d = str(dtype).strip().lower()
+    if d == "auto":
+        return "auto"
+    if d in VLLM_KV_CACHE_DTYPES:
+        return d
+    if d in VLLM_KV_CACHE_DTYPE_ALIASES:
+        return VLLM_KV_CACHE_DTYPE_ALIASES[d]
+    # bfloat16, float16, float32 not supported by vLLM CacheConfig -> use auto
+    return "auto"
+
+
+
+# ============================================================================
+# KV CACHE CALCULATION (from kv_cache_calc.py)
+# ============================================================================
+
+def _get_config_for_layers(config):
+    """Resolve config for layer/attention params. Mistral3Config uses text_config."""
+    if hasattr(config, 'text_config') and config.text_config is not None:
+        text_cfg = config.text_config
+        if hasattr(text_cfg, 'num_hidden_layers') or hasattr(text_cfg, 'n_layers') or hasattr(text_cfg, 'num_layers'):
+            return text_cfg
+    return config
+
+
+def _get_num_layers(config):
+    """Get number of layers, supporting num_hidden_layers, n_layers, num_layers, and text_config."""
+    cfg = _get_config_for_layers(config)
+    return getattr(cfg, 'num_hidden_layers', None) or getattr(cfg, 'n_layers', None) or getattr(cfg, 'num_layers', None)
+
+
+def detect_attention_type(config):
+    """Detect attention mechanism from config"""
+    if hasattr(config, 'kv_lora_rank'):
+        return "MLA"
+    if hasattr(config, 'sliding_window') and config.sliding_window:
+        return "SLIDING_WINDOW"
+    if hasattr(config, 'num_key_value_heads'):
+        num_kv = config.num_key_value_heads
+        num_q = config.num_attention_heads
+        if num_kv == 1:
+            return "MQA"
+        elif num_kv < num_q:
+            return "GQA"
+    return "MHA"
+
+
+def calculate_layer_kv_cache(config, layer_idx, seq_len, dtype_bytes, tp_size=1, batch_size=1):
+    """Calculate KV cache for a single layer"""
+
+    attention_type = detect_attention_type(config)
+    hidden_size = config.hidden_size
+
+    # Check for heterogeneous layer types (per-layer attention specification)
+    layer_specific_type = None
+    if hasattr(config, 'layer_types') and config.layer_types:
+        if layer_idx < len(config.layer_types):
+            layer_type_str = config.layer_types[layer_idx]
+            if 'full' in layer_type_str.lower():
+                layer_specific_type = "FULL_ATTENTION"
+            elif 'sliding' in layer_type_str.lower() or 'window' in layer_type_str.lower():
+                layer_specific_type = "SLIDING_WINDOW"
+
+    # MLA: Multi-Head Latent Attention (compressed)
+    if attention_type == "MLA":
+        kv_lora_rank = config.kv_lora_rank
+        qk_rope_head_dim = getattr(config, 'qk_rope_head_dim', 0)
+        kv_dim = kv_lora_rank + qk_rope_head_dim
+
+        per_gpu_kv_bytes = _ensure_int_bytes(1 * seq_len * kv_dim * dtype_bytes * batch_size)
+        total_kv_bytes = per_gpu_kv_bytes * tp_size
+
+        return {
+            'bytes': total_kv_bytes,
+            'mb': total_kv_bytes / (1024 ** 2),
+            'per_gpu_bytes': per_gpu_kv_bytes,
+            'per_gpu_mb': per_gpu_kv_bytes / (1024 ** 2),
+            'kv_dim': kv_dim,
+            'attention_type': 'MLA',
+            'tp_split': False
+        }
+
+    # Standard attention (MHA/GQA/MQA)
+    num_q_heads = config.num_attention_heads
+    num_kv_heads = getattr(config, 'num_key_value_heads', num_q_heads)
+    head_dim = hidden_size // num_q_heads
+
+    effective_seq_len = seq_len
+    final_attention_type = layer_specific_type if layer_specific_type else attention_type
+
+    if final_attention_type == "SLIDING_WINDOW":
+        effective_seq_len = min(seq_len, config.sliding_window)
+    elif final_attention_type == "FULL_ATTENTION":
+        effective_seq_len = seq_len
+    elif attention_type == "SLIDING_WINDOW" and not layer_specific_type:
+        max_window_layers = getattr(config, 'max_window_layers', _get_num_layers(config) or 0)
+        if layer_idx < max_window_layers:
+            effective_seq_len = min(seq_len, config.sliding_window)
+
+    # When num_kv_heads < tp_size, KV cache is replicated (each GPU holds full copy); otherwise sharded
+    per_gpu_kv_heads = num_kv_heads if num_kv_heads < tp_size else num_kv_heads // tp_size
+    per_gpu_kv_bytes = _ensure_int_bytes(
+        2 * effective_seq_len * per_gpu_kv_heads * head_dim * dtype_bytes * batch_size
+    )
+    total_kv_bytes = per_gpu_kv_bytes * tp_size
+
+    return {
+        'bytes': total_kv_bytes,
+        'mb': total_kv_bytes / (1024 ** 2),
+        'per_gpu_bytes': per_gpu_kv_bytes,
+        'per_gpu_mb': per_gpu_kv_bytes / (1024 ** 2),
+        'kv_dim': num_kv_heads * head_dim,
+        'attention_type': final_attention_type,
+        'num_kv_heads': num_kv_heads,
+        'per_gpu_kv_heads': per_gpu_kv_heads,
+        'effective_seq_len': effective_seq_len,
+        'tp_split': True
+    }
+
+
+def calculate_kv_cache(model_path, seq_len, dtype="float16", tp_size=1, batch_size=1, user_specified_dtype=False):
+    """Main calculation function"""
+
+    print(f"Loading config from: {model_path}")
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+
+    # Check for quantization config
+    quantization_detected = False
+    if not user_specified_dtype and hasattr(config, 'quantization_config') and config.quantization_config:
+        quant_config = config.quantization_config
+        if isinstance(quant_config, dict):
+            quant_method = quant_config.get('quant_method', '')
+            if 'fp8' in quant_method.lower():
+                dtype = "fp8"
+                quantization_detected = True
+                print(f"⚠️  Auto-detected FP8 quantization in config - using fp8 for KV cache")
+            elif 'mxfp4' in quant_method.lower() or 'fp4' in quant_method.lower():
+                dtype = "mxfp4"
+                quantization_detected = True
+                print(f"⚠️  Auto-detected MXFP4 quantization in config - using mxfp4 for KV cache")
+
+    if user_specified_dtype and hasattr(config, 'quantization_config') and config.quantization_config:
+        quant_config = config.quantization_config
+        if isinstance(quant_config, dict):
+            quant_method = quant_config.get('quant_method', '')
+            if quant_method:
+                print(f"ℹ️  Model has {quant_method} quantization, but using user-specified dtype: {dtype}")
+
+    dtype_bytes = {
+        "float32": 4,
+        "float16": 2,
+        "bfloat16": 2,
+        "int8": 1,
+        "fp8": 1,
+        "mxfp4": 0.5
+    }[dtype]
+    layer_config = _get_config_for_layers(config)
+    num_layers = _get_num_layers(config)
+    if num_layers is None:
+        raise AttributeError(f"{type(config).__name__} has no num_hidden_layers, n_layers, or num_layers")
+    hidden_size = getattr(layer_config, 'hidden_size', config.hidden_size)
+
+    attention_type = detect_attention_type(layer_config)
+    is_moe = hasattr(layer_config, 'num_local_experts')
+    is_heterogeneous = hasattr(layer_config, 'layer_types') and layer_config.layer_types
+
+    print("\n" + "=" * 80)
+    print(f"MODEL: {model_path}")
+    print("=" * 80)
+    print(f"Architecture      : {config.architectures}")
+
+    if is_heterogeneous:
+        print(f"Attention Type    : HETEROGENEOUS (Mixed)")
+        layer_type_counts = {}
+        for lt in layer_config.layer_types:
+            layer_type_counts[lt] = layer_type_counts.get(lt, 0) + 1
+        for lt, count in layer_type_counts.items():
+            print(f"  - {lt:20s}: {count} layers")
+    else:
+        print(f"Attention Type    : {attention_type}")
+
+    print(f"Hidden Size       : {hidden_size}")
+    print(f"Num Layers        : {num_layers}")
+    print(f"Attention Heads   : {getattr(layer_config, 'num_attention_heads', config.num_attention_heads)}")
+
+    if hasattr(layer_config, 'num_key_value_heads'):
+        print(f"KV Heads          : {layer_config.num_key_value_heads}")
+
+    if attention_type == "MLA":
+        print(f"KV Lora Rank      : {layer_config.kv_lora_rank}")
+        print(f"Compression Ratio : {hidden_size / layer_config.kv_lora_rank:.1f}x")
+
+    if attention_type == "SLIDING_WINDOW":
+        print(f"Sliding Window    : {layer_config.sliding_window}")
+
+    if is_moe:
+        print(f"MoE Experts       : {layer_config.num_local_experts}")
+
+    if quantization_detected:
+        quant_config = config.quantization_config
+        print(f"\n⚠️  QUANTIZATION DETECTED:")
+        print(f"  Method          : {quant_config.get('quant_method', 'N/A')}")
+
+    print(f"\nSequence Length   : {seq_len}")
+    print(f"Batch Size        : {batch_size}")
+    print(f"Data Type         : {dtype}")
+
+    if tp_size > 1:
+        print(f"Tensor Parallel   : {tp_size} GPUs")
+
+    print("=" * 80)
+
+    total_bytes = 0
+    per_gpu_total_bytes = 0
+    layer_results = []
+
+    print(f"\nLAYER-BY-LAYER KV CACHE:")
+    print("-" * 80)
+
+    if tp_size > 1:
+        print(f"{'Layer':<8} | {'Type':<20} | {'Per-GPU MB':<12} | {'Total MB':<12} | {'Details':<30}")
+    else:
+        print(f"{'Layer':<8} | {'Type':<20} | {'KV Cache (MB)':<15} | {'Details':<30}")
+
+    print("-" * 80)
+
+    for i in range(num_layers):
+        result = calculate_layer_kv_cache(layer_config, i, seq_len, dtype_bytes, tp_size, batch_size)
+        layer_results.append(result)
+        total_bytes += result['bytes']
+        per_gpu_total_bytes += result['per_gpu_bytes']
+
+        if result['attention_type'] == 'MLA':
+            details = f"KV Dim: {result['kv_dim']} (no TP split)"
+        else:
+            if tp_size > 1:
+                details = f"KV Heads: {result['per_gpu_kv_heads']}/{result['num_kv_heads']}, Seq: {result['effective_seq_len']}"
+            else:
+                details = f"KV Heads: {result['num_kv_heads']}, Seq: {result['effective_seq_len']}"
+
+        if tp_size > 1:
+            print(f"{i:<8} | {result['attention_type']:<20} | {result['per_gpu_mb']:<12.2f} | {result['mb']:<12.2f} | {details:<30}")
+        else:
+            print(f"{i:<8} | {result['attention_type']:<20} | {result['mb']:<15.2f} | {details:<30}")
+
+    total_mb = total_bytes / (1024 ** 2)
+    total_gb = total_bytes / (1024 ** 3)
+    per_gpu_mb = per_gpu_total_bytes / (1024 ** 2)
+    per_gpu_gb = per_gpu_total_bytes / (1024 ** 3)
+
+    print("-" * 80)
+    print(f"\nSUMMARY:")
+    print("=" * 80)
+
+    if tp_size > 1:
+        print(f"Total KV Cache (all GPUs)  : {total_mb:.2f} MB ({total_gb:.4f} GB)")
+        print(f"Per GPU KV Cache           : {per_gpu_mb:.2f} MB ({per_gpu_gb:.4f} GB)")
+        print(f"Per Layer Per GPU Avg      : {per_gpu_mb / num_layers:.2f} MB")
+        if batch_size > 1:
+            print(f"Per Sequence Per GPU       : {per_gpu_mb / batch_size:.2f} MB")
+    else:
+        per_layer_mb = total_mb / num_layers
+        per_token_kb = total_bytes / seq_len / batch_size / 1024
+        print(f"Total KV Cache    : {total_mb:.2f} MB ({total_gb:.4f} GB)")
+        print(f"Per Layer Avg     : {per_layer_mb:.2f} MB")
+        if batch_size > 1:
+            print(f"Per Sequence      : {total_mb / batch_size:.2f} MB")
+        print(f"Per Token         : {per_token_kb:.2f} KB")
+
+    print("=" * 80)
+
+    print(f"\nSEQUENCE LENGTH SCALING (batch_size={batch_size}):")
+    print("-" * 80)
+
+    if tp_size > 1:
+        print(f"{'Seq Length':<15} | {'Per-GPU MB':<15} | {'Total MB':<15} | {'Per-GPU GB':<15} | {'Total GB':<15}")
+    else:
+        print(f"{'Seq Length':<15} | {'Total MB':<15} | {'Total GB':<15} | {'Per Token KB':<15}")
+
+    print("-" * 80)
+
+    for test_seq in [512, 1024, 2048, 4096, 8192, 16384, 32768]:
+        if test_seq <= seq_len * 4:
+            test_total = 0
+            test_per_gpu = 0
+            for i in range(num_layers):
+                test_result = calculate_layer_kv_cache(layer_config, i, test_seq, dtype_bytes, tp_size, batch_size)
+                test_total += test_result['bytes']
+                test_per_gpu += test_result['per_gpu_bytes']
+
+            test_mb = test_total / (1024 ** 2)
+            test_gb = test_total / (1024 ** 3)
+            test_per_gpu_mb = test_per_gpu / (1024 ** 2)
+            test_per_gpu_gb = test_per_gpu / (1024 ** 3)
+            test_per_token = test_total / test_seq / batch_size / 1024
+
+            marker = " <-- Current" if test_seq == seq_len else ""
+
+            if tp_size > 1:
+                print(f"{test_seq:<15} | {test_per_gpu_mb:<15.2f} | {test_mb:<15.2f} | {test_per_gpu_gb:<15.4f} | {test_gb:<15.4f}{marker}")
+            else:
+                print(f"{test_seq:<15} | {test_mb:<15.2f} | {test_gb:<15.4f} | {test_per_token:<15.2f}{marker}")
+
+    print("-" * 80 + "\n")
+
+
+# ============================================================================
+# vLLM RUNTIME INSPECTION (from kv_cache_vllm_test.py)
+# ============================================================================
+
+def _extract_kv_cache_from_vllm_v1(
+    llm, tensor_parallel: int, pipeline_parallel: int, data_parallel_size: int
+) -> Optional[Dict]:
+    """Extract KV cache sizes from V1 engine's KVCacheConfig.
+
+    Tries two paths:
+    1. Direct: llm.llm_engine.engine_core.engine_core.scheduler.kv_cache_config
+       (works when engine runs in-process, e.g. single GPU)
+    2. RPC: call_utility("get_kv_cache_config_summary")
+       (works when engine runs in separate process, e.g. TP>1 multiprocess)
+       Requires vllm_v1_kv_cache_rpc.patch applied to vLLM.
+    """
+    try:
+        engine_core = getattr(llm.llm_engine, "engine_core", None)
+        if engine_core is None:
+            return None
+
+        # Path 1: Direct access (InprocClient - single process)
+        ec = getattr(engine_core, "engine_core", engine_core)
+        scheduler = getattr(ec, "scheduler", None)
+        if scheduler is not None and hasattr(scheduler, "kv_cache_config"):
+            kv_cfg = scheduler.kv_cache_config
+            if kv_cfg.kv_cache_tensors:
+                return _build_cache_info_from_kv_cfg(
+                    kv_cfg, tensor_parallel, pipeline_parallel, data_parallel_size
+                )
+
+        # Path 2: RPC (SyncMPClient - multiprocess, e.g. TP>1)
+        if hasattr(engine_core, "call_utility"):
+            try:
+                summary = engine_core.call_utility("get_kv_cache_config_summary")
+                if summary and summary.get("kv_cache_tensors"):
+                    return _build_cache_info_from_summary(
+                        summary, tensor_parallel, pipeline_parallel, data_parallel_size
+                    )
+            except (AttributeError, Exception):
+                pass
+
+        return None
+    except Exception:
+        return None
+
+
+def _build_cache_info_from_kv_cfg(
+    kv_cfg, tensor_parallel: int, pipeline_parallel: int, data_parallel_size: int
+) -> Dict:
+    """Build cache_info dict from KVCacheConfig object."""
+    total_gpus = tensor_parallel * pipeline_parallel * data_parallel_size
+    per_gpu_bytes = sum(t.size for t in kv_cfg.kv_cache_tensors)
+    total_bytes = per_gpu_bytes * total_gpus
+
+    layers = []
+    for idx, tensor in enumerate(kv_cfg.kv_cache_tensors):
+        layers.append({
+            "layer_idx": idx,
+            "shape": [tensor.size],
+            "dtype": "config",
+            "device": "N/A",
+            "num_elements": tensor.size,
+            "element_size_bytes": 1,
+            "memory_bytes": tensor.size,
+            "memory_mb": tensor.size / (1024 ** 2),
+            "shared_by": getattr(tensor, "shared_by", []),
+        })
+
+    return _finalize_cache_info(
+        layers, per_gpu_bytes, total_bytes, total_gpus,
+        tensor_parallel, pipeline_parallel, data_parallel_size,
+        getattr(kv_cfg, "num_blocks", None),
+    )
+
+
+def _build_cache_info_from_summary(
+    summary: Dict, tensor_parallel: int, pipeline_parallel: int, data_parallel_size: int
+) -> Optional[Dict]:
+    """Build cache_info dict from RPC summary (dict with num_blocks, kv_cache_tensors)."""
+    tensors = summary.get("kv_cache_tensors", [])
+    if not tensors:
+        return None
+
+    total_gpus = tensor_parallel * pipeline_parallel * data_parallel_size
+    per_gpu_bytes = sum(t["size"] for t in tensors)
+    total_bytes = per_gpu_bytes * total_gpus
+
+    layers = []
+    for idx, t in enumerate(tensors):
+        size = t["size"]
+        layers.append({
+            "layer_idx": idx,
+            "shape": [size],
+            "dtype": "config",
+            "device": "N/A",
+            "num_elements": size,
+            "element_size_bytes": 1,
+            "memory_bytes": size,
+            "memory_mb": size / (1024 ** 2),
+            "shared_by": t.get("shared_by", []),
+        })
+
+    return _finalize_cache_info(
+        layers, per_gpu_bytes, total_bytes, total_gpus,
+        tensor_parallel, pipeline_parallel, data_parallel_size,
+        summary.get("num_blocks"),
+    )
+
+
+def _finalize_cache_info(
+    layers, per_gpu_bytes, total_bytes, total_gpus,
+    tensor_parallel, pipeline_parallel, data_parallel_size, num_blocks
+) -> Dict:
+    """Finalize cache_info dict and print success message."""
+    cache_info = {
+        "layers": layers,
+        "total_memory_bytes": total_bytes,
+        "total_memory_bytes_per_gpu": per_gpu_bytes,
+        "engine_version": "V1",
+        "tensor_parallel": tensor_parallel,
+        "pipeline_parallel": pipeline_parallel,
+        "data_parallel_size": data_parallel_size,
+        "num_gpus": total_gpus,
+        "num_blocks": num_blocks,
+        "total_memory_mb_per_gpu": per_gpu_bytes / (1024 ** 2),
+        "total_memory_gb_per_gpu": per_gpu_bytes / (1024 ** 3),
+        "total_memory_mb": total_bytes / (1024 ** 2),
+        "total_memory_gb": total_bytes / (1024 ** 3),
+        "num_layers": len(layers),
+    }
+    if total_gpus > 1:
+        print(f"  ✓ Extracted from V1 config: {len(layers)} tensors, "
+              f"per GPU: {cache_info['total_memory_gb_per_gpu']:.4f} GB, "
+              f"total ({total_gpus} GPUs): {cache_info['total_memory_gb']:.4f} GB")
+    else:
+        print(f"  ✓ Extracted from V1 config: {len(layers)} tensors, "
+              f"{cache_info['total_memory_gb']:.4f} GB total")
+    return cache_info
+
+
+def extract_kv_cache_from_vllm(llm, tensor_parallel: int = 1, pipeline_parallel: int = 1,
+                               data_parallel_size: int = 1) -> Optional[Dict]:
+    """Extract KV cache tensors from vLLM's memory pools.
+
+    V0: llm.llm_engine -> model_executor -> workers -> cache_engine -> gpu_cache
+    V1: llm.llm_engine -> engine_core -> scheduler -> kv_cache_config (Option A)
+    Supports single-GPU, multi-GPU (TP/PP), and expert-parallel (EP) setups.
+    """
+
+    if LLM is None:
+        print("  ✗ vLLM not installed")
+        return None
+
+    try:
+        # V0 path: model_executor -> workers -> cache_engine -> gpu_cache
+        if not hasattr(llm.llm_engine, 'model_executor'):
+            return _extract_kv_cache_from_vllm_v1(
+                llm, tensor_parallel, pipeline_parallel, data_parallel_size
+            )
+
+        model_executor = llm.llm_engine.model_executor
+
+        workers = []
+        if hasattr(model_executor, 'driver_worker'):
+            workers = [model_executor.driver_worker]
+        elif hasattr(model_executor, 'workers') and len(model_executor.workers) > 0:
+            workers = model_executor.workers
+            ep_info = f", EP={data_parallel_size}" if data_parallel_size > 1 else ""
+            print(f"  • Found {len(workers)} workers (TP={tensor_parallel}, PP={pipeline_parallel}{ep_info})")
+        else:
+            return _extract_kv_cache_from_vllm_v1(
+                llm, tensor_parallel, pipeline_parallel, data_parallel_size
+            )
+
+        worker = workers[0]
+        if hasattr(worker, 'worker'):
+            worker = worker.worker
+
+        if not hasattr(worker, 'cache_engine'):
+            return _extract_kv_cache_from_vllm_v1(
+                llm, tensor_parallel, pipeline_parallel, data_parallel_size
+            )
+
+        cache_engine = worker.cache_engine
+        gpu_cache = None
+
+        if isinstance(cache_engine, list) and len(cache_engine) > 0:
+            first_elem = cache_engine[0]
+            if hasattr(first_elem, 'gpu_cache'):
+                gpu_cache = first_elem.gpu_cache
+            elif hasattr(first_elem, 'shape'):
+                gpu_cache = cache_engine
+        elif hasattr(cache_engine, 'gpu_cache'):
+            gpu_cache = cache_engine.gpu_cache
+
+        if not gpu_cache or len(gpu_cache) == 0:
+            return _extract_kv_cache_from_vllm_v1(
+                llm, tensor_parallel, pipeline_parallel, data_parallel_size
+            )
+
+        # V0: Extract from actual tensors
+        total_gpus = tensor_parallel * pipeline_parallel * data_parallel_size
+        cache_info = {
+            "layers": [],
+            "total_memory_bytes": 0,
+            "total_memory_bytes_per_gpu": 0,
+            "engine_version": "V0",
+            "tensor_parallel": tensor_parallel,
+            "pipeline_parallel": pipeline_parallel,
+            "data_parallel_size": data_parallel_size,
+            "num_gpus": total_gpus,
+        }
+
+        for layer_idx, cache_tensor in enumerate(gpu_cache):
+            if cache_tensor is not None:
+                num_elements = cache_tensor.numel()
+                element_size = cache_tensor.element_size()
+                memory_bytes = num_elements * element_size
+
+                layer_info = {
+                    "layer_idx": layer_idx,
+                    "shape": list(cache_tensor.shape),
+                    "dtype": str(cache_tensor.dtype),
+                    "device": str(cache_tensor.device),
+                    "num_elements": num_elements,
+                    "element_size_bytes": element_size,
+                    "memory_bytes": memory_bytes,
+                    "memory_mb": memory_bytes / (1024 ** 2),
+                }
+
+                cache_info["layers"].append(layer_info)
+                cache_info["total_memory_bytes"] += memory_bytes
+
+        cache_info["total_memory_bytes_per_gpu"] = cache_info["total_memory_bytes"]
+        cache_info["total_memory_mb_per_gpu"] = cache_info["total_memory_bytes_per_gpu"] / (1024 ** 2)
+        cache_info["total_memory_gb_per_gpu"] = cache_info["total_memory_bytes_per_gpu"] / (1024 ** 3)
+        cache_info["total_memory_bytes"] = cache_info["total_memory_bytes_per_gpu"] * total_gpus
+        cache_info["total_memory_mb"] = cache_info["total_memory_bytes"] / (1024 ** 2)
+        cache_info["total_memory_gb"] = cache_info["total_memory_bytes"] / (1024 ** 3)
+        cache_info["num_layers"] = len(cache_info["layers"])
+
+        if total_gpus > 1:
+            print(f"  ✓ Extracted {cache_info['num_layers']} layers (V0)")
+            print(f"    Per GPU: {cache_info['total_memory_gb_per_gpu']:.4f} GB")
+            print(f"    Total ({total_gpus} GPUs): {cache_info['total_memory_gb']:.4f} GB")
+        else:
+            print(f"  ✓ Extracted {cache_info['num_layers']} layers, {cache_info['total_memory_gb']:.4f} GB total (V0)")
+
+        return cache_info
+
+    except Exception as e:
+        v1_result = _extract_kv_cache_from_vllm_v1(
+            llm, tensor_parallel, pipeline_parallel, data_parallel_size
+        )
+        if v1_result is not None:
+            return v1_result
+        print(f"  ✗ Extraction error: {e}")
+        return None
+
+
+def print_cache_summary(model_name: str, cache_info: Dict, sequence_length: int):
+    """Print detailed layer-wise KV cache information."""
+
+    num_gpus = cache_info.get('num_gpus', 1)
+    tp = cache_info.get('tensor_parallel', 1)
+    pp = cache_info.get('pipeline_parallel', 1)
+
+    print("\n" + "=" * 80)
+    print(f"MODEL: {model_name}")
+    print(f"SEQUENCE LENGTH: {sequence_length} tokens")
+    if num_gpus > 1:
+        print(f"PARALLELISM: {num_gpus} GPUs (TP={tp}, PP={pp})")
+    print(f"ENGINE: {cache_info.get('engine_version', 'Unknown')}")
+    print("=" * 80)
+
+    if "note" in cache_info:
+        print(f"\n{cache_info['note']}")
+        return
+
+    if not cache_info or "layers" not in cache_info:
+        print("\n✗ Could not retrieve detailed KV cache information")
+        return
+
+    print(f"\nTotal Layers: {cache_info['num_layers']}")
+
+    print("\n" + "-" * 80)
+    print(f"{'Layer':<8} {'Shape':<30} {'Memory (MB)':<15} {'dtype':<15}")
+    print("-" * 80)
+
+    for layer in cache_info["layers"]:
+        shape_str = "×".join(map(str, layer["shape"]))
+        print(f"{layer['layer_idx']:<8} {shape_str:<30} {layer['memory_mb']:>12.2f}   {layer['dtype']:<15}")
+
+    print("-" * 80)
+
+    if num_gpus > 1:
+        print(f"\n{'KV CACHE PER GPU':.<50} {cache_info['total_memory_mb_per_gpu']:>10.2f} MB")
+        print(f"{'':.<50} {cache_info['total_memory_gb_per_gpu']:>10.4f} GB")
+        print(f"\n{'TOTAL KV CACHE (all ' + str(num_gpus) + ' GPUs)':.<50} {cache_info['total_memory_mb']:>10.2f} MB")
+        print(f"{'':.<50} {cache_info['total_memory_gb']:>10.4f} GB")
+        print(f"{'':.<50} {cache_info['total_memory_bytes']:>10,} bytes")
+    else:
+        print(f"\n{'TOTAL KV CACHE MEMORY':.<50} {cache_info['total_memory_mb']:>10.2f} MB")
+        print(f"{'':.<50} {cache_info['total_memory_gb']:>10.4f} GB")
+        print(f"{'':.<50} {cache_info['total_memory_bytes']:>10,} bytes")
+
+    if cache_info['num_layers'] > 0:
+        avg_per_layer = cache_info.get('total_memory_mb_per_gpu', cache_info['total_memory_mb']) / cache_info['num_layers']
+        print(f"\n{'Average per layer (per GPU)':.<50} {avg_per_layer:>10.2f} MB")
+
+    print("=" * 80 + "\n")
+
+
+def test_model(model_name: str, sequence_length: int, tensor_parallel: int = 1, pipeline_parallel: int = 1,
+               batch_size: int = 1, kv_cache_dtype: str = "auto", enable_expert_parallel: bool = False,
+               data_parallel_size: int = 1) -> Dict:
+    """Load a model in vLLM and inspect its KV cache allocation."""
+
+    if LLM is None or torch is None:
+        return {
+            "model": model_name,
+            "sequence_length": sequence_length,
+            "tensor_parallel": tensor_parallel,
+            "pipeline_parallel": pipeline_parallel,
+            "num_gpus": tensor_parallel * pipeline_parallel * data_parallel_size,
+            "success": False,
+            "error": "vLLM or torch not installed"
+        }
+
+    total_gpus = tensor_parallel * pipeline_parallel * data_parallel_size
+
+    print(f"\n{'#' * 80}")
+    print(f"MODEL: {model_name}")
+    print(f"SEQUENCE LENGTH: {sequence_length} tokens")
+    print(f"BATCH SIZE (concurrency): {batch_size}")
+    if total_gpus > 1:
+        ep_info = f", EP={data_parallel_size}" if enable_expert_parallel else ""
+        dp_info = f", DP={data_parallel_size}" if data_parallel_size > 1 and not enable_expert_parallel else ""
+        print(f"PARALLELISM: {total_gpus} GPUs (TP={tensor_parallel}, PP={pipeline_parallel}{ep_info}{dp_info})")
+    print(f"{'#' * 80}\n")
+
+    llm = None
+    try:
+        blocks_needed = (sequence_length // BLOCK_SIZE) * batch_size
+
+        print("Initializing vLLM...")
+        print(f"  • Allocating for {batch_size} concurrent request(s)")
+        print(f"  • Blocks: {blocks_needed} (seq_len={sequence_length} × batch={batch_size} ÷ block_size={BLOCK_SIZE})")
+        if total_gpus > 1:
+            print(f"  • Tensor Parallel: {tensor_parallel} GPUs")
+            print(f"  • Pipeline Parallel: {pipeline_parallel} GPUs")
+            if enable_expert_parallel:
+                print(f"  • Expert Parallel: enabled (data_parallel_size={data_parallel_size})")
+            elif data_parallel_size > 1:
+                print(f"  • Data Parallel: data_parallel_size={data_parallel_size}")
+        vllm_kv_dtype = _vllm_kv_cache_dtype(kv_cache_dtype)
+        if vllm_kv_dtype and vllm_kv_dtype != "auto":
+            print(f"  • KV cache dtype: {vllm_kv_dtype}")
+
+        llm_kwargs = {
+            "model": model_name,
+            "max_model_len": sequence_length,
+            "max_num_seqs": batch_size,
+            "num_gpu_blocks_override": blocks_needed,
+            "tensor_parallel_size": tensor_parallel,
+            "pipeline_parallel_size": pipeline_parallel,
+            "trust_remote_code": True,
+            "enforce_eager": True,
+            "disable_log_stats": True,
+            "kv_cache_dtype": vllm_kv_dtype,
+        }
+        if enable_expert_parallel:
+            llm_kwargs["enable_expert_parallel"] = True
+        if data_parallel_size > 1:
+            llm_kwargs["data_parallel_size"] = data_parallel_size
+
+        llm = LLM(**llm_kwargs)
+
+        print("✓ Model loaded successfully\n")
+
+        print("Running test inference...")
+        sampling_params = SamplingParams(temperature=0.8, max_tokens=50)
+        test_prompt = "This is a test prompt to allocate the KV cache."
+
+        outputs = llm.generate([test_prompt], sampling_params)
+        print("✓ Inference completed\n")
+
+        print("Extracting KV cache information...")
+        cache_info = extract_kv_cache_from_vllm(
+            llm, tensor_parallel, pipeline_parallel,
+            data_parallel_size=data_parallel_size,
+        )
+
+        if cache_info:
+            print_cache_summary(model_name, cache_info, sequence_length)
+
+            return {
+                "model": model_name,
+                "sequence_length": sequence_length,
+                "tensor_parallel": tensor_parallel,
+                "pipeline_parallel": pipeline_parallel,
+                "num_gpus": total_gpus,
+                "cache_info": cache_info,
+                "success": True,
+            }
+        else:
+            print("✗ Could not access KV cache information\n")
+            return {
+                "model": model_name,
+                "sequence_length": sequence_length,
+                "tensor_parallel": tensor_parallel,
+                "pipeline_parallel": pipeline_parallel,
+                "num_gpus": total_gpus,
+                "success": False,
+                "error": "Cache extraction failed"
+            }
+
+    except Exception as e:
+        error_msg = str(e)
+        print(f"✗ Error: {error_msg}\n")
+
+        if "out of memory" in error_msg.lower():
+            print("💡 Model too large for GPU. Try a smaller model or reduce sequence length.\n")
+        elif "torch._scaled_mm" in error_msg or "MI300+" in error_msg:
+            print("💡 This model requires MI300+ GPU for FP8. Use non-FP8 models.\n")
+        elif "triton_kernels" in error_msg:
+            print("💡 Missing triton_kernels for MXFP4. Avoid MXFP4 quantized models.\n")
+
+        return {
+            "model": model_name,
+            "sequence_length": sequence_length,
+            "tensor_parallel": tensor_parallel,
+            "pipeline_parallel": pipeline_parallel,
+            "num_gpus": total_gpus,
+            "success": False,
+            "error": error_msg,
+        }
+
+    finally:
+        if llm is not None:
+            del llm
+        gc.collect()
+        if torch is not None:
+            torch.cuda.empty_cache()
+
+
+# ============================================================================
+# ESTIMATOR WRAPPER (from kv_estimator.py)
+# ============================================================================
+
+def estimate_kv_cache(model_name: str, sequence_length: int,
+                     dtype: str = "float16", tp_size: int = 1,
+                     batch_size: int = 1) -> Tuple[int, Dict]:
+    """Estimate KV cache size with layer-by-layer details."""
+
+    print(f"\n{'=' * 80}")
+    print(f"KV Cache Estimation")
+    print(f"{'=' * 80}")
+    print(f"Model: {model_name}")
+    print(f"Sequence Length: {sequence_length}")
+    print(f"Data Type: {dtype}")
+    print(f"Tensor Parallel: {tp_size}")
+    print(f"Batch Size: {batch_size}")
+    print(f"{'=' * 80}\n")
+
+    try:
+        calculate_kv_cache(
+            model_name,
+            sequence_length,
+            dtype,
+            tp_size,
+            batch_size,
+            user_specified_dtype=(dtype != "float16")
+        )
+
+        config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
+        layer_config = _get_config_for_layers(config)
+        num_layers = _get_num_layers(config)
+        if num_layers is None:
+            raise AttributeError(f"{type(config).__name__} has no num_hidden_layers, n_layers, or num_layers")
+
+        dtype_bytes = {
+            "float32": 4, "float16": 2, "bfloat16": 2,
+            "int8": 1, "fp8": 1, "mxfp4": 0.5
+        }.get(dtype, 2)
+
+        hidden_size = getattr(layer_config, 'hidden_size', config.hidden_size)
+        num_attention_heads = getattr(layer_config, 'num_attention_heads', config.num_attention_heads)
+        num_kv_heads = getattr(layer_config, 'num_key_value_heads', num_attention_heads)
+        head_dim = hidden_size // num_attention_heads
+
+        layer_details = []
+        total_bytes = 0
+        per_gpu_total_bytes = 0
+
+        for layer_idx in range(num_layers):
+            layer_result = calculate_layer_kv_cache(
+                layer_config, layer_idx, sequence_length, dtype_bytes, tp_size, batch_size
+            )
+
+            layer_info = {
+                "layer": layer_idx,
+                "attention_type": layer_result['attention_type'],
+                "kv_cache_bytes": layer_result['bytes'],
+                "kv_cache_mb": layer_result['mb'],
+                "per_gpu_bytes": layer_result['per_gpu_bytes'],
+                "per_gpu_mb": layer_result['per_gpu_mb'],
+                "kv_dim": layer_result['kv_dim']
+            }
+
+            if layer_result['attention_type'] != 'MLA':
+                layer_info['num_kv_heads'] = layer_result['num_kv_heads']
+                layer_info['per_gpu_kv_heads'] = layer_result['per_gpu_kv_heads']
+                layer_info['effective_seq_len'] = layer_result['effective_seq_len']
+
+            layer_details.append(layer_info)
+            total_bytes += layer_result['bytes']
+            per_gpu_total_bytes += layer_result['per_gpu_bytes']
+
+        if tp_size > 1:
+            estimated_bytes = _ensure_int_bytes(per_gpu_total_bytes)
+        else:
+            estimated_bytes = _ensure_int_bytes(total_bytes)
+
+        results = {
+            "model": model_name,
+            "sequence_length": sequence_length,
+            "dtype": dtype,
+            "tp_size": tp_size,
+            "batch_size": batch_size,
+            "estimated_bytes": estimated_bytes,
+            "estimated_mb": estimated_bytes / (1024 ** 2),
+            "estimated_gb": estimated_bytes / (1024 ** 3),
+            "total_bytes_all_gpus": total_bytes,
+            "num_layers": num_layers,
+            "hidden_size": hidden_size,
+            "num_attention_heads": num_attention_heads,
+            "num_kv_heads": num_kv_heads,
+            "head_dim": head_dim,
+            "layer_by_layer": layer_details
+        }
+
+        print(f"\n✓ Estimation complete: {results['estimated_gb']:.4f} GB ({results['estimated_bytes']:,} bytes)")
+        print(f"✓ Layer-by-layer details: {len(layer_details)} layers captured")
+
+        return estimated_bytes, results
+
+    except Exception as e:
+        print(f"\n✗ Estimation failed: {e}")
+        raise
+
+
+def verify_with_vllm(model_name: str, sequence_length: int,
+                     dtype: str = "float16", tp_size: int = 1,
+                     batch_size: int = 1, quiet: bool = False,
+                     pp_size: int = 1, ep_size: int = 1,
+                     data_parallel_size: int = 1) -> Optional[Tuple[int, Dict]]:
+    """Verify KV cache size using vLLM runtime inspection."""
+
+    if not quiet:
+        print(f"\n{'=' * 80}")
+        print(f"vLLM Runtime Verification")
+        print(f"{'=' * 80}\n")
+
+    try:
+        enable_expert_parallel = ep_size > 1
+        dp_size = max(1, data_parallel_size)
+        vllm_dtype = _vllm_kv_cache_dtype(dtype)
+        result = test_model(
+            model_name, sequence_length, tp_size, pp_size,
+            batch_size=batch_size, kv_cache_dtype=vllm_dtype,
+            enable_expert_parallel=enable_expert_parallel,
+            data_parallel_size=dp_size,
+        )
+
+        if result.get('success', False):
+            cache_info = result['cache_info']
+            actual_bytes = cache_info.get('total_memory_bytes_per_gpu', cache_info.get('total_memory_bytes', 0))
+
+            vllm_layers = cache_info.get('layers', [])
+            layer_by_layer = []
+            for layer in vllm_layers:
+                layer_info = {
+                    "layer": layer.get('layer_idx', 0),
+                    "shape": layer.get('shape', []),
+                    "dtype": layer.get('dtype', 'unknown'),
+                    "element_size_bytes": layer.get('element_size_bytes'),
+                    "actual_bytes": layer.get('memory_bytes', 0),
+                    "actual_mb": layer.get('memory_mb', 0),
+                    "device": layer.get('device', 'unknown')
+                }
+                layer_by_layer.append(layer_info)
+
+            results = {
+                "model": model_name,
+                "sequence_length": sequence_length,
+                "dtype": dtype,
+                "tp_size": tp_size,
+                "batch_size": batch_size,
+                "pp_size": pp_size,
+                "ep_size": ep_size,
+                "actual_bytes": actual_bytes,
+                "actual_mb": actual_bytes / (1024 ** 2),
+                "actual_gb": actual_bytes / (1024 ** 3),
+                "num_layers": cache_info.get('num_layers', 0),
+                "layer_by_layer": layer_by_layer
+            }
+
+            if not quiet:
+                print(f"\n✓ Verification complete: {results['actual_gb']:.4f} GB ({results['actual_bytes']:,} bytes)")
+                print(f"✓ Layer-by-layer vLLM data: {len(layer_by_layer)} layers captured")
+
+            return actual_bytes, results
+        else:
+            err = result.get('error', 'Unknown error')
+            if not quiet:
+                print(f"\n✗ Verification failed: {err}")
+            return None, err
+
+    except Exception as e:
+        if not quiet:
+            print(f"\n✗ Verification failed: {e}")
+        return None, str(e)
+
+
+def calculate_test_sizes(base_size_bytes: int, multipliers: list = None) -> list:
+    """Calculate test sizes based on base size (max per-layer KV cache)."""
+    if multipliers is None:
+        multipliers = [0.0625, 0.125, 0.25, 0.5, 1, 2, 4]
+
+    test_sizes = []
+    for mult in multipliers:
+        size = int(base_size_bytes * mult)
+        size = max(size, 4096)
+        test_sizes.append(size)
+
+    return test_sizes
+
+
+def get_max_layer_kv_cache_size(layer_details: list) -> int:
+    """Get the maximum per-layer KV cache size from layer details."""
+    if not layer_details:
+        return 0
+    return max(layer['kv_cache_bytes'] for layer in layer_details)
+
+
+# ============================================================================
+# BATCH MEASUREMENT
+# ============================================================================
+
+BATCH_MEASUREMENT_CONCURRENCY = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
+BATCH_MEASUREMENT_SEQ_LENGTHS = [1024, 2048, 4096, 8192]
+BATCH_MEASUREMENT_TP_SIZES = [1, 8]
+BATCH_MEASUREMENT_PP_SIZES = [1]
+BATCH_MEASUREMENT_DTYPE = "fp8"
+
+DTYPE_BYTES_MAP = {"float32": 4, "float16": 2, "bfloat16": 2, "int8": 1, "fp8": 1, "mxfp4": 0.5}
+
+
+def _infer_kv_cache_dtype_from_config(config) -> Optional[str]:
+    """Infer KV cache dtype from model config (quantization_config, torch_dtype).
+    Returns None if nothing can be inferred.
+    """
+    # Check quantization_config first (FP8/MXFP4 models)
+    if hasattr(config, 'quantization_config') and config.quantization_config:
+        qc = config.quantization_config
+        if isinstance(qc, dict):
+            qm = (qc.get('quant_method') or '').lower()
+            if 'fp8' in qm:
+                return "fp8"
+            if 'mxfp4' in qm or 'fp4' in qm:
+                return "mxfp4"
+    # Fallback to torch_dtype (e.g. bfloat16, float16)
+    td = getattr(config, 'torch_dtype', None)
+    if td is not None:
+        s = str(td).lower()
+        if 'bfloat16' in s or 'bf16' in s:
+            return "bfloat16"
+        if 'float16' in s or 'fp16' in s:
+            return "float16"
+        if 'float32' in s or 'fp32' in s:
+            return "float32"
+    return None
+
+
+def _resolve_dtype_for_estimation(config, dtype: str) -> str:
+    """Resolve 'auto' to concrete dtype for theoretical estimation.
+    When dtype is 'auto', infers from model config: quantization_config first,
+    then torch_dtype. Defaults to bfloat16 if nothing can be inferred.
+    """
+    d = (dtype or "").strip().lower()
+    if d and d != "auto":
+        return d
+    inferred = _infer_kv_cache_dtype_from_config(config)
+    return inferred if inferred else "bfloat16"
+
+
+def _parse_config_value(val: Any) -> List[int]:
+    """Parse config value: int, list, or space/comma-separated string -> list of ints."""
+    if val is None:
+        return []
+    if isinstance(val, int):
+        return [val]
+    if isinstance(val, list):
+        return [int(x) for x in val]
+    s = str(val).strip()
+    if not s:
+        return []
+    # Support both space and comma separators
+    parts = s.replace(",", " ").split()
+    return [int(x) for x in parts if x]
+
+
+def load_estimator_config(config_path: str) -> Dict[str, Any]:
+    """Load estimator config from YAML. Returns dict with model, concurrency, seq_lengths, tp_sizes, pp_sizes, dtype."""
+    if yaml is None:
+        raise RuntimeError("PyYAML is required for --config. Install with: pip install pyyaml")
+    with open(config_path, "r") as f:
+        data = yaml.safe_load(f)
+    if not data:
+        raise ValueError(f"Empty or invalid config: {config_path}")
+
+    model = data.get("model") or {}
+
+    model_name = model.get("name")
+    if not model_name:
+        raise ValueError(f"Config must have model.name: {config_path}")
+
+    concurrency = _parse_config_value(model.get("concurrency"))
+    tp_sizes = _parse_config_value(model.get("tp"))
+    seq_lengths = _parse_config_value(model.get("seq-length"))
+    pp_sizes = _parse_config_value(model.get("pp"))
+    ep_sizes = _parse_config_value(model.get("ep"))
+    dp_sizes = _parse_config_value(model.get("dp"))
+    dtype = model.get("kv_cache_dtype") or model.get("dtype")
+    if isinstance(dtype, str):
+        dtype = dtype.strip().strip('"')
+    vllm_verify_kv_cache_dtype = model.get("vllm_verify_kv_cache_dtype")
+    if isinstance(vllm_verify_kv_cache_dtype, str):
+        vllm_verify_kv_cache_dtype = vllm_verify_kv_cache_dtype.strip().strip('"')
+
+    skip_vllm_verify = model.get("skip_vllm_verify", False)
+    if isinstance(skip_vllm_verify, str):
+        skip_vllm_verify = str(skip_vllm_verify).lower() in ("true", "1", "yes")
+
+    return {
+        "model": model_name,
+        "concurrency": concurrency or [1],
+        "seq_lengths": seq_lengths or [2048],
+        "tp_sizes": tp_sizes or [1],
+        "pp_sizes": pp_sizes or [1],
+        "ep_sizes": ep_sizes or [1],
+        "dp_sizes": dp_sizes or [1],
+        "dtype": dtype or "fp8",
+        "vllm_verify_kv_cache_dtype": vllm_verify_kv_cache_dtype,
+        "skip_vllm_verify": skip_vllm_verify,
+    }
+
+
+def _model_name_only(model_path: str) -> str:
+    """Extract model name from path (e.g. 'DeepSeek-R1' from '/path/to/deepseek-ai/DeepSeek-R1/')."""
+    name = model_path.rstrip("/")
+    parts = [p for p in name.split("/") if p]
+    return parts[-1] if parts else model_path
+
+
+def _measure_single_batch_config(config, seq_len, batch_size, tp_size, pp_size, dtype):
+    """Compute KV cache for a single batch config. Returns per-layer bytes (primary) and total bytes.
+
+    With PP>1, layers are split across stages; per_gpu_total_bytes is max over stages.
+    """
+    resolved = _resolve_dtype_for_estimation(config, dtype) if dtype == "auto" else (dtype or "fp8")
+    dtype_bytes = DTYPE_BYTES_MAP.get(resolved) or DTYPE_BYTES_MAP.get("fp8", 1)
+    layer_config = _get_config_for_layers(config)
+    num_layers = _get_num_layers(config)
+    if num_layers is None:
+        raise AttributeError(f"{type(config).__name__} has no num_hidden_layers, n_layers, or num_layers")
+
+    total_bytes = 0
+    max_per_layer_bytes = 0
+    if pp_size > 1:
+        layers_per_stage = (num_layers + pp_size - 1) // pp_size
+        per_stage_bytes = [0] * pp_size
+        for layer_idx in range(num_layers):
+            result = calculate_layer_kv_cache(
+                layer_config, layer_idx, seq_len, dtype_bytes, tp_size, batch_size
+            )
+            total_bytes += result["bytes"]
+            pp_stage = min(layer_idx // layers_per_stage, pp_size - 1)
+            per_stage_bytes[pp_stage] += result["per_gpu_bytes"]
+            layer_bytes = result["per_gpu_bytes"] if tp_size > 1 else result["bytes"]
+            max_per_layer_bytes = max(max_per_layer_bytes, layer_bytes)
+        per_gpu_total_bytes = max(per_stage_bytes)
+    else:
+        per_gpu_total_bytes = 0
+        for layer_idx in range(num_layers):
+            result = calculate_layer_kv_cache(
+                layer_config, layer_idx, seq_len, dtype_bytes, tp_size, batch_size
+            )
+            total_bytes += result["bytes"]
+            per_gpu_total_bytes += result["per_gpu_bytes"]
+            layer_bytes = result["per_gpu_bytes"] if tp_size > 1 else result["bytes"]
+            max_per_layer_bytes = max(max_per_layer_bytes, layer_bytes)
+
+    if tp_size > 1 or pp_size > 1:
+        return max_per_layer_bytes, per_gpu_total_bytes, total_bytes
+    return max_per_layer_bytes, total_bytes, total_bytes
+
+
+def run_batch_measurements(
+    model_name: str,
+    output_dir: str,
+    concurrency: Optional[list] = None,
+    seq_lengths: Optional[list] = None,
+    tp_sizes: Optional[list] = None,
+    pp_sizes: Optional[list] = None,
+    dtype: Optional[str] = None,
+) -> list:
+    """Run batch measurements for all config combinations. Generates test report by default.
+
+    Override iteration values via args; defaults to BATCH_MEASUREMENT_* constants when None.
+    """
+    concurrency = concurrency or BATCH_MEASUREMENT_CONCURRENCY
+    seq_lengths = seq_lengths or BATCH_MEASUREMENT_SEQ_LENGTHS
+    tp_sizes = tp_sizes or BATCH_MEASUREMENT_TP_SIZES
+    pp_sizes = pp_sizes or BATCH_MEASUREMENT_PP_SIZES
+    dtype = dtype or BATCH_MEASUREMENT_DTYPE
+
+    print(f"Loading model config: {model_name}")
+    config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
+
+    results = []
+    total_configs = len(concurrency) * len(seq_lengths) * len(tp_sizes) * len(pp_sizes)
+    count = 0
+
+    for seq_len in seq_lengths:
+        for batch_size in concurrency:
+            for tp_size in tp_sizes:
+                for pp_size in pp_sizes:
+                    count += 1
+                    try:
+                        per_layer_bytes, _, _ = _measure_single_batch_config(
+                            config, seq_len, batch_size, tp_size, pp_size, dtype
+                        )
+                        model_short = _model_name_only(model_name)
+                        model_unique_name = f"{model_short}_seq{seq_len}_c{batch_size}_tp{tp_size}_pp{pp_size}_{dtype}"
+                        entry = {
+                            "model_name": model_short,
+                            "model_unique_name": model_unique_name,
+                            "concurrency": batch_size,
+                            "seq_length": seq_len,
+                            "tp_size": tp_size,
+                            "pp_size": pp_size,
+                            "dtype": dtype,
+                            "kv_cache_mb": round(per_layer_bytes / (1024 ** 2), 2),
+                        }
+                        results.append(entry)
+                        print(
+                            f"[{count}/{total_configs}] seq={seq_len} c={batch_size} tp={tp_size} pp={pp_size} "
+                            f"dtype={dtype} -> {entry['kv_cache_mb']:.2f} MB per layer"
+                        )
+                    except Exception as e:
+                        print(
+                            f"[{count}/{total_configs}] ERROR seq={seq_len} c={batch_size} tp={tp_size} pp={pp_size}: {e}"
+                        )
+                        model_short = _model_name_only(model_name)
+                        model_unique_name = f"{model_short}_seq{seq_len}_c{batch_size}_tp{tp_size}_pp{pp_size}_{dtype}"
+                        results.append(
+                            {
+                                "model_name": model_short,
+                                "model_unique_name": model_unique_name,
+                                "concurrency": batch_size,
+                                "seq_length": seq_len,
+                                "tp_size": tp_size,
+                                "pp_size": pp_size,
+                                "dtype": dtype,
+                                "error": str(e),
+                            }
+                        )
+
+    output_dir = os.path.abspath(output_dir)
+    os.makedirs(output_dir, exist_ok=True)
+    print(f"\nOutput directory: {output_dir}")
+    _generate_batch_test_report(model_name, results, output_dir, concurrency, seq_lengths, tp_sizes, pp_sizes, dtype)
+
+    return results
+
+
+def _generate_batch_test_report(
+    model_name: str,
+    results: list,
+    output_dir: str,
+    concurrency: list,
+    seq_lengths: list,
+    tp_sizes: list,
+    pp_sizes: list,
+    dtype: str,
+) -> None:
+    """Generate test report (JSON + CSV) for batch measurements."""
+    valid_results = [r for r in results if "error" not in r]
+    failed_results = [r for r in results if "error" in r]
+
+    report = {
+        "report_metadata": {
+            "model": model_name,
+            "timestamp": datetime.datetime.now().isoformat(),
+            "total_configs": len(results),
+            "successful": len(valid_results),
+            "failed": len(failed_results),
+        },
+        "test_config": {
+            "concurrency": concurrency,
+            "seq_lengths": seq_lengths,
+            "tp_sizes": tp_sizes,
+            "pp_sizes": pp_sizes,
+            "dtype": dtype,
+        },
+        "results": results,
+        "summary": {
+            "min_kv_cache_mb": min(r["kv_cache_mb"] for r in valid_results) if valid_results else None,
+            "max_kv_cache_mb": max(r["kv_cache_mb"] for r in valid_results) if valid_results else None,
+        },
+    }
+    if failed_results:
+        report["failed_configs"] = failed_results
+
+    json_path = os.path.abspath(os.path.join(output_dir, "kv_cache_test_report.json"))
+    with open(json_path, "w") as f:
+        json.dump(report, f, indent=2)
+    print(f"\nTest report (JSON): {json_path}")
+
+    csv_path = os.path.abspath(os.path.join(output_dir, "kv_cache_test_report.csv"))
+    csv_fieldnames = [
+        "model_name", "model_unique_name", "concurrency", "seq_length", "tp_size", "pp_size", "ep_size", "dtype",
+        "kv_cache_mb",
+    ]
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=csv_fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for r in results:
+            writer.writerow({k: r.get(k, "") for k in csv_fieldnames})
+    print(f"Test report (CSV): {csv_path}")
+
+    if valid_results:
+        pivot_path = os.path.abspath(os.path.join(output_dir, "kv_cache_test_report_pivot.csv"))
+        seq_tp_pp_tuples = sorted(
+            {(r["seq_length"], r["tp_size"], r.get("pp_size", 1)) for r in valid_results},
+            key=lambda x: (x[0], x[1], x[2]),
+        )
+        with open(pivot_path, "w", newline="") as f:
+            writer = csv.writer(f)
+            header = ["seq_length", "tp_size", "pp_size"] + [f"concurrency_{b}_mb" for b in concurrency]
+            writer.writerow(header)
+            for seq_len, tp, pp in seq_tp_pp_tuples:
+                row = [seq_len, tp, pp]
+                for batch in concurrency:
+                    match = next(
+                        (
+                            r for r in valid_results
+                            if (r["seq_length"] == seq_len and r["tp_size"] == tp
+                                and r.get("pp_size", 1) == pp and r["concurrency"] == batch)
+                        ),
+                        None,
+                    )
+                    row.append(f"{match['kv_cache_mb']:.2f}" if match else "")
+                writer.writerow(row)
+        print(f"Test report (pivot CSV): {pivot_path}")
+
+    print(f"\nAll results saved to: {os.path.abspath(output_dir)}")
+
+
+# ============================================================================
+# MAIN / CLI
+# ============================================================================
+
+def main():
+    """Unified CLI entry point. Requires --config."""
+
+    parser = argparse.ArgumentParser(description='KV Cache Estimator (config-only)')
+    parser.add_argument(
+        '--config',
+        type=str,
+        required=True,
+        help='Path to YAML config file (model.name, model.concurrency, model.tp, model.seq-length, model.kv_cache_dtype, model.pp, model.ep, model.dp)',
+    )
+    parser.add_argument(
+        '--output-dir',
+        default='shared/kv_cache_batch_results',
+        help='Output dir for results (default: shared/kv_cache_batch_results)',
+    )
+    parser.add_argument('--verify-vllm', action='store_true', help='Enable vLLM verification (optional)')
+    parser.add_argument('--append', action='store_true', help='Append results to existing files (error if entries already exist)')
+    args = parser.parse_args()
+
+    _script_dir = os.path.dirname(os.path.abspath(__file__))
+    config_path = args.config
+    if not os.path.isabs(config_path):
+        config_path = os.path.join(_script_dir, config_path)
+    if not os.path.isfile(config_path):
+        print(f"Error: Config file not found: {config_path}")
+        sys.exit(1)
+
+    cfg = load_estimator_config(config_path)
+    model_name = cfg["model"]
+    concurrency = cfg["concurrency"]
+    seq_lengths = cfg["seq_lengths"]
+    tp_sizes = cfg["tp_sizes"]
+    pp_sizes = cfg["pp_sizes"]
+    ep_sizes = cfg["ep_sizes"]
+    dp_sizes = cfg["dp_sizes"]
+    dtype = cfg["dtype"]
+    config_kv_cache_dtype = dtype  # Original from config, for vLLM mapping
+    vllm_verify_override = cfg.get("vllm_verify_kv_cache_dtype")
+    skip_vllm_verify = cfg.get("skip_vllm_verify", False)
+    print(f"Loaded config from: {config_path}")
+
+    # Determine output directory
+    if os.path.exists("/workspace/results/phase1"):
+        results_dir = "/workspace/results/phase1"
+    elif os.path.exists("/workspace/results"):
+        results_dir = "/workspace/results"
+    else:
+        out = args.output_dir
+        results_dir = os.path.join(_script_dir, out) if not os.path.isabs(out) else out
+    results_dir = os.path.abspath(results_dir)
+
+    print("=" * 80)
+    print("KV Cache Estimation")
+    print("=" * 80)
+    print(f"Model: {model_name}")
+    print(f"Concurrency: {concurrency}")
+    print(f"Seq lengths: {seq_lengths}")
+    print(f"TP sizes: {tp_sizes}")
+    print(f"PP sizes: {pp_sizes}")
+    print(f"EP sizes: {ep_sizes}")
+    print(f"DP sizes (data_parallel_size): {dp_sizes}")
+    print(f"dtype: {dtype}")
+    if vllm_verify_override:
+        print(f"vLLM verify kv_cache_dtype override: {vllm_verify_override}")
+    print("=" * 80)
+
+    print(f"\nLoading model config: {model_name}")
+    config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
+
+    # Resolve "auto" to concrete dtype for estimation (from model quantization config)
+    # config_kv_cache_dtype stays as-is for vLLM (pass "auto" when config says auto)
+    estimation_dtype = _resolve_dtype_for_estimation(config, dtype or "fp8")
+    if (dtype or "").strip().lower() == "auto":
+        print(f"dtype: auto (resolved to {estimation_dtype} for estimation)")
+        dtype = estimation_dtype
+
+    vllm_kv_cache_dtype = _vllm_kv_cache_dtype(
+        vllm_verify_override or config_kv_cache_dtype or "fp8"
+    )
+
+    results = []
+    total_configs = len(seq_lengths) * len(concurrency) * len(tp_sizes) * len(pp_sizes) * len(ep_sizes) * len(dp_sizes)
+    count = 0
+
+    for seq_len in seq_lengths:
+        for batch_size in concurrency:
+            for tp_size in tp_sizes:
+                for pp_size in pp_sizes:
+                    for ep_size in ep_sizes:
+                        for dp_size in dp_sizes:
+                            count += 1
+                            try:
+                                per_layer_bytes, primary_total_bytes, _ = _measure_single_batch_config(
+                                    config, seq_len, batch_size, tp_size, pp_size, dtype
+                                )
+                                model_short = _model_name_only(model_name)
+                                ep_suffix = f"_ep{ep_size}" if ep_size > 1 else ""
+                                dp_suffix = f"_dp{dp_size}" if dp_size > 1 else ""
+                                model_unique_name = f"{model_short}_seq{seq_len}_c{batch_size}_tp{tp_size}_pp{pp_size}{ep_suffix}{dp_suffix}_{dtype}"
+                                entry = {
+                                    "model_name": model_short,
+                                    "model_unique_name": model_unique_name,
+                                    "seq_length": seq_len,
+                                    "concurrency": batch_size,
+                                    "tp_size": tp_size,
+                                    "pp_size": pp_size,
+                                    "ep_size": ep_size,
+                                    "data_parallel_size": dp_size,
+                                    "dtype": dtype,
+                                    "kv_cache_bytes": int(per_layer_bytes),
+                                    "_total_bytes": int(primary_total_bytes),  # for vLLM verification only
+                                }
+                                results.append(entry)
+                                ep_str = f" ep={ep_size}" if ep_size > 1 else ""
+                                dp_str = f" dp={dp_size}" if dp_size > 1 else ""
+                                print(
+                                    f"[{count}/{total_configs}] seq={seq_len} c={batch_size} tp={tp_size} pp={pp_size}{ep_str}{dp_str} "
+                                    f"dtype={dtype} -> {entry['kv_cache_bytes']:,} bytes"
+                                )
+                            except Exception as e:
+                                ep_str = f" ep={ep_size}" if ep_size > 1 else ""
+                                dp_str = f" dp={dp_size}" if dp_size > 1 else ""
+                                print(f"[{count}/{total_configs}] ERROR seq={seq_len} c={batch_size} tp={tp_size} pp={pp_size}{ep_str}{dp_str}: {e}")
+                                model_short = _model_name_only(model_name)
+                                ep_suffix = f"_ep{ep_size}" if ep_size > 1 else ""
+                                dp_suffix = f"_dp{dp_size}" if dp_size > 1 else ""
+                                model_unique_name = f"{model_short}_seq{seq_len}_c{batch_size}_tp{tp_size}_pp{pp_size}{ep_suffix}{dp_suffix}_{dtype}"
+                                results.append(
+                                    {
+                                        "model_name": model_short,
+                                        "model_unique_name": model_unique_name,
+                                        "seq_length": seq_len,
+                                        "concurrency": batch_size,
+                                        "tp_size": tp_size,
+                                        "pp_size": pp_size,
+                                        "ep_size": ep_size,
+                                        "data_parallel_size": dp_size,
+                                        "dtype": dtype,
+                                        "error": str(e),
+                                    }
+                                )
+
+    # vLLM verification (default: enabled) - batch verify multiple configs, print error if mismatch
+    vllm_verified_list = []
+    # Derive verify configs from benchmark run: representative subset of (seq_len, concurrency, tp_size, pp_size, ep_size, dp_size)
+    def _build_verify_configs(seq_lens, conc, tp, pp, ep, dp):
+        if not seq_lens or not conc or not tp or not pp or not ep or not dp:
+            return []
+        cfg = []
+        for s in seq_lens[:3]:  # up to 3 seq lengths with base concurrency/tp/pp/ep/dp
+            cfg.append((s, conc[0], tp[0], pp[0], ep[0], dp[0]))
+        if len(conc) > 1:
+            cfg.append((seq_lens[0], conc[1], tp[0], pp[0], ep[0], dp[0]))
+        if len(tp) > 1:
+            cfg.append((seq_lens[0], conc[0], tp[-1], pp[0], ep[0], dp[0]))
+        if len(pp) > 1:
+            cfg.append((seq_lens[0], conc[0], tp[0], pp[-1], ep[0], dp[0]))
+        if len(ep) > 1:
+            cfg.append((seq_lens[0], conc[0], tp[0], pp[0], ep[-1], dp[0]))
+        if len(dp) > 1:
+            cfg.append((seq_lens[0], conc[0], tp[0], pp[0], ep[0], dp[-1]))
+        return list(dict.fromkeys(cfg))  # dedupe
+
+    verify_configs = _build_verify_configs(seq_lengths, concurrency, tp_sizes, pp_sizes, ep_sizes, dp_sizes)
+    if args.verify_vllm and not skip_vllm_verify:
+        print(f"\n{'=' * 80}")
+        print("vLLM Verification (batch)")
+        print(f"{'=' * 80}")
+        if LLM is None or torch is None:
+            print("  SKIP: vLLM or PyTorch not installed. Install with: pip install vllm torch")
+        mismatches = []
+        for verify_seq, verify_batch, verify_tp, verify_pp, verify_ep, verify_dp in verify_configs:
+            if LLM is None or torch is None:
+                continue
+            if (verify_seq not in seq_lengths or verify_batch not in concurrency
+                    or verify_tp not in tp_sizes or verify_pp not in pp_sizes
+                    or verify_ep not in ep_sizes or verify_dp not in dp_sizes):
+                continue
+            # Multi-GPU verification supported (V0 engine exposes cache via workers)
+            match = next(
+                (r for r in results
+                 if (r.get("seq_length") == verify_seq and r.get("concurrency") == verify_batch
+                     and r.get("tp_size") == verify_tp and r.get("pp_size") == verify_pp
+                     and r.get("ep_size") == verify_ep and r.get("data_parallel_size") == verify_dp
+                     and "error" not in r)),
+                None,
+            )
+            if not match:
+                continue
+            verify_result = verify_with_vllm(
+                model_name, verify_seq, vllm_kv_cache_dtype, verify_tp, verify_batch, quiet=True,
+                pp_size=verify_pp, ep_size=verify_ep, data_parallel_size=verify_dp
+            )
+            actual_bytes, vllm_data = verify_result
+            if actual_bytes is None:
+                ep_str = f" ep={verify_ep}" if verify_ep > 1 else ""
+                dp_str = f" dp={verify_dp}" if verify_dp > 1 else ""
+                print(f"  SKIP seq={verify_seq} c={verify_batch} tp={verify_tp} pp={verify_pp}{ep_str}{dp_str}: {vllm_data}")
+                continue
+            vllm_results = vllm_data
+            est_bytes = match.get("_total_bytes", match.get("kv_cache_bytes", 0))  # use stored total for verification
+
+            # Infer actual vLLM dtype from layer info; scale est if dtype mismatch (e.g. vLLM bfloat16 vs config fp8)
+            config_dtype_bytes = {"float32": 4, "float16": 2, "bfloat16": 2, "int8": 1, "fp8": 1, "mxfp4": 0.5}.get(
+                dtype or "fp8", 1
+            )
+            actual_dtype_bytes = config_dtype_bytes
+            vllm_layers = vllm_data.get("layer_by_layer", [])
+            for layer in (vllm_layers if isinstance(vllm_layers, list) else []):
+                es = layer.get("element_size_bytes")
+                if es is not None and es > 0:
+                    actual_dtype_bytes = es
+                    break
+                dt = str(layer.get("dtype", "")).lower()
+                if "bfloat16" in dt or "float16" in dt:
+                    actual_dtype_bytes = 2
+                    break
+                if "fp8" in dt or "uint8" in dt:
+                    actual_dtype_bytes = 1
+                    break
+
+            # Fallback: if ratio ~2.0, vLLM likely used bfloat16 when we estimated fp8
+            if actual_dtype_bytes == config_dtype_bytes and est_bytes > 0:
+                ratio = actual_bytes / est_bytes
+                if 1.95 <= ratio <= 2.05:
+                    actual_dtype_bytes = 2
+                    config_dtype_bytes = 1
+                elif 0.48 <= ratio <= 0.52:
+                    actual_dtype_bytes = 1
+                    config_dtype_bytes = 2
+
+            if actual_dtype_bytes != config_dtype_bytes and config_dtype_bytes > 0:
+                est_bytes_scaled = int(est_bytes * actual_dtype_bytes / config_dtype_bytes)
+            else:
+                est_bytes_scaled = est_bytes
+
+            vllm_mb = actual_bytes / (1024 ** 2)
+            est_total_mb = est_bytes_scaled / (1024 ** 2)
+            diff_pct = abs(est_bytes_scaled - actual_bytes) / est_bytes_scaled * 100 if est_bytes_scaled > 0 else 0
+            status = "OK" if diff_pct < 1.0 else "MISMATCH"
+            vllm_results["comparison"] = {
+                "estimated_mb": est_total_mb,
+                "vllm_actual_mb": vllm_mb,
+                "accuracy_percent": 100 - diff_pct,
+            }
+            vllm_verified_list.append(vllm_results)
+            ep_str = f" ep={verify_ep}" if verify_ep > 1 else ""
+            dp_str = f" dp={verify_dp}" if verify_dp > 1 else ""
+            print(f"  seq={verify_seq} c={verify_batch} tp={verify_tp} pp={verify_pp}{ep_str}{dp_str}: "
+                  f"theoretical={est_total_mb:.2f} MB (total), vLLM={vllm_mb:.2f} MB -> {status}")
+            if status == "MISMATCH":
+                mismatches.append(
+                    f"seq={verify_seq} c={verify_batch} tp={verify_tp} pp={verify_pp}{ep_str}{dp_str}: "
+                    f"theoretical={est_total_mb:.2f} MB vs vLLM={vllm_mb:.2f} MB (diff={diff_pct:.2f}%)"
+                )
+        if mismatches:
+            print(f"\n{'=' * 80}")
+            print("ERROR: vLLM verification MISMATCH(es):")
+            for m in mismatches:
+                print(f"  {m}")
+            print(f"{'=' * 80}\n")
+        elif vllm_verified_list:
+            print(f"\nVLLM Verification passed\n")
+            print(f"{'=' * 80}\n")
+    elif args.verify_vllm and skip_vllm_verify:
+        print(f"\n{'=' * 80}")
+        print("vLLM Verification: SKIPPED (skip_vllm_verify=true in config)")
+        print(f"{'=' * 80}\n")
+
+    # Save to CSV only (single source of truth)
+    os.makedirs(results_dir, exist_ok=True)
+    csv_file = os.path.join(results_dir, "kv_cache_estimator.csv")
+    csv_fieldnames = [
+        "model_name", "model_unique_name", "seq_length", "concurrency", "tp_size", "pp_size", "ep_size",
+        "data_parallel_size", "dtype", "kv_cache_bytes",
+    ]
+
+    # Append mode: load existing from CSV only, merge (error if overlap)
+    existing_unique_names = set()
+    existing_results_csv = []   # for shared CSV (all models)
+
+    if args.append:
+        print(f"Append mode: reading existing from {csv_file}")
+        if os.path.isfile(csv_file):
+            try:
+                with open(csv_file) as f:
+                    reader = csv.DictReader(f)
+                    for row in reader:
+                        uid = row.get("model_unique_name")
+                        if uid:
+                            existing_unique_names.add(uid)
+                            r = {k: row.get(k, "") for k in csv_fieldnames}
+                            # Backward compat: convert legacy kv_cache_mb to kv_cache_bytes
+                            if not r.get("kv_cache_bytes") and row.get("kv_cache_mb"):
+                                try:
+                                    r["kv_cache_bytes"] = int(float(row["kv_cache_mb"]) * (1024 ** 2))
+                                except (ValueError, TypeError):
+                                    pass
+                            existing_results_csv.append(r)
+            except (IOError, csv.Error):
+                pass
+        else:
+            print(f"  CSV not found at {csv_file}")
+        overlapping = [r.get("model_unique_name") for r in results if r.get("model_unique_name") in existing_unique_names]
+        if overlapping:
+            print(f"\nError: The following entries already exist in the output file. Remove --append or delete existing entries.")
+            for uid in overlapping[:10]:
+                print(f"  {uid}")
+            if len(overlapping) > 10:
+                print(f"  ... and {len(overlapping) - 10} more")
+            sys.exit(1)
+        merged_results_csv = existing_results_csv + results
+        print(f"\nAppending {len(results)} new entries ({len(existing_results_csv)} existing in CSV, {len(merged_results_csv)} total)")
+    else:
+        merged_results_csv = results
+
+    with open(csv_file, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=csv_fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for r in merged_results_csv:
+            writer.writerow({k: r.get(k, "") for k in csv_fieldnames})
+
+    print(f"\nCSV saved to: {csv_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kvcache_transfer_bench/scripts/merge_results.py
+++ b/scripts/kvcache_transfer_bench/scripts/merge_results.py
@@ -1,0 +1,618 @@
+#!/usr/bin/env python3
+"""
+Post-process benchmark results: merge results_rixl.json, results_mori.json,
+and results_mooncake.json from a shared directory into:
+  - results_merged.json  (combined, normalized list)
+  - results_merged.csv   (pivot: one row per transfer size, one column per backend)
+  - report.html          (self-contained HTML report with table + throughput chart)
+
+Use --kv-cache-estimator-file to load KV cache mapping from a CSV file.
+"""
+
+import argparse
+import csv
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+RESULT_FILES = [
+    "results_rixl.json",
+    "results_mori.json",
+    "results_mooncake.json",
+]
+
+BACKENDS = ["rixl", "mori", "mooncake"]
+
+BACKEND_COLORS = {
+    "rixl": "#4472C4",
+    "mori": "#ED7D31",
+    "mooncake": "#A5A5A5",
+}
+
+
+def _bytes_to_label(size_bytes: int) -> str:
+    """Convert byte count to human-readable label (e.g. 4096 -> '4KB')."""
+    if size_bytes >= 1 << 30:
+        val = size_bytes / (1 << 30)
+        return f"{val:g}GB"
+    if size_bytes >= 1 << 20:
+        val = size_bytes / (1 << 20)
+        return f"{val:g}MB"
+    if size_bytes >= 1 << 10:
+        val = size_bytes / (1 << 10)
+        return f"{val:g}KB"
+    return f"{size_bytes}B"
+
+
+def _normalize_result(entry: dict) -> dict | None:
+    """
+    Normalize a single result entry from any backend into a common format:
+    { backend, transfer_size, throughput_gbs, timestamp }
+
+    Mori uses flat keys: transfer_size, throughput
+    RIXL/Mooncake use nested: test_parameters.size_bytes, results.bandwidth_gbs_avg
+    """
+    backend = entry.get("backend", "").strip().lower()
+
+    if "transfer_size" in entry:
+        size = entry["transfer_size"]
+        throughput = entry.get("throughput", 0)
+        timestamp = entry.get("date-time", "")
+    elif "test_parameters" in entry:
+        size = entry["test_parameters"].get("size_bytes", 0)
+        res = entry.get("results") or {}
+        throughput = res.get("bandwidth_gbs_avg", res.get("bandwidth_gbs", res.get("throughput", 0)))
+        timestamp = entry.get("timestamp_utc", "")
+    else:
+        return None
+
+    if size is None or size == 0:
+        return None
+
+    return {
+        "backend": backend,
+        "transfer_size": int(size),
+        "throughput_gbs": round(float(throughput), 4) if throughput else 0,
+        "timestamp": timestamp,
+    }
+
+
+def merge_results(input_dir: Path, output_path: Path, verbose: bool = True, kv_cache_estimator_file: Path | None = None) -> dict:
+    input_dir = Path(input_dir)
+    output_path = Path(output_path)
+    merged = {"metadata": {}, "results": []}
+
+    for filename in RESULT_FILES:
+        path = input_dir / filename
+        if not path.exists():
+            if verbose:
+                print(f"Skipping (not found): {path}", file=sys.stderr)
+            continue
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"Warning: could not read {path}: {e}", file=sys.stderr)
+            continue
+
+        backend_name = filename.replace("results_", "").replace(".json", "")
+        meta = data.get("metadata", data.get("version_info", {}))
+        merged["metadata"][backend_name] = meta
+
+        raw_results = data.get("results", [])
+        normalized = [_normalize_result(r) for r in raw_results]
+        normalized = [r for r in normalized if r is not None]
+        merged["results"].extend(normalized)
+        if verbose:
+            print(f"Added {len(normalized)} result(s) from {filename} (backend={backend_name})")
+
+    merged["results"].sort(key=lambda r: (r.get("backend", ""), r.get("transfer_size", 0)))
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(merged, f, indent=2)
+    if verbose:
+        print(f"Merged JSON written to {output_path} ({len(merged['results'])} total results)")
+
+    # --- Pivot CSV ---
+    by_size: dict[int, dict] = {}
+    for r in merged["results"]:
+        size = r["transfer_size"]
+        backend = r["backend"]
+        if size not in by_size:
+            by_size[size] = {"transfer_size": size, "size_label": _bytes_to_label(size)}
+            for b in BACKENDS:
+                by_size[size][f"{b}_throughput"] = ""
+        if backend in BACKENDS:
+            by_size[size][f"{backend}_throughput"] = r["throughput_gbs"]
+
+    rows = sorted(by_size.values(), key=lambda x: x["transfer_size"])
+    csv_columns = ["transfer_size", "size_label"] + [f"{b}_throughput" for b in BACKENDS]
+    csv_path = output_path.with_suffix(".csv")
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=csv_columns)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({k: row.get(k, "") for k in csv_columns})
+    if verbose:
+        print(f"CSV written to {csv_path}")
+
+    # --- HTML Report ---
+    html_path = output_path.parent / "report.html"
+    kv_cache_rows = _load_kv_cache_estimator(kv_cache_estimator_file)
+    html = _generate_html_report(merged, rows, kv_cache_rows)
+    with open(html_path, "w") as f:
+        f.write(html)
+    if verbose:
+        print(f"HTML report written to {html_path}")
+
+    return merged
+
+
+def _load_kv_cache_estimator(kv_cache_file: Path | None) -> list[dict]:
+    """Load kv_cache_estimator.csv from the given path. Returns list of {model_name, model_unique_name, kv_cache_bytes, ...}."""
+    if kv_cache_file is None:
+        return []
+    path = Path(kv_cache_file)
+    if not path.exists():
+        return []
+    rows = []
+    try:
+        with open(path) as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                kv_bytes = row.get("kv_cache_bytes", "")
+                if kv_bytes:
+                    try:
+                        kv_bytes = int(kv_bytes)
+                    except ValueError:
+                        kv_bytes = 0
+                else:
+                    # Backward compat: convert legacy kv_cache_mb to bytes
+                    kv_mb = row.get("kv_cache_mb", "")
+                    try:
+                        kv_bytes = int(float(kv_mb) * (1024 ** 2)) if kv_mb else 0
+                    except (ValueError, TypeError):
+                        kv_bytes = 0
+                rows.append({
+                    "model_name": row.get("model_name", ""),
+                    "model_unique_name": row.get("model_unique_name", ""),
+                    "seq_length": row.get("seq_length", ""),
+                    "concurrency": row.get("concurrency", row.get("batch_size", "")),
+                    "tp_size": row.get("tp_size", ""),
+                    "dtype": row.get("dtype", ""),
+                    "kv_cache_bytes": kv_bytes,
+                })
+    except (OSError, csv.Error):
+        pass
+    return rows
+
+
+def _interpolate_throughput(size_bytes: float, benchmark_rows: list[dict], backend: str) -> float | None:
+    """
+    Find throughput for size_bytes. Exact match or linear interpolation between bracketing sizes.
+    Returns None if size is outside benchmark range (use nearest endpoint).
+    """
+    col = f"{backend}_throughput"
+    sizes = [r["transfer_size"] for r in benchmark_rows]
+    if not sizes:
+        return None
+    min_s, max_s = min(sizes), max(sizes)
+    if size_bytes <= min_s:
+        for r in benchmark_rows:
+            if r["transfer_size"] == min_s:
+                v = r.get(col, "")
+                return float(v) if v != "" else None
+        return None
+    if size_bytes >= max_s:
+        for r in benchmark_rows:
+            if r["transfer_size"] == max_s:
+                v = r.get(col, "")
+                return float(v) if v != "" else None
+        return None
+    # Find bracketing sizes
+    sorted_rows = sorted(benchmark_rows, key=lambda x: x["transfer_size"])
+    lo, hi = None, None
+    for r in sorted_rows:
+        if r["transfer_size"] <= size_bytes:
+            lo = r
+        if r["transfer_size"] >= size_bytes and hi is None:
+            hi = r
+            break
+    if lo is None or hi is None:
+        return None
+    t_lo = lo.get(col, "")
+    t_hi = hi.get(col, "")
+    if t_lo == "" or t_hi == "":
+        return float(t_lo) if t_lo != "" else (float(t_hi) if t_hi != "" else None)
+    t_lo, t_hi = float(t_lo), float(t_hi)
+    if lo["transfer_size"] == hi["transfer_size"]:
+        return t_lo
+    frac = (size_bytes - lo["transfer_size"]) / (hi["transfer_size"] - lo["transfer_size"])
+    return round(t_lo + (t_hi - t_lo) * frac, 4)
+
+
+def _generate_html_report(merged: dict, pivot_rows: list[dict], kv_cache_rows: list[dict]) -> str:
+    """Generate a self-contained HTML report with a data table and Plotly chart."""
+    now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    backends_present = []
+    for b in BACKENDS:
+        if any(row.get(f"{b}_throughput", "") != "" for row in pivot_rows):
+            backends_present.append(b)
+
+    # Plotly traces: benchmark lines
+    plotly_traces = []
+    for b in backends_present:
+        x_vals = [row["transfer_size"] for row in pivot_rows]
+        y_vals = []
+        for row in pivot_rows:
+            v = row.get(f"{b}_throughput", "")
+            y_vals.append(float(v) if v != "" and v is not None else None)
+        color = BACKEND_COLORS.get(b, "#333333")
+        plotly_traces.append({
+            "x": x_vals,
+            "y": y_vals,
+            "type": "scatter",
+            "mode": "lines+markers",
+            "name": b,
+            "line": {"color": color, "width": 2.5},
+            "marker": {"size": 6, "color": color},
+        })
+    plotly_traces_json = json.dumps(plotly_traces)
+    x_tickvals_json = json.dumps([r["transfer_size"] for r in pivot_rows])
+    x_ticktext_json = json.dumps([r["size_label"] for r in pivot_rows])
+
+    meta_rows = ""
+    for b in backends_present:
+        meta = merged.get("metadata", {}).get(b, {})
+        vi = meta.get("version_info", meta)
+        parts = [f"<strong>{k}:</strong> {v}" for k, v in vi.items()]
+        meta_rows += f'<tr><td class="backend-name" style="color:{BACKEND_COLORS.get(b, "#333")}">{b}</td><td>{" &nbsp;|&nbsp; ".join(parts) if parts else "N/A"}</td></tr>\n'
+
+    table_header = '<th class="size-col">Transfer Size</th>'
+    for b in backends_present:
+        table_header += f'<th style="color:{BACKEND_COLORS.get(b, "#333")}">{b} (GB/s)</th>'
+
+    table_rows = ""
+    for row in pivot_rows:
+        table_rows += f'<tr><td class="size-col">{row["size_label"]}</td>'
+        for b in backends_present:
+            v = row.get(f"{b}_throughput", "")
+            cell = f"{v:.4f}" if isinstance(v, (int, float)) and v != "" else "&mdash;"
+            table_rows += f"<td>{cell}</td>"
+        table_rows += "</tr>\n"
+
+    # KV cache dropdown and mapping: model names only, table shows all configs
+    kv_cache_options = ""
+    kv_cache_data_json = "[]"
+    if kv_cache_rows:
+        kv_cache_data_json = json.dumps(kv_cache_rows)
+        unique_models = sorted(set(r["model_name"] for r in kv_cache_rows if r.get("model_name")))
+        for name in unique_models:
+            kv_cache_options += f'<option value="{name}">{name}</option>\n'
+    else:
+        kv_cache_options = '<option value="">No kv_cache_estimator.csv found</option>'
+
+    benchmark_data_json = json.dumps([
+        {"transfer_size": r["transfer_size"], **{f"{b}_throughput": r.get(f"{b}_throughput", "") for b in backends_present}}
+        for r in pivot_rows
+    ])
+    backends_json = json.dumps(backends_present)
+    backend_colors_json = json.dumps(BACKEND_COLORS)
+
+    kv_th_cols = "".join(f'<th style="color:{BACKEND_COLORS.get(b, "#333")}">{b} (GB/s)</th>' for b in backends_present)
+    # Build filter options from kv_cache data
+    filter_model_opts = kv_cache_options
+    filter_tp_opts = '<option value="">All</option>'
+    filter_dtype_opts = '<option value="">All</option>'
+    filter_seq_opts = '<option value="">All</option>'
+    filter_batch_opts = '<option value="">All</option>'
+    if kv_cache_rows:
+        unique_tp = sorted(set(str(r.get("tp_size", "")) for r in kv_cache_rows if r.get("tp_size")))
+        unique_dtype = sorted(set(str(r.get("dtype", "")) for r in kv_cache_rows if r.get("dtype")))
+        unique_seq = sorted(set(str(r.get("seq_length", "")) for r in kv_cache_rows if r.get("seq_length")), key=lambda x: int(x) if x.isdigit() else 0)
+        unique_concurrency = sorted(set(str(r.get("concurrency", r.get("batch_size", ""))) for r in kv_cache_rows if r.get("concurrency") or r.get("batch_size")), key=lambda x: int(x) if x.isdigit() else 0)
+        for v in unique_tp:
+            filter_tp_opts += f'<option value="{v}">tp={v}</option>\n'
+        for v in unique_dtype:
+            filter_dtype_opts += f'<option value="{v}">{v}</option>\n'
+        for v in unique_seq:
+            filter_seq_opts += f'<option value="{v}">seq={v}</option>\n'
+        for v in unique_concurrency:
+            filter_batch_opts += f'<option value="{v}">concurrency={v}</option>\n'
+
+    kv_cache_card = ""
+    if kv_cache_rows:
+        kv_cache_card = f"""
+<div class="card">
+  <h2>KV Cache → Benchmark Mapping</h2>
+  <p class="kv-desc">Select a model and optionally filter by tp, dtype, seq, concurrency to see configs plotted on the chart.</p>
+  <div class="kv-controls kv-filters">
+    <span><label for="kvModelSelect">Model:</label><select id="kvModelSelect"><option value="">-- Select model --</option>{filter_model_opts}</select></span>
+    <span><label for="kvFilterTp">tp:</label><select id="kvFilterTp">{filter_tp_opts}</select></span>
+    <span><label for="kvFilterDtype">dtype:</label><select id="kvFilterDtype">{filter_dtype_opts}</select></span>
+    <span><label for="kvFilterSeq">seq:</label><select id="kvFilterSeq">{filter_seq_opts}</select></span>
+    <span><label for="kvFilterBatch">concurrency:</label><select id="kvFilterBatch">{filter_batch_opts}</select></span>
+  </div>
+  <div id="kvMappingTable" class="kv-mapping-table" style="display:none;">
+    <div class="table-scroll" style="max-height:360px;">
+      <table>
+        <thead><tr><th class="size-col">seq</th><th>concurrency</th><th>tp</th><th>dtype</th><th>KV Cache (MB) per layer</th>{kv_th_cols}</tr></thead>
+        <tbody id="kvMappingBody"></tbody>
+      </table>
+    </div>
+    <p id="kvInterpNote" class="kv-note">Lines: benchmark data from results_merged.csv. Scattered points: per-layer KV cache sizes from kv_cache_estimator.csv (y = interpolated throughput at that size).</p>
+  </div>
+</div>"""
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>KV-Transfer Performance Benchmark Report</title>
+<script src="https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.2/plotly.min.js"></script>
+<style>
+  :root {{
+    --bg: #ffffff; --fg: #1a1a2e; --card-bg: #f8f9fa; --border: #dee2e6;
+    --accent: #4472C4; --font: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  }}
+  * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+  body {{ font-family: var(--font); background: var(--bg); color: var(--fg); padding: 2rem; max-width: 1400px; margin: 0 auto; }}
+  h1 {{ font-size: 1.75rem; font-weight: 700; margin-bottom: .25rem; }}
+  .subtitle {{ color: #6c757d; font-size: .9rem; margin-bottom: 1.5rem; }}
+  .card {{ background: var(--card-bg); border: 1px solid var(--border); border-radius: 8px; padding: 1.5rem; margin-bottom: 1.5rem; }}
+  .card h2 {{ font-size: 1.15rem; font-weight: 600; margin-bottom: 1rem; border-bottom: 2px solid var(--accent); padding-bottom: .4rem; display: inline-block; }}
+  .chart-wrapper {{ position: relative; width: 100%; max-width: 1200px; margin: 0 auto; min-height: 520px; }}
+  table {{ width: 100%; border-collapse: collapse; font-size: .88rem; }}
+  thead th {{ background: #e9ecef; position: sticky; top: 0; }}
+  th, td {{ padding: .55rem .75rem; text-align: right; border-bottom: 1px solid var(--border); }}
+  .size-col {{ text-align: left; font-weight: 600; }}
+  tbody tr:hover {{ background: #f1f3f5; }}
+  .meta-table {{ font-size: .85rem; }}
+  .meta-table td {{ text-align: left; padding: .35rem .75rem; }}
+  .backend-name {{ font-weight: 700; text-transform: uppercase; letter-spacing: .5px; }}
+  .table-scroll {{ max-height: 520px; overflow-y: auto; border: 1px solid var(--border); border-radius: 6px; }}
+  .kv-desc {{ color: #6c757d; font-size: .9rem; margin-bottom: .75rem; }}
+  .kv-controls {{ margin-bottom: 1rem; }}
+  .kv-controls label {{ margin-right: .5rem; font-weight: 500; }}
+  .kv-controls select {{ padding: .4rem .75rem; font-size: .9rem; min-width: 180px; border-radius: 4px; border: 1px solid var(--border); }}
+  .kv-filters {{ display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; }}
+  .kv-mapping-table {{ margin-top: 1rem; }}
+  .kv-note {{ font-size: .85rem; color: #6c757d; margin-top: .5rem; }}
+  .chart-controls {{ display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; margin-bottom: 0.75rem; }}
+  .chart-controls label {{ display: flex; align-items: center; gap: 0.4rem; font-weight: 500; cursor: pointer; }}
+  .chart-controls input[type="checkbox"] {{ width: 1rem; height: 1rem; cursor: pointer; }}
+</style>
+</head>
+<body>
+
+<h1>KV-Transfer Performance Benchmark</h1>
+<p class="subtitle">Report generated {now_utc}</p>
+
+<div class="card">
+  <h2>Environment</h2>
+  <table class="meta-table">
+    {meta_rows}
+  </table>
+</div>
+
+{kv_cache_card}
+<div class="card">
+  <h2>Throughput Comparison</h2>
+  <p class="kv-desc">Scroll to zoom, drag to pan. Double-click to reset zoom.</p>
+  <div class="chart-controls">
+    <label for="showLabelsCheck"><input type="checkbox" id="showLabelsCheck" checked> Show labels on data points</label>
+  </div>
+  <div id="throughputChart" class="chart-wrapper"></div>
+</div>
+
+<div class="card">
+  <h2>Results Table</h2>
+  <div class="table-scroll">
+    <table>
+      <thead><tr>{table_header}</tr></thead>
+      <tbody>
+        {table_rows}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<script>
+const baseTraces = {plotly_traces_json};
+const layout = {{
+  title: {{ text: 'Throughput vs Transfer Size (GB/s)', font: {{ size: 16, weight: 600 }} }},
+  xaxis: {{ type: 'log', title: 'Transfer Size', tickvals: {x_tickvals_json}, ticktext: {x_ticktext_json}, tickfont: {{ size: 12 }} }},
+  yaxis: {{ title: 'Throughput (GB/s)', zeroline: true, tickfont: {{ size: 12 }} }},
+  legend: {{ orientation: 'h', y: 1.02, yanchor: 'bottom' }},
+  margin: {{ t: 60, b: 50, l: 60, r: 40 }},
+  hovermode: 'closest',
+  showlegend: true,
+  dragmode: 'pan'
+}};
+const config = {{ scrollZoom: true, responsive: true }};
+Plotly.newPlot('throughputChart', baseTraces, layout, config);
+window._baseTraces = baseTraces;
+window._layout = layout;
+window._config = config;
+</script>
+
+<script>
+(function() {{
+  const kvCacheData = {kv_cache_data_json};
+  const benchmarkData = {benchmark_data_json};
+  const backends = {backends_json};
+  const backendColors = {backend_colors_json};
+
+  function interpolateThroughput(sizeBytes, backend) {{
+    const col = backend + '_throughput';
+    const sizes = benchmarkData.map(r => r.transfer_size);
+    if (!sizes.length) return null;
+    const minS = Math.min(...sizes), maxS = Math.max(...sizes);
+    if (sizeBytes <= minS) {{
+      const r = benchmarkData.find(x => x.transfer_size === minS);
+      const v = r && r[col];
+      return (v !== '' && v !== undefined) ? parseFloat(v) : null;
+    }}
+    if (sizeBytes >= maxS) {{
+      const r = benchmarkData.find(x => x.transfer_size === maxS);
+      const v = r && r[col];
+      return (v !== '' && v !== undefined) ? parseFloat(v) : null;
+    }}
+    const sorted = [...benchmarkData].sort((a,b) => a.transfer_size - b.transfer_size);
+    let lo = null, hi = null;
+    for (const r of sorted) {{
+      if (r.transfer_size <= sizeBytes) lo = r;
+      if (r.transfer_size >= sizeBytes && !hi) {{ hi = r; break; }}
+    }}
+    if (!lo || !hi) return null;
+    const tLo = lo[col], tHi = hi[col];
+    if (tLo === '' || tLo === undefined) return (tHi !== '' && tHi !== undefined) ? parseFloat(tHi) : null;
+    if (tHi === '' || tHi === undefined) return parseFloat(tLo);
+    const tLoV = parseFloat(tLo), tHiV = parseFloat(tHi);
+    if (lo.transfer_size === hi.transfer_size) return tLoV;
+    const frac = (sizeBytes - lo.transfer_size) / (hi.transfer_size - lo.transfer_size);
+    return Math.round((tLoV + (tHiV - tLoV) * frac) * 10000) / 10000;
+  }}
+
+  function applyFilters() {{
+    const modelName = document.getElementById('kvModelSelect')?.value;
+    const filterTp = document.getElementById('kvFilterTp')?.value;
+    const filterDtype = document.getElementById('kvFilterDtype')?.value;
+    const filterSeq = document.getElementById('kvFilterSeq')?.value;
+    const filterBatch = document.getElementById('kvFilterBatch')?.value;
+    let configs = modelName ? kvCacheData.filter(c => c.model_name === modelName) : [];
+    if (filterTp) configs = configs.filter(c => String(c.tp_size) === filterTp);
+    if (filterDtype) configs = configs.filter(c => String(c.dtype) === filterDtype);
+    if (filterSeq) configs = configs.filter(c => String(c.seq_length) === filterSeq);
+    if (filterBatch) configs = configs.filter(c => String(c.concurrency || c.batch_size) === filterBatch);
+    return configs;
+  }}
+
+  function updateChartAndTable() {{
+    const tableDiv = document.getElementById('kvMappingTable');
+    const tbodyEl = document.getElementById('kvMappingBody');
+    const showLabels = document.getElementById('showLabelsCheck')?.checked ?? true;
+    const configs = applyFilters();
+    const baseTraces = JSON.parse(JSON.stringify(window._baseTraces || []));
+    let traces = baseTraces;
+
+    if (configs.length) {{
+      for (let i = 0; i < backends.length; i++) {{
+        const b = backends[i];
+        const color = backendColors[b] || '#333';
+        const xArr = [], yArr = [], textArr = [], hoverTextArr = [];
+        for (const cfg of configs) {{
+          const sizeBytes = cfg.kv_cache_bytes || (cfg.kv_cache_mb * 1024 * 1024);
+          const tp = interpolateThroughput(sizeBytes, b);
+          if (tp != null) {{
+            xArr.push(sizeBytes);
+            yArr.push(tp);
+            const modelLabel = 'tp_' + cfg.tp_size + '_seq_' + cfg.seq_length + '_c_' + (cfg.concurrency || cfg.batch_size);
+            const sizeStr = (sizeBytes >= 1024*1024*1024) ? (sizeBytes/1024/1024/1024).toFixed(1) + ' GB' : (sizeBytes/1024/1024).toFixed(1) + ' MB';
+            textArr.push('(' + modelLabel + ', ' + sizeStr + ')');
+            hoverTextArr.push(
+              'Model: ' + (cfg.model_unique_name || cfg.model_name || '—') + '<br>' +
+              'Size: ' + sizeStr + '<br>' +
+              'Throughput: ' + tp.toFixed(4) + ' GB/s (' + b + ')'
+            );
+          }}
+        }}
+        if (xArr.length) {{
+          const useText = showLabels && (i === 0);
+          traces.push({{
+            x: xArr, y: yArr, text: useText ? textArr : [],
+            hovertext: hoverTextArr, hoverinfo: 'text',
+            type: 'scatter', mode: useText ? 'markers+text' : 'markers',
+            name: b + ' (KV)', showlegend: false,
+            marker: {{ size: 8, color: color, symbol: 'diamond' }},
+            textposition: 'top center', textfont: {{ size: 13, color: color }}
+          }});
+        }}
+      }}
+    }}
+
+    Plotly.react('throughputChart', traces, window._layout, window._config);
+
+    let rows = '';
+    for (const cfg of configs) {{
+      const sizeBytes = cfg.kv_cache_bytes || (cfg.kv_cache_mb * 1024 * 1024);
+      const sizeStr = (sizeBytes >= 1024*1024*1024) ? (sizeBytes/1024/1024/1024).toFixed(1) + ' GB' : (sizeBytes/1024/1024).toFixed(1) + ' MB';
+      rows += `<tr><td class="size-col">${{cfg.seq_length}}</td><td>${{cfg.concurrency || cfg.batch_size}}</td><td>${{cfg.tp_size}}</td><td>${{cfg.dtype || '—'}}</td><td>${{sizeStr}}</td>`;
+      for (const b of backends) {{
+        const tp = interpolateThroughput(sizeBytes, b);
+        rows += `<td>${{tp != null ? tp.toFixed(4) : '—'}}</td>`;
+      }}
+      rows += '</tr>';
+    }}
+    if (tbodyEl) tbodyEl.innerHTML = rows;
+    if (tableDiv) tableDiv.style.display = configs.length ? 'block' : 'none';
+  }}
+
+  const select = document.getElementById('kvModelSelect');
+  const filterTp = document.getElementById('kvFilterTp');
+  const filterDtype = document.getElementById('kvFilterDtype');
+  const filterSeq = document.getElementById('kvFilterSeq');
+  const filterBatch = document.getElementById('kvFilterBatch');
+  const tableDiv = document.getElementById('kvMappingTable');
+  const tbodyEl = document.getElementById('kvMappingBody');
+
+  const showLabelsCheck = document.getElementById('showLabelsCheck');
+  if (kvCacheData.length) {{
+    [select, filterTp, filterDtype, filterSeq, filterBatch, showLabelsCheck].filter(Boolean).forEach(el => {{
+      el.addEventListener('change', updateChartAndTable);
+    }});
+    // Auto-select first model when only one exists, so chart shows KV points on load
+    const uniqueModels = [...new Set(kvCacheData.map(c => c.model_name))];
+    if (select && uniqueModels.length === 1) {{
+      select.value = uniqueModels[0];
+    }}
+    updateChartAndTable();
+  }}
+}})();
+</script>
+
+</body>
+</html>
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Merge backend benchmark results and generate CSV + HTML report."
+    )
+    parser.add_argument(
+        "--input-dir", "-i",
+        type=Path,
+        default=Path("logs/shared"),
+        help="Directory containing results_*.json files (default: logs/shared)",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        type=Path,
+        default=None,
+        help="Output merged JSON path (default: <input-dir>/results_merged.json)",
+    )
+    parser.add_argument(
+        "--quiet", "-q",
+        action="store_true",
+        help="Suppress progress messages",
+    )
+    parser.add_argument(
+        "--kv-cache-estimator-file",
+        type=Path,
+        default=None,
+        help="Path to KV cache estimator CSV. If not set, no KV cache mapping is loaded.",
+    )
+    args = parser.parse_args()
+    input_dir = args.input_dir
+    output_path = args.output or (input_dir / "results_merged.json")
+    merge_results(input_dir, output_path, verbose=not args.quiet, kv_cache_estimator_file=args.kv_cache_estimator_file)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/kvcache_transfer_bench/scripts/run_node.sh
+++ b/scripts/kvcache_transfer_bench/scripts/run_node.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+NODE1=""
+NODE2=""
+KV_CACHE_TEST_PATH="/workspace/kvcache_transfer_bench"
+SHARED_FOLDER=""
+BENCH_BACKENDS="all"
+START_SIZE="4096" # 4kb
+STOP_SIZE="1073741824" # 1GB
+IBDEVICES="mlx5_0"
+SYNC_PORT="9999"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --node1)
+            NODE1="$2"
+            shift 2
+            ;;
+        --node2)
+            NODE2="$2"
+            shift 2
+            ;;
+        --kv-cache-test-path)
+            KV_CACHE_TEST_PATH="$2"
+            shift 2
+            ;;
+        --shared-folder)
+            SHARED_FOLDER="$2"
+            shift 2
+            ;;
+        --backends)
+            BENCH_BACKENDS="$2"
+            shift 2
+            ;;
+        --start-size)
+            START_SIZE="$2"
+            shift 2
+            ;;
+        --stop-size)
+            STOP_SIZE="$2"
+            shift 2
+            ;;
+        --ibdevice)
+            IBDEVICES="$2"
+            shift 2
+            ;;
+        --sync-port)
+            SYNC_PORT="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+BENCH_BACKENDS=$(echo "$BENCH_BACKENDS" | tr ',' ' ')
+if [ "$BENCH_BACKENDS" = "all" ]; then
+    BENCH_BACKENDS="mooncake mori rixl"
+fi
+
+JOB_ID=${SLURM_JOB_ID:-${JOB_ID:-unknown}}
+SHARED_FOLDER_BASE="${SHARED_FOLDER:-${KV_CACHE_TEST_PATH}}"
+SHARED_FOLDER="${SHARED_FOLDER_BASE%/}/shared/results_${JOB_ID}"
+
+# UCX/GLOO env for RDMA/ROCm transfers (used by mori, rixl, mooncake)
+export GLOO_SOCKET_IFNAME=eth0
+export UCX_TLS=rc,sm,self,rocm_copy,rocm_ipc,tcp
+export UCX_NET_DEVICES="${IBDEVICES}:1"
+export UCX_SOCKADDR_TLS_PRIORITY=rdmacm,tcp
+export UCX_SOCKADDR_CM_ENABLE=y
+export UCX_MEMTYPE_CACHE=y
+export UCX_RDMA_CM_ENABLED=y
+export UCX_RNDV_SCHEME=get_zcopy
+export UCX_RNDV_THRESH=4k
+export UCX_ROCM_IPC_MIN_ZCOPY=0
+export HSA_ENABLE_SDMA=1
+export UCX_LOG_LEVEL=error
+export NIXL_LOG_LEVEL=WARN
+
+# Require essential args
+missing=
+[ -z "$NODE1" ]       && missing="${missing}--node1 "
+[ -z "$NODE2" ]       && missing="${missing}--node2 "
+
+if [ -n "$missing" ]; then
+    echo "ERROR: Required arguments not set: $missing" >&2
+    echo "Usage: $0 --node1 HOST --node2 HOST [--kv-cache-test-path PATH] [--shared-folder PATH] [--backends BACKENDS] [--start-size N] [--stop-size N] [--sync-port N] [--ibdevice DEV]" >&2
+    exit 1
+fi
+
+mkdir -p "$SHARED_FOLDER"
+
+# Resolve current hostname on the fly (hostname command works when $HOSTNAME is unset)
+CURRENT_HOST=$(hostname)
+echo "CURRENT_HOST: $CURRENT_HOST"
+
+for backend in $BENCH_BACKENDS; do
+    echo "=== Starting backend: $backend on $(hostname) (NODE1=$NODE1 CURRENT_HOST=$CURRENT_HOST) ==="
+    if [ "$NODE1" = "$CURRENT_HOST" ]; then
+        echo "  Role: TARGET (node matches NODE1)"
+        python3 $KV_CACHE_TEST_PATH/backends/$backend/target_bench.py \
+            --target_node "$NODE1" \
+            --initiator_node "$NODE2" \
+            --shared_folder "$SHARED_FOLDER" \
+            --start_size $START_SIZE \
+            --end_size $STOP_SIZE \
+            --sync-port "$SYNC_PORT" 2>&1
+    else
+        echo "  Role: INITIATOR (node does not match NODE1)"
+        python3 $KV_CACHE_TEST_PATH/backends/$backend/initiator_bench.py \
+            --target_node "$NODE1" \
+            --initiator_node "$NODE2" \
+            --shared_folder "$SHARED_FOLDER" \
+            --start_size $START_SIZE \
+            --end_size $STOP_SIZE \
+            --sync-port "$SYNC_PORT" 2>&1
+    fi
+    echo "=== Backend $backend finished with exit code $? ==="
+done
+
+# Merge results and generate report (run only on the initiator node)
+if [ "$NODE1" != "$CURRENT_HOST" ]; then
+    echo "=== Merging results and generating report ==="
+    python3 $KV_CACHE_TEST_PATH/scripts/merge_results.py \
+        --input-dir "$SHARED_FOLDER" \
+        --output "$SHARED_FOLDER/results_merged.json"
+    echo "=== Merge complete (exit code $?) ==="
+
+    # Copy SLURM output/error files into the shared results folder
+    if [ -n "${SLURM_SUBMIT_DIR:-}" ] && [ -n "${JOB_ID:-}" ] && [ "$JOB_ID" != "unknown" ]; then
+        for ext in out err; do
+            src="${SLURM_SUBMIT_DIR}/kv_cache_perf_bench_${JOB_ID}.${ext}"
+            if [ -f "$src" ]; then
+                cp "$src" "$SHARED_FOLDER/" && echo "Copied $(basename "$src") -> $SHARED_FOLDER/"
+            fi
+        done
+    fi
+fi
+

--- a/scripts/kvcache_transfer_bench/scripts/slurm_launcher.slrum
+++ b/scripts/kvcache_transfer_bench/scripts/slurm_launcher.slrum
@@ -1,0 +1,126 @@
+#!/bin/bash
+set +x
+
+#SBATCH --job-name=kv_cache_perf_bench
+#SBATCH -N 2
+#SBATCH -n 2
+#SBATCH --ntasks-per-node=1
+#SBATCH --time=08:00:00         # Time limit (HH:MM:SS); override with sbatch -t
+#SBATCH --output="kv_cache_perf_bench_%j.out"
+#SBATCH --error="kv_cache_perf_bench_%j.err"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --start-size)
+            START_SIZE="$2"
+            shift 2
+            ;;
+        --stop-size)
+            STOP_SIZE="$2"
+            shift 2
+            ;;
+        --backends)
+            BENCH_BACKENDS="$2"
+            shift 2
+            ;;
+        --docker-image)
+            DOCKER_IMAGE_ARG="$2"
+            shift 2
+            ;;
+        --ibdevice)
+            IBDEVICES="$2"
+            shift 2
+            ;;
+        --sync-port)
+            SYNC_PORT="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+# Script dir: directory containing this slurm_launcher.sbatch
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+START_SIZE=${START_SIZE:-4096} # 4KB
+STOP_SIZE=${STOP_SIZE:-1073741824} # 1GB
+BENCH_BACKENDS=${BENCH_BACKENDS:-all}
+DOCKER_IMAGE=${DOCKER_IMAGE_ARG:?DOCKER_IMAGE_ARG must be set and non-empty}
+IBDEVICES=${IBDEVICES:-mlx5_0}
+SYNC_PORT=${SYNC_PORT:-9999}
+KV_CACHE_TEST_PATH=/workspace/kvcache_transfer_bench
+
+PROJECT_DIR="${SLURM_SUBMIT_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+KV_CACHE_TEST_REPO="$(cd "$PROJECT_DIR" && pwd)/"
+DOCKER_CONTAINER_NAME=container_kv_transfer_perf_bench
+# Get node names from Slurm (recover from SLURM_JOB_ID if SLURM_NODELIST is empty)
+if [ -z "${SLURM_NODELIST:-}" ] && [ -n "${SLURM_JOB_ID:-}" ]; then
+    SLURM_NODELIST=$(scontrol show job "$SLURM_JOB_ID" 2>/dev/null | grep -oP '(?<!\w)NodeList=\K\S+' | grep -v '(null)' | head -1)
+    echo "INFO: Recovered SLURM_NODELIST='$SLURM_NODELIST' from SLURM_JOB_ID=$SLURM_JOB_ID"
+fi
+NODES=($(scontrol show hostname "${SLURM_NODELIST:-}" 2>/dev/null))
+if [ ${#NODES[@]} -eq 0 ]; then
+    echo "ERROR: Could not get nodes. SLURM_NODELIST='${SLURM_NODELIST:-}' SLURM_JOB_ID='${SLURM_JOB_ID:-}'"
+    exit 1
+fi
+NODE1=${NODES[0]}
+NODE2=${NODES[1]:-${NODES[0]}}
+
+if [ -z "$NODE1" ]; then
+    echo "ERROR: NODE1 is empty — NODES array: ${NODES[*]:-<empty>}"
+    exit 1
+fi
+echo "INFO: NODE1=$NODE1 NODE2=$NODE2 (${#NODES[@]} node(s))"
+echo "INFO: KV_CACHE_TEST_REPO=$KV_CACHE_TEST_REPO -> $KV_CACHE_TEST_PATH"
+
+# ---------------------------------------------------------------------------
+# Phase 1: Always pull latest image on all nodes. srun blocks until all nodes
+# complete, so both nodes have the image before any proceeds to docker run.
+# ---------------------------------------------------------------------------
+srun --cpu-bind=none /bin/bash -c '
+echo "Rank $SLURM_PROCID on $(hostname) (SLURM_NODEID=$SLURM_NODEID) — pull phase";
+docker stop '"$DOCKER_CONTAINER_NAME"' 2>/dev/null || true;
+docker rm '"$DOCKER_CONTAINER_NAME"' 2>/dev/null || true;
+sleep 2;
+echo "  [$(hostname)] Pulling '"$DOCKER_IMAGE"'...";
+docker pull '"$DOCKER_IMAGE"'
+echo "  [$(hostname)] Pull phase done"
+'
+
+# ---------------------------------------------------------------------------
+# Phase 2: Run benchmark. All nodes have the image; srun starts all together.
+# ---------------------------------------------------------------------------
+DRIVER_SCRIPT="$KV_CACHE_TEST_PATH/scripts/run_node.sh"
+srun --cpu-bind=none /bin/bash -c '
+LOCAL_HOSTNAME=$(hostname)
+LOCAL_IP=$(hostname -I | awk '"'"'{print $1}'"'"')
+
+docker run --rm \
+    --device /dev/dri \
+    --device /dev/kfd \
+    --device /dev/infiniband \
+    --network host \
+    --hostname "$LOCAL_HOSTNAME" \
+    --add-host "$LOCAL_HOSTNAME:$LOCAL_IP" \
+    --ipc host \
+    --group-add video \
+    --cap-add SYS_PTRACE \
+    --privileged=true \
+    --security-opt seccomp=unconfined \
+    --ulimit memlock=-1:-1 \
+    -v "$HOME:$HOME" \
+    -v /sys:/sys \
+    -v "$HOME/.ssh:/root/.ssh" \
+    -v '"$KV_CACHE_TEST_REPO"':'"$KV_CACHE_TEST_PATH"' \
+    --shm-size 64G \
+    -e SLURM_JOB_ID=$SLURM_JOB_ID \
+    -e SLURM_SUBMIT_DIR='"$SLURM_SUBMIT_DIR"' \
+    -e SLURM_JOB_NODELIST=$SLURM_JOB_NODELIST \
+    -e NODE_RANK=$SLURM_PROCID \
+    --name '"$DOCKER_CONTAINER_NAME"' \
+    '"$DOCKER_IMAGE"' /bin/bash -c "'"$DRIVER_SCRIPT"' --node1 '"${NODE1}"' --node2 '"${NODE2}"' --kv-cache-test-path '"$KV_CACHE_TEST_PATH"' --shared-folder '"$KV_CACHE_TEST_PATH"' --backends '"${BENCH_BACKENDS:-all}"' --start-size '"$START_SIZE"' --stop-size '"$STOP_SIZE"' --sync-port '"$SYNC_PORT"' --ibdevice '"$IBDEVICES"'"
+'
+
+srun --cpu-bind=none /bin/bash -c 'docker stop '"$DOCKER_CONTAINER_NAME"' 2>/dev/null || true; docker rm '"$DOCKER_CONTAINER_NAME"' 2>/dev/null || true'


### PR DESCRIPTION
Adds scripts/kvcache_transfer_bench, a two-node benchmark for measuring

**Description**
KV-cache-style GPU memory transfer throughput across RIXL, Mori, and
Mooncake, with Slurm and bare-metal.

**Features:**
- Per-backend initiator/target Python benches under backends/{rixl,mori,mooncake}/
- scripts/run_node.sh for role-based runs; scripts/slurm_launcher.slrum for sbatch / salloc
- scripts/merge_results.py to merge per-backend JSON into results_merged.{json,csv} and
  generate an interactive report.html (Plotly); optional KV-cache size overlay via estimator CSV
- README.md with Docker build, Slurm options and non-Slurm notes.

**Output Artifacts:**
- results_{rixl,mori,mooncake}.json, merged artifacts, and report.html (see README for full table).