### PR TITLE
Fix/janus pro flash attention

### DIFF
--- a/docker/pyt_janus_pro_inference.ubuntu.amd.Dockerfile
+++ b/docker/pyt_janus_pro_inference.ubuntu.amd.Dockerfile
@@ -43,27 +43,42 @@ ENV HIP_ARCHITECTURES=${MAD_SYSTEM_GPU_ARCHITECTURE}
 RUN echo HIP_ARCHITECTURES = ${HIP_ARCHITECTURES}
 
 # Install flash attention
-ARG BUILD_FA="1"
-ARG FA_BRANCH="v3.0.0.r1-cktile"
-ARG FA_REPO="https://github.com/ROCm/flash-attention.git"
-RUN if [ "$BUILD_FA" = "1" ]; then \
-    cd ${APP_DIR} \
-    && pip uninstall -y flash-attention \
-    && rm -rf flash-attention \
-    && git clone ${FA_REPO} \
-    && cd flash-attention \
-    && git checkout ${FA_BRANCH} \
-    && git submodule update --init \
-    && GPU_ARCHS=${HIP_ARCHITECTURES} python3 setup.py bdist_wheel --dist-dir=dist \
-    && pip install dist/*.whl \
-    && python -c "import flash_attn; print(f'Flash Attention version == {flash_attn.__version__}')"; \
-    fi
+#ARG BUILD_FA="1"
+#ARG FA_BRANCH="v3.0.0.r1-cktile"
+#ARG FA_REPO="https://github.com/ROCm/flash-attention.git"
+#RUN if [ "$BUILD_FA" = "1" ]; then \
+#    cd ${APP_DIR} \
+#    && pip uninstall -y flash-attention \
+#    && rm -rf flash-attention \
+#    && git clone ${FA_REPO} \
+#    && cd flash-attention \
+#    && git checkout ${FA_BRANCH} \
+#    && git submodule update --init \
+#    && GPU_ARCHS=${HIP_ARCHITECTURES} python3 setup.py bdist_wheel --dist-dir=dist \
+#    && pip install dist/*.whl \
+#    && python -c "import flash_attn; print(f'Flash Attention version == {flash_attn.__version__}')"; \
+#    fi
 
-# Install Janus-pro
+# install flash attention
+ENV FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE"
+
+RUN git clone https://github.com/ROCm/flash-attention.git &&\
+    cd flash-attention &&\
+    python setup.py install
+
+# Install Janus-pro (patches for Hugging Face transformers 5.x):
+# - @dataclass rejects mutable default dict on PretrainedConfig subclasses; use default_factory
+# - PreTrainedModel.post_init() sets all_tied_weights_keys (required by from_pretrained / loading)
 RUN cd ${APP_DIR} \
   && git clone https://github.com/deepseek-ai/Janus.git \
   && cd Janus \
   && sed -i 's/^torch==/# torch==/' requirements.txt \
+  && for f in janus/models/modeling_vlm.py janus/janusflow/models/modeling_vlm.py; do \
+    sed -i '/^from transformers.configuration_utils import PretrainedConfig/a from dataclasses import field' "$f" \
+    && sed -i 's/params: AttrDict = {}/params: AttrDict = field(default_factory=dict)/g' "$f"; \
+  done \
+  && sed -i '/self\.language_model = LlamaForCausalLM(language_config)/a\        self.post_init()' janus/models/modeling_vlm.py \
+  && sed -i '/self\.vision_gen_dec_aligner = nn.Linear(2048, 768, bias=True)/a\        self.post_init()' janus/janusflow/models/modeling_vlm.py \
   && pip install -e . \
   && pip install datasets \
   && cd ..

--- a/docker/pyt_mochi_inference.ubuntu.amd.Dockerfile
+++ b/docker/pyt_mochi_inference.ubuntu.amd.Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p $WORKSPACE_DIR
 WORKDIR $WORKSPACE_DIR
 
 ARG FA_REPO="https://github.com/Dao-AILab/flash-attention.git"
-ARG PYTORCH_ROCM_ARCH=gfx90a;gfx942;gfx1100;gfx1101;gfx1200;gfx1201
+ARG PYTORCH_ROCM_ARCH=gfx950;gfx90a;gfx942;gfx1100;gfx1101;gfx1200;gfx1201
 RUN git clone ${FA_REPO}
 RUN cd flash-attention \
     && git submodule update --init \


### PR DESCRIPTION
## Motivation

Fixed FA compilation steps , as the steps are taken from https://github.com/dao-ailab/flash-attention ROCM support repo and fixed AttributeError: 'MultiModalityCausalLM' object has no attribute 'all_tied_weights_keys'. Did you mean: '_tied_weights_keys'?

## Technical Details

Janus + Transformers 5.x — PretrainedConfig / dataclasses
Change: After clone, for both
janus/models/modeling_vlm.py and janus/janusflow/models/modeling_vlm.py:
add from dataclasses import field after the PretrainedConfig import;
replace params: AttrDict = {} with params: AttrDict = field(default_factory=dict).
Why: Transformers 5.x turns those configs into dataclasses; a plain {} is an illegal mutable default and caused:
ValueError: mutable default … for field params … use default_factory.
3. Janus + Transformers 5.x — from_pretrained / weight loading
Change: append self.post_init() at the end of MultiModalityCausalLM.__init__ in:
Main model: right after self.language_model = LlamaForCausalLM(language_config).
Janus-Flow model: right after self.vision_gen_dec_aligner = nn.Linear(2048, 768, bias=True).
Why: In Transformers 5.x, all_tied_weights_keys (and related setup) is applied in PreTrainedModel.post_init(). Janus never called it, which caused:
AttributeError: 'MultiModalityCausalLM' object has no attribute 'all_tied_weights_keys'.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<img width="1425" height="187" alt="image" src="https://github.com/user-attachments/assets/e77c0107-9b1e-4dc1-a120-5890c20ae657" />



## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
