### PR TITLE
[DistInf][SGLang] Enable WideEP/LargeEP for SGLang PD Disagg. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Below are blueprints of supported models along with their documentation.
 | [**PyTorch PEFT/FSDP fine-tuning**](scripts/pytorch_train/HF_PEFT_FSDP/README.md) | Finetuning a HF model with LoRA approach & FSDP strategy | Llama-2-70b-chat-hf |
 | [**Large EP microbenchmark**](scripts/large-ep-benchmark/README.md) | MoE Large Expert Paralellism with MoRI-EP & DeepEP communication microbenchmarks | no specific models |
 | [**vLLM disaggregated P/D inference**](scripts/vllm_dissag/README.MD) | Distributed Inference P/D disaggregation with vLLM (Default, MoRI EP, DeepEP) | DeepSeek-R1, DeepSeek-V3, DeepSeek-V3-5layer, amd-Llama-3.3-70B-Instruct-FP8-KV, Llama-3.1-405B-Instruct-FP8-KV, gpt-oss-120b |
-| [**SGLang disaggregated P/D inference**](scripts/sglang_disagg/README.MD) | Distributed Inference P/D disaggregation with SGLang | Qwen3-32B, Llama-3.1-8B-Instruct, Llama-3.3-70B-Instruct-FP8-KV, Llama-3.1-405B-Instruct-FP8-KV, DeepSeek-V3, Mixtral-8x7B-v0.1 |
+| [**SGLang disaggregated P/D inference**](scripts/sglang_disagg/README.MD) | Distributed Inference P/D disaggregation with SGLang | Qwen3-32B, Llama-3.1-8B-Instruct, Llama-3.3-70B-Instruct-FP8-KV, Llama-3.1-405B-Instruct-FP8-KV, DeepSeek-V3, Mixtral-8x7B-v0.1, DeepSeek-R1 |
+| [**SGLang disaggregated P/D inference with WideEP/LargeEP**](scripts/sglang_disagg/README.MD) | Distributed Inference P/D disaggregation with SGLang with WideEP/LargeEP | DeepSeek-V3, DeepSeek-R1 |
 | [**KVCache Transfer Bench**](scripts/kvcache_transfer_bench/README.md) | Inter-node Transfer Benchmark | no specific models |
 
 ## Table of Contents

--- a/docker/sglang_disagg_inference.ubuntu.amd.Dockerfile
+++ b/docker/sglang_disagg_inference.ubuntu.amd.Dockerfile
@@ -24,7 +24,7 @@
 # SOFTWARE.
 #
 #################################################################################
-ARG BASE_DOCKER=lmsysorg/sglang:v0.5.11-rocm720-mi30x
+ARG BASE_DOCKER=lmsysorg/sglang:v0.5.12.post1-rocm720-mi30x
 FROM $BASE_DOCKER
 
 RUN sed -i 's|http://|https://|g' /etc/apt/sources.list
@@ -35,6 +35,35 @@ ARG GPU_ARCH=gfx942
 WORKDIR /sgl-workspace
 
 RUN pip install --upgrade sglang-router
+
+WORKDIR /sgl-workspace/mori
+
+ARG MORI_COMMIT="158c7e8335a0b19b3f1f422ff134d7869252135e"
+# Set INSTALL_MORI=1 to build/install MoRI at MORI_COMMIT; any other value skips it.
+ARG INSTALL_MORI=1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    git ibverbs-utils libibverbs-dev \
+    openmpi-bin libopenmpi-dev \
+    libpci-dev libdw1 locales \
+    libgrpc-dev libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
+    cmake
+
+RUN if [ "${INSTALL_MORI}" = "1" ]; then \
+      echo "INSTALL_MORI=1: installing MoRI at ${MORI_COMMIT}" \
+      && git checkout main \
+      && git fetch origin \
+      && git pull origin main \
+      && git checkout ${MORI_COMMIT} \
+      && pip install -r requirements-build.txt \
+      && pip install -e . ; \
+    else \
+      echo "INSTALL_MORI=${INSTALL_MORI}: skipping MoRI installation"; \
+    fi
+
+
+WORKDIR /sgl-workspace
 
 # Display installed packages for verification
 RUN pip list

--- a/scripts/sglang_disagg/README.MD
+++ b/scripts/sglang_disagg/README.MD
@@ -22,10 +22,32 @@ This repository contains scripts and documentation to launch PD Disaggregation f
 
 ## Building the Docker image
 Access the Dockerfile located at `docker/sglang_disagg_inference.ubuntu.amd.Dockerfile`.
