### PR TITLE
pytorch-xdit:v26.4 release

### DIFF
--- a/benchmark/xdit/README.md
+++ b/benchmark/xdit/README.md
@@ -42,9 +42,9 @@ latencies can be found from `results.csv` once the benchmark runs have finished.
 | pyt_xdit_hunyuanvideo          | [HunyuanVideo](https://huggingface.co/tencent/HunyuanVideo)                           |
 | pyt_xdit_hunyuanvideo_1_5      | [HunyuanVideo 1.5](https://huggingface.co/tencent/HunyuanVideo-1.5)                   |
 | pyt_xdit_ltx_2                 | [LTX-2](https://huggingface.co/Lightricks/LTX-2)                                      |
-| pyt_xdit_qwen_image            | [Qwen-Image](https://huggingface.co/Qwen/Qwen-Image)                                  |
+| pyt_xdit_qwen_image            | [Qwen-Image](https://huggingface.co/Qwen/Qwen-Image-2512)                             |
 | pyt_xdit_qwen_image_edit       | [Qwen-Image-Edit](https://huggingface.co/Qwen/Qwen-Image-Edit)                        |
 | pyt_xdit_sd_3_5                | [Stable diffusion 3.5](https://huggingface.co/stabilityai/stable-diffusion-3.5-large) |
 | pyt_xdit_wan_2_1               | [Wan 2.1](https://huggingface.co/Wan-AI/Wan2.1-I2V-14B-720P)                          |
 | pyt_xdit_wan_2_2               | [Wan 2.2](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B)                              |
-| pyt_xdit_z_image_turbo         | [Z-Image Turbo](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo)                      |
+| pyt_xdit_z_image               | [Z-Image](https://huggingface.co/Tongyi-MAI/Z-Image)                                  |

--- a/docker/pyt_xdit.ubuntu.amd.Dockerfile
+++ b/docker/pyt_xdit.ubuntu.amd.Dockerfile
@@ -24,7 +24,7 @@
 # SOFTWARE.
 #
 #################################################################################
-ARG BASE_DOCKER=rocm/pytorch-xdit:v26.3
+ARG BASE_DOCKER=rocm/pytorch-xdit:v26.4
 FROM ${BASE_DOCKER} AS base
 
 RUN apt-get update && apt install -y lshw && rm -rf /var/lib/apt/lists/*

--- a/models.json
+++ b/models.json
@@ -2449,10 +2449,10 @@
     "multiple_results": "results.csv"
   },
   {
-    "name": "pyt_xdit_z_image_turbo",
+    "name": "pyt_xdit_z_image",
     "dockerfile": "docker/pyt_xdit",
     "scripts": "scripts/pyt_xdit/run.sh",
-    "n_gpus": "2",
+    "n_gpus": "8",
     "owner": "nsakkine@amd.com",
     "training_precision": "",
     "tags": [
@@ -2462,7 +2462,7 @@
         "pyt",
         "xdit"
     ],
-    "args": "--workload z_image_turbo",
+    "args": "--workload z_image",
     "multiple_results": "results.csv"
   }
 ]


### PR DESCRIPTION
Purpose is to add pytorch-xdit:v26.4 image to MAD workflows and to publish it.

Work here contains

    -Dockerfile wrapping rocm/pytorch-xdit:v26.4
    -a run script to execute selected diffusion model inference workloads
    -updated models.json
    -README instructions
