### PR TITLE
Added gfx950 to pyt_mochi_inference.ubuntu dockerfile to enable fa

### DIFF
--- a/docker/pyt_mochi_inference.ubuntu.amd.Dockerfile
+++ b/docker/pyt_mochi_inference.ubuntu.amd.Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p $WORKSPACE_DIR
 WORKDIR $WORKSPACE_DIR
 
 ARG FA_REPO="https://github.com/Dao-AILab/flash-attention.git"
-ARG PYTORCH_ROCM_ARCH=gfx90a;gfx942;gfx1100;gfx1101;gfx1200;gfx1201
+ARG PYTORCH_ROCM_ARCH=gfx950;gfx90a;gfx942;gfx1100;gfx1101;gfx1200;gfx1201
 RUN git clone ${FA_REPO}
 RUN cd flash-attention \
     && git submodule update --init \


### PR DESCRIPTION
## Motivation

PR to fix the pyt_mochi_video_inference enablment on Mi350/ Mi355.

## Technical Details

Updated gfx arch for Mi350 on mochi inference dockerfile 

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<img width="1009" height="88" alt="image" src="https://github.com/user-attachments/assets/b3c1243d-a794-4e1c-80a0-7ea9f6c157c4" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