-It uses `lmsysorg/sglang:v0.5.11-rocm700-mi30x` as the base docker image.
+It uses `lmsysorg/sglang:v0.5.12.post1-rocm720-mi30x` as the base docker image.
 
 ```bash
 docker build  -t sglang_disagg_pd_image -f sglang_disagg_inference.ubuntu.amd.Dockerfile .
+```
+
+### Build arguments
+
+| Arg | Default | Description |
+|-----|---------|-------------|
+| `INSTALL_MORI` | `1` | When `1`, builds and installs MoRI at `MORI_COMMIT`. Set to any other value (e.g. `0`) to skip MoRI installation entirely. |
+| `MORI_COMMIT` | `158c7e8335a0b19b3f1f422ff134d7869252135e` | MoRI commit to check out and install when `INSTALL_MORI=1`. |
+| `BASE_DOCKER` | `lmsysorg/sglang:v0.5.12.post1-rocm720-mi30x` | Base SGLang ROCm image. |
+| `GPU_ARCH` | `gfx942` | Target AMD GPU architecture. |
+
+Examples:
+
+```bash
+# Default build: installs MoRI pinned at MORI_COMMIT
+docker build -t sglang_disagg_pd_image -f sglang_disagg_inference.ubuntu.amd.Dockerfile .
+
+# Skip MoRI (e.g. when using Mooncake KV transfer only)
+docker build --build-arg INSTALL_MORI=0 -t sglang_disagg_pd_image -f sglang_disagg_inference.ubuntu.amd.Dockerfile .
+
+# Pin a different MoRI commit
+docker build --build-arg MORI_COMMIT=<sha> -t sglang_disagg_pd_image -f sglang_disagg_inference.ubuntu.amd.Dockerfile .
 ```
 
 ## Scripts
@@ -49,11 +71,34 @@ export DOCKER_IMAGE_NAME=<DOCKER_IMAGE_NAME>
 export xP=1
 export yD=1
 export MODEL_NAME=Llama-3.1-8B-Instruct
-export RUN_MORI=1  # MoRI (default). Set RUN_MORI=0 for Mooncake/RIXLE (KV_TRANSFER_BACKEND=mooncake)
+export RUN_MORI=1  # MoRI (default). Set RUN_MORI=0 for Mooncake (KV_TRANSFER_BACKEND=mooncake)
 
 # num_nodes = xP + yD
 sbatch -N 2 -n 2 --nodelist=<node1,node2> run_xPyD_models.slurm
 ```
+
+## Current Support Status
+
+### KV Cache Transfer Backend
+
+The unified launcher (`sglang_disagg_mori_io_ep.sh`) selects the disaggregation KV-cache transfer backend (`--disaggregation-transfer-backend`) via `RUN_MORI`. The backend is intentionally kept out of `models.yaml` so model configs stay backend-agnostic, and it applies to all supported models.
+
+| `RUN_MORI` | `KV_TRANSFER_BACKEND` | Backend | Status |
+|------------|-----------------------|---------|--------|
+| `1` | `mori` | MoRI IO | Supported |
+| `0` | `mooncake` | Mooncake | Supported |
+
+### Parallelism Mode (`DP_MODE`)
+
+`PARALLEL_MODE` is derived strictly from `DP_MODE`, which selects the flag set from `models.yaml`.
+
+| `DP_MODE` | `PARALLEL_MODE` | Flags applied | Supported models |
+|-----------|-----------------|---------------|------------------|
+| `0` (default) | `tp` | `base_flags` + `tp_flags` + `prefill.tp` / `decode.tp` | All models |
+| `1` | `dp` | `base_flags` + `dp_flags` (`--moe-a2a-backend mori`, DP attention) + `prefill.dp` / `decode.dp` | DeepSeek-V3, DeepSeek-R1 only |
+
+- `DP_MODE=1` enables MoRI expert parallelism (EP) with DP attention and currently requires `RUN_MORI=1` (MoRI IO).
+- It is restricted by an allowlist (`MORI_DP_MODE1_ALLOWED_MODELS`) enforced in both `run_xPyD_models.slurm` and `sglang_disagg_mori_io_ep.sh`. Launching any other model with `DP_MODE=1` exits with an error — use `DP_MODE=0` (TP) for all non-DeepSeek models.
 
 ## Log Files
 

--- a/scripts/sglang_disagg/README.MD
+++ b/scripts/sglang_disagg/README.MD
@@ -88,7 +88,7 @@ The unified launcher (`sglang_disagg_mori_io_ep.sh`) selects the disaggregation 
 | `1` | `mori` | MoRI IO | Supported |
 | `0` | `mooncake` | Mooncake | Supported |
 
-### Parallelism Mode (`DP_MODE`)
+### WideEP/LargeEP Parallelism Mode (`DP_MODE`)
 
 `PARALLEL_MODE` is derived strictly from `DP_MODE`, which selects the flag set from `models.yaml`.
 

--- a/scripts/sglang_disagg/models.yaml
+++ b/scripts/sglang_disagg/models.yaml
@@ -8,7 +8,6 @@
 # Each model contains:
 # - base_flags: always applied (prefill + decode)
 # - tp_flags / dp_flags: mode-level flags applied to BOTH prefill and decode (omit if empty)
-# - prefill_dp_flags / decode_dp_flags: role-specific dp mode overrides (take precedence over dp_flags)
 # - prefill/decode.<tp|dp>: role + mode specific flags
 # - experimental_flags: optional extra CLI flags (omit if empty)
 
@@ -54,25 +53,22 @@ Mixtral-8x7B-Instruct-v0.1:
 DeepSeek-V3:
   base_flags: "--attention-backend aiter --watchdog-timeout 1000000 --mem-fraction-static 0.73"
   # --enable-dp-attention-local-control-broadcast on both roles: forces all DP ranks to
-  # step together so idle ranks enter the MoRI EP collective.
-  dp_flags: "--enable-dp-attention --enable-dp-lm-head --moe-dense-tp-size 1"
-  prefill_dp_flags: "--moe-a2a-backend mori --enable-dp-attention --enable-dp-lm-head --moe-dense-tp-size 1 --enable-dp-attention-local-control-broadcast"
-  decode_dp_flags: "--moe-a2a-backend mori --enable-dp-attention --enable-dp-lm-head --moe-dense-tp-size 1 --enable-dp-attention-local-control-broadcast"
+  # step together so idle ranks enter the MoRI EP collective. prefill/decode dp use the
+  # same mode-level flags, so they live in dp_flags (role-specific batch tuning is in prefill.dp/decode.dp).
+  dp_flags: "--moe-a2a-backend mori --enable-dp-attention --enable-dp-lm-head --moe-dense-tp-size 1 --enable-dp-attention-local-control-broadcast"
   prefill:
     tp: "--disable-cuda-graph"
     dp: "--max-running-requests 8192 --cuda-graph-bs $(seq 1 3) --mem-fraction-static 0.65"
   decode:
     tp: "--disable-radix-cache --cuda-graph-bs $(seq 1 512)"
-    dp: "--max-running-requests 8192 --cuda-graph-bs $(seq 1 8)"
+    dp: "--max-running-requests 8192 --cuda-graph-bs 1 2 4 8 16 24 32 48 64 96 128"
 
 DeepSeek-R1:
   base_flags: "--attention-backend aiter --watchdog-timeout 1000000 --mem-fraction-static 0.73"
-  dp_flags: "--enable-dp-attention --enable-dp-lm-head --moe-dense-tp-size 1"
-  prefill_dp_flags: "--moe-a2a-backend mori --enable-dp-attention --enable-dp-lm-head --moe-dense-tp-size 1 --enable-dp-attention-local-control-broadcast"
-  decode_dp_flags: "--moe-a2a-backend mori --enable-dp-attention --enable-dp-lm-head --moe-dense-tp-size 1 --enable-dp-attention-local-control-broadcast"
+  dp_flags: "--moe-a2a-backend mori --enable-dp-attention --enable-dp-lm-head --moe-dense-tp-size 1 --enable-dp-attention-local-control-broadcast"
   prefill:
     tp: "--disable-cuda-graph"
     dp: "--max-running-requests 8192 --cuda-graph-bs $(seq 1 3)"
   decode:
     tp: "--disable-radix-cache --cuda-graph-bs $(seq 1 512)"
-    dp: "--max-running-requests 8192 --cuda-graph-bs $(seq 1 8)"
+    dp: "--max-running-requests 8192 --cuda-graph-bs 1 2 4 8 16 24 32 48 64 96 128"

--- a/scripts/sglang_disagg/run_xPyD_models.slurm
+++ b/scripts/sglang_disagg/run_xPyD_models.slurm
@@ -80,7 +80,7 @@ model_allows_mori_ep() {
 
 # ---------------------------------------------------------------------------
 # Run file: always use sglang_disagg_mori_io_ep.sh (unified launcher).
-# RUN_MORI=0: sets KV_TRANSFER_BACKEND=mooncake (Mooncake/RIXLE IO).
+# RUN_MORI=0: sets KV_TRANSFER_BACKEND=mooncake (Mooncake).
 # RUN_MORI=1: uses mori IO (default).
 # ---------------------------------------------------------------------------
 RUN_FILE="sglang_disagg_mori_io_ep.sh"
@@ -89,7 +89,7 @@ if [[ "$_run_mori" == "1" ]]; then
     echo "RUN_MORI=1: using $RUN_FILE with MoRI IO for model '$MODEL_NAME'"
 else
     export KV_TRANSFER_BACKEND="mooncake"
-    echo "RUN_MORI=0: using $RUN_FILE with Mooncake/RIXLE IO (KV_TRANSFER_BACKEND=mooncake)"
+    echo "RUN_MORI=0: using $RUN_FILE with Mooncake (KV_TRANSFER_BACKEND=mooncake)"
 fi
 if [[ ! -f "$RUN_FILE" ]]; then
     echo "Error: '$RUN_FILE' not found in $(pwd)." >&2
@@ -140,11 +140,6 @@ validate_model_name() {
 }
 
 validate_model_name "${MODEL_NAME}"
-
-if [[ "${DP_MODE:-0}" == "1" ]] && (( xP > 1 || yD > 1 )); then
-    echo "Error: DP_MODE=1 requires xP=1 and yD=1 (1P1D). Got xP=${xP}, yD=${yD}." >&2
-    exit 1
-fi
 
 # ------------------------
 # Model path validation and selection across all nodes

--- a/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
+++ b/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # MoRI EP PD entrypoint (used when RUN_MORI=1 in run_xPyD_models.slurm).
 # Customize for MoRI expert-parallel + disaggregated launch; until then this
-# delegates to the standard Mooncake/RIXLE PD launcher.
+# delegates to the standard Mooncake PD launcher.
 
 _MORI_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_DIR="${_MORI_SCRIPT_DIR}"
@@ -206,7 +206,7 @@ export PREFILL_MODEL_CONFIG DECODE_MODEL_CONFIG MODEL_EXPERIMENTAL_FLAGS
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/mori_ep_env.sh"
 
-# KV transfer backend: default mori, switchable to mooncake (Mooncake/RIXLE).
+# KV transfer backend: default mori, switchable to mooncake (Mooncake).
 # Kept out of models.yaml so model config is backend-agnostic.
 _TRANSFER_BACKEND="${KV_TRANSFER_BACKEND:-mori}"
 PREFILL_MODEL_CONFIG+=" --disaggregation-transfer-backend ${_TRANSFER_BACKEND}"

--- a/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
+++ b/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
@@ -186,8 +186,7 @@ prefill_flags = prefill.get(mode, "") or ""
 
 exports = {
     "MODEL_BASE_FLAGS": cfg.get("base_flags", ""),
-    "MODEL_PREFILL_MODE_FLAGS": cfg.get(f"prefill_{mode}_flags", cfg.get(f"{mode}_flags", "")),
-    "MODEL_DECODE_MODE_FLAGS": cfg.get(f"decode_{mode}_flags", cfg.get(f"{mode}_flags", "")),
+    "MODEL_MODE_FLAGS": cfg.get(f"{mode}_flags", ""),
     "MODEL_PREFILL_FLAGS": prefill_flags,
     "MODEL_DECODE_FLAGS": decode.get(mode, ""),
     "MODEL_EXPERIMENTAL_FLAGS": cfg.get("experimental_flags", ""),
@@ -198,8 +197,8 @@ for key, value in exports.items():
 PY
 )"
 
-PREFILL_MODEL_CONFIG="${MODEL_BASE_FLAGS} ${MODEL_PREFILL_MODE_FLAGS} ${MODEL_PREFILL_FLAGS} ${MODEL_EXPERIMENTAL_FLAGS}"
-DECODE_MODEL_CONFIG="${MODEL_BASE_FLAGS} ${MODEL_DECODE_MODE_FLAGS} ${MODEL_DECODE_FLAGS} ${MODEL_EXPERIMENTAL_FLAGS}"
+PREFILL_MODEL_CONFIG="${MODEL_BASE_FLAGS} ${MODEL_MODE_FLAGS} ${MODEL_PREFILL_FLAGS} ${MODEL_EXPERIMENTAL_FLAGS}"
+DECODE_MODEL_CONFIG="${MODEL_BASE_FLAGS} ${MODEL_MODE_FLAGS} ${MODEL_DECODE_FLAGS} ${MODEL_EXPERIMENTAL_FLAGS}"
 echo "Using model-specific configuration for: $MODEL_NAME (mode=${PARALLEL_MODE})"
 
 export PREFILL_MODEL_CONFIG DECODE_MODEL_CONFIG MODEL_EXPERIMENTAL_FLAGS


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR updates the SGLang Disagg PD Disagg scripts to support WideEP mode (EP 16 & above). 
The following changes are made:
* Enable WideEP features - for DP mode > 1. 
* Docker pipeline support to enable/disable MORI Installation from the defautl containers. 
* Minor fixes in models.yaml 
* Clean up the comments about invalid RIXLE transfer backend. 
* README updates. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Validated on 1P1D, 1P2D, 2P1D, 2P2D with WideEP mode. Results offline. 


<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
