### PR TITLE
madengine new models cards supporting sglan_disagg, vllm_disagg  and large_ep_benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Below are blueprints of supported models along with their documentation.
 | [**PyTorch PEFT/FSDP fine-tuning**](scripts/pytorch_train/HF_PEFT_FSDP/README.md) | Finetuning a HF model with LoRA approach & FSDP strategy | Llama-2-70b-chat-hf |
 | [**Large EP microbenchmark**](scripts/large-ep-benchmark/README.md) | MoE Large Expert Paralellism with MoRI-EP & DeepEP communication microbenchmarks | no specific models |
 | [**vLLM disaggregated P/D inference**](scripts/vllm_dissag/README.MD) | Distributed Inference P/D disaggregation with vLLM (Default, MoRI EP, DeepEP) | DeepSeek-R1, DeepSeek-V3, DeepSeek-V3-5layer, amd-Llama-3.3-70B-Instruct-FP8-KV, Llama-3.1-405B-Instruct-FP8-KV, gpt-oss-120b |
-| [**SGLang disaggregated P/D inference**](scripts/sglang_disagg/README.MD) | Distributed Inference P/D disaggregation with SGLang | Qwen3-32B, Llama-3.1-8B-Instruct, Llama-3.3-70B-Instruct-FP8-KV, Llama-3.1-405B-Instruct-FP8-KV, DeepSeek-V3, Mixtral-8x7B-v0.1, DeepSeek-R1 |
+| [**SGLang disaggregated P/D inference**](scripts/sglang_disagg/README.MD) | Distributed Inference P/D disaggregation with SGLang (MoRI IO, Mooncake/RIXLE) | Llama-3.1-8B, Qwen3-32B, Llama-3.3-70B-FP8, Llama-3.1-405B-FP8, Mixtral-8x7B, DeepSeek-V3, DeepSeek-R1 |
 | [**SGLang disaggregated P/D inference with WideEP/LargeEP**](scripts/sglang_disagg/README.MD) | Distributed Inference P/D disaggregation with SGLang with WideEP/LargeEP | DeepSeek-V3, DeepSeek-R1 |
 | [**KVCache Transfer Bench**](scripts/kvcache_transfer_bench/README.md) | Inter-node Transfer Benchmark | no specific models |
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Below are blueprints of supported models along with their documentation.
 | [**PyTorch PEFT/FSDP fine-tuning**](scripts/pytorch_train/HF_PEFT_FSDP/README.md) | Finetuning a HF model with LoRA approach & FSDP strategy | Llama-2-70b-chat-hf |
 | [**Large EP microbenchmark**](scripts/large-ep-benchmark/README.md) | MoE Large Expert Paralellism with MoRI-EP & DeepEP communication microbenchmarks | no specific models |
 | [**vLLM disaggregated P/D inference**](scripts/vllm_dissag/README.MD) | Distributed Inference P/D disaggregation with vLLM (Default, MoRI EP, DeepEP) | DeepSeek-R1, DeepSeek-V3, DeepSeek-V3-5layer, amd-Llama-3.3-70B-Instruct-FP8-KV, Llama-3.1-405B-Instruct-FP8-KV, gpt-oss-120b |
-| [**SGLang disaggregated P/D inference**](scripts/sglang_disagg/README.MD) | Distributed Inference P/D disaggregation with SGLang (MoRI IO, Mooncake/RIXLE) | Llama-3.1-8B, Qwen3-32B, Llama-3.3-70B-FP8, Llama-3.1-405B-FP8, Mixtral-8x7B, DeepSeek-V3, DeepSeek-R1 |
+| [**SGLang disaggregated P/D inference**](scripts/sglang_disagg/README.MD) | Distributed Inference P/D disaggregation with SGLang (MoRI IO, Mooncake) | Llama-3.1-8B, Qwen3-32B, Llama-3.3-70B-FP8, Llama-3.1-405B-FP8, Mixtral-8x7B, DeepSeek-V3, DeepSeek-R1 |
 | [**SGLang disaggregated P/D inference with WideEP/LargeEP**](scripts/sglang_disagg/README.MD) | Distributed Inference P/D disaggregation with SGLang with WideEP/LargeEP | DeepSeek-V3, DeepSeek-R1 |
 | [**KVCache Transfer Bench**](scripts/kvcache_transfer_bench/README.md) | Inter-node Transfer Benchmark | no specific models |
 

--- a/docker/vllm_disagg_inference.ubuntu.amd.Dockerfile
+++ b/docker/vllm_disagg_inference.ubuntu.amd.Dockerfile
@@ -114,10 +114,14 @@ RUN pip install vllm-router
 WORKDIR /app
 
 # versions.txt is provided by the base image and contains MORI_REPO / MORI_BRANCH entries.
+# Override MORI_BRANCH at build time: docker build --build-arg MORI_BRANCH=158c7e83 ...
+ARG MORI_BRANCH="158c7e83"
 RUN pip install tqdm prettytable
 RUN git clone --recursive $(grep '^MORI_REPO:' /app/versions.txt | cut -d' ' -f2) && \
     cd mori && \
-    git checkout $(grep '^MORI_BRANCH:' /app/versions.txt | cut -d' ' -f2)
+    git checkout ${MORI_BRANCH:-$(grep '^MORI_BRANCH:' /app/versions.txt | cut -d' ' -f2)} && \
+    git submodule update --init --recursive && \
+    pip install .
 
 RUN git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-systems.git && cd rocm-systems && \
     git sparse-checkout set --cone projects/rocshmem && \
@@ -126,6 +130,7 @@ RUN git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-syst
 WORKDIR /app/rocm-systems/projects/rocshmem
 RUN echo "ROCSHMEM_REPO=\"https://github.com/ROCm/rocm-systems.git\"" >> /app/versions.txt
 RUN echo "ROCSHMEM_BRANCH=\"$(git log | head -1 | awk '{print $2}' | cut -c1-8)\"" >> /app/versions.txt
+RUN pip install pyyaml
 RUN mkdir -p /app/rocshmem-build
 WORKDIR /app/rocshmem-build
 RUN /app/rocm-systems/projects/rocshmem/scripts/build_configs/all_backends -DUSE_EXTERNAL_MPI=OFF -DGPU_TARGETS=$GFX_COMPILATION_ARCH

--- a/models.json
+++ b/models.json
@@ -2676,7 +2676,7 @@
       "mori_io",
       "inference"
     ],
-    "timeout": -1,
+    "timeout": 0,
     "distributed": {
       "launcher": "slurm_multi"
     },

--- a/models.json
+++ b/models.json
@@ -2659,5 +2659,1062 @@
     ],
     "args": "--workload z_image",
     "multiple_results": "results.csv"
+  },
+  {
+    "name": "pyt_sglang_disagg_mori_io_llama-3.1-8b",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mori_io",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "Llama-3.1-8B-Instruct",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "0",
+      "RUN_MORI": "1",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_sglang_disagg_mori_io_qwen3-32b",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mori_io",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "Qwen3-32B",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "0",
+      "RUN_MORI": "1",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_sglang_disagg_mori_io_llama-3.3-70b-fp8",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mori_io",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "amd-Llama-3.3-70B-Instruct-FP8-KV",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "0",
+      "RUN_MORI": "1",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_sglang_disagg_mori_io_llama-3.1-405b-fp8",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mori_io",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "Llama-3.1-405B-Instruct-FP8-KV",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "0",
+      "RUN_MORI": "1",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_sglang_disagg_mori_io_mixtral-8x7b",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mori_io",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "Mixtral-8x7B-Instruct-v0.1",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "0",
+      "RUN_MORI": "1",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_sglang_disagg_mori_io_deepseek-v3",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mori_io",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "DeepSeek-V3",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "0",
+      "RUN_MORI": "1",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_sglang_disagg_mori_io_deepseek-r1",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mori_io",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "DeepSeek-R1",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "0",
+      "RUN_MORI": "1",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_sglang_disagg_mori_dp_deepseek-v3",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mori_dp",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "DeepSeek-V3",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "1",
+      "RUN_MORI": "1",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_sglang_disagg_mori_dp_deepseek-r1",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mori_dp",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "DeepSeek-R1",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "1",
+      "RUN_MORI": "1",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_sglang_disagg_mooncake_llama-3.1-8b",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mooncake",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "Llama-3.1-8B-Instruct",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "0",
+      "RUN_MORI": "0",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_sglang_disagg_mooncake_qwen3-32b",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mooncake",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "Qwen3-32B",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "0",
+      "RUN_MORI": "0",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_sglang_disagg_mooncake_llama-3.3-70b-fp8",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mooncake",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "amd-Llama-3.3-70B-Instruct-FP8-KV",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "0",
+      "RUN_MORI": "0",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_sglang_disagg_mooncake_llama-3.1-405b-fp8",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mooncake",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "Llama-3.1-405B-Instruct-FP8-KV",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "0",
+      "RUN_MORI": "0",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_sglang_disagg_mooncake_mixtral-8x7b",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mooncake",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "Mixtral-8x7B-Instruct-v0.1",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "0",
+      "RUN_MORI": "0",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_sglang_disagg_mooncake_deepseek-v3",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mooncake",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "DeepSeek-V3",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "0",
+      "RUN_MORI": "0",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_sglang_disagg_mooncake_deepseek-r1",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+    "dockerfile": "docker/sglang_disagg_inference",
+    "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "sglang",
+      "sglang_disagg",
+      "mooncake",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "MODEL_NAME": "DeepSeek-R1",
+      "xP": "1",
+      "yD": "1",
+      "DP_MODE": "0",
+      "RUN_MORI": "0",
+      "USE_CX7_NICS": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_vllm_disagg_nixl_deepseek-v3",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+    "dockerfile": "docker/vllm_disagg_inference",
+    "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm",
+      "vllm_disagg",
+      "nixl",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "MODEL_NAME": "DeepSeek-V3",
+      "xP": "1",
+      "yD": "1",
+      "RUN_MORI": "0",
+      "RUN_DEEPEP": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_vllm_disagg_nixl_deepseek-r1",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+    "dockerfile": "docker/vllm_disagg_inference",
+    "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm",
+      "vllm_disagg",
+      "nixl",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "MODEL_NAME": "DeepSeek-R1",
+      "xP": "1",
+      "yD": "1",
+      "RUN_MORI": "0",
+      "RUN_DEEPEP": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_vllm_disagg_nixl_deepseek-v3-5layer",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+    "dockerfile": "docker/vllm_disagg_inference",
+    "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm",
+      "vllm_disagg",
+      "nixl",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "MODEL_NAME": "DeepSeek-V3-5layer",
+      "xP": "1",
+      "yD": "1",
+      "RUN_MORI": "0",
+      "RUN_DEEPEP": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_vllm_disagg_nixl_llama-3.1-405b-fp8",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+    "dockerfile": "docker/vllm_disagg_inference",
+    "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm",
+      "vllm_disagg",
+      "nixl",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "MODEL_NAME": "Llama-3.1-405B-Instruct-FP8-KV",
+      "xP": "1",
+      "yD": "1",
+      "RUN_MORI": "0",
+      "RUN_DEEPEP": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_vllm_disagg_nixl_llama-3.3-70b-fp8",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+    "dockerfile": "docker/vllm_disagg_inference",
+    "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm",
+      "vllm_disagg",
+      "nixl",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "MODEL_NAME": "amd-Llama-3.3-70B-Instruct-FP8-KV",
+      "xP": "1",
+      "yD": "1",
+      "RUN_MORI": "0",
+      "RUN_DEEPEP": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_vllm_disagg_nixl_gpt-oss-120b",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+    "dockerfile": "docker/vllm_disagg_inference",
+    "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm",
+      "vllm_disagg",
+      "nixl",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "MODEL_NAME": "gpt-oss-120b",
+      "xP": "1",
+      "yD": "1",
+      "RUN_MORI": "0",
+      "RUN_DEEPEP": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_vllm_disagg_mori_deepseek-v3",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+    "dockerfile": "docker/vllm_disagg_inference",
+    "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm",
+      "vllm_disagg",
+      "mori_ep",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "MODEL_NAME": "DeepSeek-V3",
+      "xP": "1",
+      "yD": "1",
+      "RUN_MORI": "1",
+      "RUN_DEEPEP": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_vllm_disagg_mori_deepseek-r1",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+    "dockerfile": "docker/vllm_disagg_inference",
+    "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm",
+      "vllm_disagg",
+      "mori_ep",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "MODEL_NAME": "DeepSeek-R1",
+      "xP": "1",
+      "yD": "1",
+      "RUN_MORI": "1",
+      "RUN_DEEPEP": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_vllm_disagg_mori_deepseek-v3-5layer",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+    "dockerfile": "docker/vllm_disagg_inference",
+    "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm",
+      "vllm_disagg",
+      "mori_ep",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "MODEL_NAME": "DeepSeek-V3-5layer",
+      "xP": "1",
+      "yD": "1",
+      "RUN_MORI": "1",
+      "RUN_DEEPEP": "0",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_vllm_disagg_deepep_deepseek-v3",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+    "dockerfile": "docker/vllm_disagg_inference",
+    "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm",
+      "vllm_disagg",
+      "deepep",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "MODEL_NAME": "DeepSeek-V3",
+      "xP": "1",
+      "yD": "1",
+      "RUN_MORI": "0",
+      "RUN_DEEPEP": "1",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_vllm_disagg_deepep_deepseek-r1",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+    "dockerfile": "docker/vllm_disagg_inference",
+    "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm",
+      "vllm_disagg",
+      "deepep",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "MODEL_NAME": "DeepSeek-R1",
+      "xP": "1",
+      "yD": "1",
+      "RUN_MORI": "0",
+      "RUN_DEEPEP": "1",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_vllm_disagg_deepep_deepseek-v3-5layer",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+    "dockerfile": "docker/vllm_disagg_inference",
+    "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
+    "data": "huggingface",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "vllm",
+      "vllm_disagg",
+      "deepep",
+      "inference"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "MODEL_NAME": "DeepSeek-V3-5layer",
+      "xP": "1",
+      "yD": "1",
+      "RUN_MORI": "0",
+      "RUN_DEEPEP": "1",
+      "BENCHMARK_COMBINATIONS": "1024/1024"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_large_ep_bench_1n",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+    "dockerfile": "docker/large_ep_benchmark",
+    "scripts": "scripts/large-ep-benchmark/run_benchmark.sbatch",
+    "data": "",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "large_ep",
+      "deepep",
+      "mori_ep",
+      "benchmark"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+      "IBDEVICES": "mlx5_0",
+      "SKIP_DEEPEP": "0"
+    },
+    "args": "-N 1 -n 1"
+  },
+  {
+    "name": "pyt_large_ep_bench_1n_mori_only",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+    "dockerfile": "docker/large_ep_benchmark",
+    "scripts": "scripts/large-ep-benchmark/run_benchmark.sbatch",
+    "data": "",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "large_ep",
+      "large_ep_scaling",
+      "mori_ep",
+      "benchmark"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+      "IBDEVICES": "mlx5_0",
+      "SKIP_DEEPEP": "1"
+    },
+    "args": "-N 1 -n 1"
+  },
+  {
+    "name": "pyt_large_ep_bench_2n",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+    "dockerfile": "docker/large_ep_benchmark",
+    "scripts": "scripts/large-ep-benchmark/run_benchmark.sbatch",
+    "data": "",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "large_ep",
+      "deepep",
+      "mori_ep",
+      "benchmark"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+      "IBDEVICES": "mlx5_0",
+      "SKIP_DEEPEP": "0"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_large_ep_bench_2n_mori_only",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+    "dockerfile": "docker/large_ep_benchmark",
+    "scripts": "scripts/large-ep-benchmark/run_benchmark.sbatch",
+    "data": "",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "large_ep",
+      "large_ep_scaling",
+      "mori_ep",
+      "benchmark"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+      "IBDEVICES": "mlx5_0",
+      "SKIP_DEEPEP": "1"
+    },
+    "args": "-N 2 -n 2"
+  },
+  {
+    "name": "pyt_large_ep_bench_4n_mori_only",
+    "url": "",
+    "docker_image": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+    "dockerfile": "docker/large_ep_benchmark",
+    "scripts": "scripts/large-ep-benchmark/run_benchmark.sbatch",
+    "data": "",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "tags": [
+      "pyt",
+      "large_ep",
+      "large_ep_scaling",
+      "mori_ep",
+      "benchmark"
+    ],
+    "timeout": -1,
+    "distributed": {
+      "launcher": "slurm_multi"
+    },
+    "env_vars": {
+      "DOCKER_IMAGE": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+      "IBDEVICES": "mlx5_0",
+      "SKIP_DEEPEP": "1"
+    },
+    "args": "-N 4 -n 4"
   }
 ]

--- a/models.json
+++ b/models.json
@@ -2663,7 +2663,6 @@
   {
     "name": "pyt_sglang_disagg_mori_io_llama-3.1-8b",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -2682,7 +2681,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "Llama-3.1-8B-Instruct",
       "xP": "1",
       "yD": "1",
@@ -2696,7 +2695,6 @@
   {
     "name": "pyt_sglang_disagg_mori_io_qwen3-32b",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -2715,7 +2713,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "Qwen3-32B",
       "xP": "1",
       "yD": "1",
@@ -2729,7 +2727,6 @@
   {
     "name": "pyt_sglang_disagg_mori_io_llama-3.3-70b-fp8",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -2748,7 +2745,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "amd-Llama-3.3-70B-Instruct-FP8-KV",
       "xP": "1",
       "yD": "1",
@@ -2762,7 +2759,6 @@
   {
     "name": "pyt_sglang_disagg_mori_io_llama-3.1-405b-fp8",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -2781,7 +2777,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "Llama-3.1-405B-Instruct-FP8-KV",
       "xP": "1",
       "yD": "1",
@@ -2795,7 +2791,6 @@
   {
     "name": "pyt_sglang_disagg_mori_io_mixtral-8x7b",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -2814,7 +2809,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "Mixtral-8x7B-Instruct-v0.1",
       "xP": "1",
       "yD": "1",
@@ -2828,7 +2823,6 @@
   {
     "name": "pyt_sglang_disagg_mori_io_deepseek-v3",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -2847,7 +2841,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "DeepSeek-V3",
       "xP": "1",
       "yD": "1",
@@ -2861,7 +2855,6 @@
   {
     "name": "pyt_sglang_disagg_mori_io_deepseek-r1",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -2880,7 +2873,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "DeepSeek-R1",
       "xP": "1",
       "yD": "1",
@@ -2894,7 +2887,6 @@
   {
     "name": "pyt_sglang_disagg_mori_dp_deepseek-v3",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -2913,7 +2905,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "DeepSeek-V3",
       "xP": "1",
       "yD": "1",
@@ -2927,7 +2919,6 @@
   {
     "name": "pyt_sglang_disagg_mori_dp_deepseek-r1",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -2946,7 +2937,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "DeepSeek-R1",
       "xP": "1",
       "yD": "1",
@@ -2960,7 +2951,6 @@
   {
     "name": "pyt_sglang_disagg_mooncake_llama-3.1-8b",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -2979,7 +2969,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "Llama-3.1-8B-Instruct",
       "xP": "1",
       "yD": "1",
@@ -2993,7 +2983,6 @@
   {
     "name": "pyt_sglang_disagg_mooncake_qwen3-32b",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3012,7 +3001,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "Qwen3-32B",
       "xP": "1",
       "yD": "1",
@@ -3026,7 +3015,6 @@
   {
     "name": "pyt_sglang_disagg_mooncake_llama-3.3-70b-fp8",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3045,7 +3033,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "amd-Llama-3.3-70B-Instruct-FP8-KV",
       "xP": "1",
       "yD": "1",
@@ -3059,7 +3047,6 @@
   {
     "name": "pyt_sglang_disagg_mooncake_llama-3.1-405b-fp8",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3078,7 +3065,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "Llama-3.1-405B-Instruct-FP8-KV",
       "xP": "1",
       "yD": "1",
@@ -3092,7 +3079,6 @@
   {
     "name": "pyt_sglang_disagg_mooncake_mixtral-8x7b",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3111,7 +3097,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "Mixtral-8x7B-Instruct-v0.1",
       "xP": "1",
       "yD": "1",
@@ -3125,7 +3111,6 @@
   {
     "name": "pyt_sglang_disagg_mooncake_deepseek-v3",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3144,7 +3129,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "DeepSeek-V3",
       "xP": "1",
       "yD": "1",
@@ -3158,7 +3143,6 @@
   {
     "name": "pyt_sglang_disagg_mooncake_deepseek-r1",
     "url": "",
-    "docker_image": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
     "dockerfile": "docker/sglang_disagg_inference",
     "scripts": "scripts/sglang_disagg/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3177,7 +3161,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:sglang-v0.5.11-rocm720-mi30x-20260526",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "DeepSeek-R1",
       "xP": "1",
       "yD": "1",
@@ -3191,7 +3175,6 @@
   {
     "name": "pyt_vllm_disagg_nixl_deepseek-v3",
     "url": "",
-    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
     "dockerfile": "docker/vllm_disagg_inference",
     "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3210,7 +3193,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "DeepSeek-V3",
       "xP": "1",
       "yD": "1",
@@ -3223,7 +3206,6 @@
   {
     "name": "pyt_vllm_disagg_nixl_deepseek-r1",
     "url": "",
-    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
     "dockerfile": "docker/vllm_disagg_inference",
     "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3242,7 +3224,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "DeepSeek-R1",
       "xP": "1",
       "yD": "1",
@@ -3255,7 +3237,6 @@
   {
     "name": "pyt_vllm_disagg_nixl_deepseek-v3-5layer",
     "url": "",
-    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
     "dockerfile": "docker/vllm_disagg_inference",
     "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3274,7 +3255,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "DeepSeek-V3-5layer",
       "xP": "1",
       "yD": "1",
@@ -3287,7 +3268,6 @@
   {
     "name": "pyt_vllm_disagg_nixl_llama-3.1-405b-fp8",
     "url": "",
-    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
     "dockerfile": "docker/vllm_disagg_inference",
     "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3306,7 +3286,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "Llama-3.1-405B-Instruct-FP8-KV",
       "xP": "1",
       "yD": "1",
@@ -3319,7 +3299,6 @@
   {
     "name": "pyt_vllm_disagg_nixl_llama-3.3-70b-fp8",
     "url": "",
-    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
     "dockerfile": "docker/vllm_disagg_inference",
     "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3338,7 +3317,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "amd-Llama-3.3-70B-Instruct-FP8-KV",
       "xP": "1",
       "yD": "1",
@@ -3351,7 +3330,6 @@
   {
     "name": "pyt_vllm_disagg_nixl_gpt-oss-120b",
     "url": "",
-    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
     "dockerfile": "docker/vllm_disagg_inference",
     "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3370,7 +3348,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "gpt-oss-120b",
       "xP": "1",
       "yD": "1",
@@ -3383,7 +3361,6 @@
   {
     "name": "pyt_vllm_disagg_mori_deepseek-v3",
     "url": "",
-    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
     "dockerfile": "docker/vllm_disagg_inference",
     "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3402,7 +3379,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "DeepSeek-V3",
       "xP": "1",
       "yD": "1",
@@ -3415,7 +3392,6 @@
   {
     "name": "pyt_vllm_disagg_mori_deepseek-r1",
     "url": "",
-    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
     "dockerfile": "docker/vllm_disagg_inference",
     "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3434,7 +3410,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "DeepSeek-R1",
       "xP": "1",
       "yD": "1",
@@ -3447,7 +3423,6 @@
   {
     "name": "pyt_vllm_disagg_mori_deepseek-v3-5layer",
     "url": "",
-    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
     "dockerfile": "docker/vllm_disagg_inference",
     "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3466,7 +3441,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "DeepSeek-V3-5layer",
       "xP": "1",
       "yD": "1",
@@ -3479,7 +3454,6 @@
   {
     "name": "pyt_vllm_disagg_deepep_deepseek-v3",
     "url": "",
-    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
     "dockerfile": "docker/vllm_disagg_inference",
     "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3498,7 +3472,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "DeepSeek-V3",
       "xP": "1",
       "yD": "1",
@@ -3511,7 +3485,6 @@
   {
     "name": "pyt_vllm_disagg_deepep_deepseek-r1",
     "url": "",
-    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
     "dockerfile": "docker/vllm_disagg_inference",
     "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3530,7 +3503,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "DeepSeek-R1",
       "xP": "1",
       "yD": "1",
@@ -3543,7 +3516,6 @@
   {
     "name": "pyt_vllm_disagg_deepep_deepseek-v3-5layer",
     "url": "",
-    "docker_image": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
     "dockerfile": "docker/vllm_disagg_inference",
     "scripts": "scripts/vllm_dissag/run_xPyD_models.slurm",
     "data": "huggingface",
@@ -3562,7 +3534,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:vllm-disagg-v0.19.0.dev-mori-158c7e83-2026-06-12",
+      "DOCKER_IMAGE_NAME": "",
       "MODEL_NAME": "DeepSeek-V3-5layer",
       "xP": "1",
       "yD": "1",
@@ -3575,7 +3547,6 @@
   {
     "name": "pyt_large_ep_bench_1n",
     "url": "",
-    "docker_image": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
     "dockerfile": "docker/large_ep_benchmark",
     "scripts": "scripts/large-ep-benchmark/run_benchmark.sbatch",
     "data": "",
@@ -3595,7 +3566,7 @@
     },
     "env_vars": {
       "DOCKER_IMAGE": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+      "DOCKER_IMAGE_NAME": "",
       "IBDEVICES": "mlx5_0",
       "SKIP_DEEPEP": "0"
     },
@@ -3604,7 +3575,6 @@
   {
     "name": "pyt_large_ep_bench_1n_mori_only",
     "url": "",
-    "docker_image": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
     "dockerfile": "docker/large_ep_benchmark",
     "scripts": "scripts/large-ep-benchmark/run_benchmark.sbatch",
     "data": "",
@@ -3624,7 +3594,7 @@
     },
     "env_vars": {
       "DOCKER_IMAGE": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+      "DOCKER_IMAGE_NAME": "",
       "IBDEVICES": "mlx5_0",
       "SKIP_DEEPEP": "1"
     },
@@ -3633,7 +3603,6 @@
   {
     "name": "pyt_large_ep_bench_2n",
     "url": "",
-    "docker_image": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
     "dockerfile": "docker/large_ep_benchmark",
     "scripts": "scripts/large-ep-benchmark/run_benchmark.sbatch",
     "data": "",
@@ -3653,7 +3622,7 @@
     },
     "env_vars": {
       "DOCKER_IMAGE": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+      "DOCKER_IMAGE_NAME": "",
       "IBDEVICES": "mlx5_0",
       "SKIP_DEEPEP": "0"
     },
@@ -3662,7 +3631,6 @@
   {
     "name": "pyt_large_ep_bench_2n_mori_only",
     "url": "",
-    "docker_image": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
     "dockerfile": "docker/large_ep_benchmark",
     "scripts": "scripts/large-ep-benchmark/run_benchmark.sbatch",
     "data": "",
@@ -3682,7 +3650,7 @@
     },
     "env_vars": {
       "DOCKER_IMAGE": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+      "DOCKER_IMAGE_NAME": "",
       "IBDEVICES": "mlx5_0",
       "SKIP_DEEPEP": "1"
     },
@@ -3691,7 +3659,6 @@
   {
     "name": "pyt_large_ep_bench_4n_mori_only",
     "url": "",
-    "docker_image": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
     "dockerfile": "docker/large_ep_benchmark",
     "scripts": "scripts/large-ep-benchmark/run_benchmark.sbatch",
     "data": "",
@@ -3711,7 +3678,7 @@
     },
     "env_vars": {
       "DOCKER_IMAGE": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
-      "DOCKER_IMAGE_NAME": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
+      "DOCKER_IMAGE_NAME": "",
       "IBDEVICES": "mlx5_0",
       "SKIP_DEEPEP": "1"
     },

--- a/models.json
+++ b/models.json
@@ -2681,7 +2681,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "Llama-3.1-8B-Instruct",
       "xP": "1",
       "yD": "1",
@@ -2713,7 +2713,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "Qwen3-32B",
       "xP": "1",
       "yD": "1",
@@ -2745,7 +2745,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "amd-Llama-3.3-70B-Instruct-FP8-KV",
       "xP": "1",
       "yD": "1",
@@ -2777,7 +2777,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "Llama-3.1-405B-Instruct-FP8-KV",
       "xP": "1",
       "yD": "1",
@@ -2809,7 +2809,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "Mixtral-8x7B-Instruct-v0.1",
       "xP": "1",
       "yD": "1",
@@ -2841,7 +2841,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "DeepSeek-V3",
       "xP": "1",
       "yD": "1",
@@ -2873,7 +2873,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "DeepSeek-R1",
       "xP": "1",
       "yD": "1",
@@ -2905,7 +2905,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "DeepSeek-V3",
       "xP": "1",
       "yD": "1",
@@ -2937,7 +2937,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "DeepSeek-R1",
       "xP": "1",
       "yD": "1",
@@ -2969,7 +2969,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "Llama-3.1-8B-Instruct",
       "xP": "1",
       "yD": "1",
@@ -3001,7 +3001,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "Qwen3-32B",
       "xP": "1",
       "yD": "1",
@@ -3033,7 +3033,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "amd-Llama-3.3-70B-Instruct-FP8-KV",
       "xP": "1",
       "yD": "1",
@@ -3065,7 +3065,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "Llama-3.1-405B-Instruct-FP8-KV",
       "xP": "1",
       "yD": "1",
@@ -3097,7 +3097,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "Mixtral-8x7B-Instruct-v0.1",
       "xP": "1",
       "yD": "1",
@@ -3129,7 +3129,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "DeepSeek-V3",
       "xP": "1",
       "yD": "1",
@@ -3161,7 +3161,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "DeepSeek-R1",
       "xP": "1",
       "yD": "1",
@@ -3193,7 +3193,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "DeepSeek-V3",
       "xP": "1",
       "yD": "1",
@@ -3224,7 +3224,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "DeepSeek-R1",
       "xP": "1",
       "yD": "1",
@@ -3255,7 +3255,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "DeepSeek-V3-5layer",
       "xP": "1",
       "yD": "1",
@@ -3286,7 +3286,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "Llama-3.1-405B-Instruct-FP8-KV",
       "xP": "1",
       "yD": "1",
@@ -3317,7 +3317,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "amd-Llama-3.3-70B-Instruct-FP8-KV",
       "xP": "1",
       "yD": "1",
@@ -3348,7 +3348,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "gpt-oss-120b",
       "xP": "1",
       "yD": "1",
@@ -3379,7 +3379,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "DeepSeek-V3",
       "xP": "1",
       "yD": "1",
@@ -3410,7 +3410,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "DeepSeek-R1",
       "xP": "1",
       "yD": "1",
@@ -3441,7 +3441,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "DeepSeek-V3-5layer",
       "xP": "1",
       "yD": "1",
@@ -3472,7 +3472,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "DeepSeek-V3",
       "xP": "1",
       "yD": "1",
@@ -3503,7 +3503,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "DeepSeek-R1",
       "xP": "1",
       "yD": "1",
@@ -3534,7 +3534,7 @@
       "launcher": "slurm_multi"
     },
     "env_vars": {
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "MODEL_NAME": "DeepSeek-V3-5layer",
       "xP": "1",
       "yD": "1",
@@ -3566,7 +3566,7 @@
     },
     "env_vars": {
       "DOCKER_IMAGE": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "IBDEVICES": "mlx5_0",
       "SKIP_DEEPEP": "0"
     },
@@ -3594,7 +3594,7 @@
     },
     "env_vars": {
       "DOCKER_IMAGE": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "IBDEVICES": "mlx5_0",
       "SKIP_DEEPEP": "1"
     },
@@ -3622,7 +3622,7 @@
     },
     "env_vars": {
       "DOCKER_IMAGE": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "IBDEVICES": "mlx5_0",
       "SKIP_DEEPEP": "0"
     },
@@ -3650,7 +3650,7 @@
     },
     "env_vars": {
       "DOCKER_IMAGE": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "IBDEVICES": "mlx5_0",
       "SKIP_DEEPEP": "1"
     },
@@ -3678,7 +3678,7 @@
     },
     "env_vars": {
       "DOCKER_IMAGE": "rocm/pytorch-private:large-ep-benchmark-rocm720-mori-42e89547-20260605",
-      "DOCKER_IMAGE_NAME": "",
+      "DOCKER_IMAGE_NAME": "<supply-your-image>",
       "IBDEVICES": "mlx5_0",
       "SKIP_DEEPEP": "1"
     },

--- a/scripts/large-ep-benchmark/parse_ep_to_csv.py
+++ b/scripts/large-ep-benchmark/parse_ep_to_csv.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+Parse large EP benchmark logs and generate madengine-compatible perf.csv.
+
+Parses output from:
+- MoRI bench_dispatch_combine / test_dispatch_combine_internode (PrettyTable format)
+- DeepEP test_internode / test_low_latency (inline GB/s format)
+
+Each benchmark test becomes a row in perf.csv with:
+  model = test name (e.g. "mori_internode_dispatch")
+  performance = best bandwidth or latency
+  metric = "GB/s" or "us"
+"""
+
+import re
+import csv
+import os
+from pathlib import Path
+from typing import List, Dict
+
+
+def parse_mori_prettytable(content: str, source: str) -> List[Dict]:
+    """Parse MoRI PrettyTable output.
+
+    Format:
+    +------ Dispatch (bfloat16) block=... ------+
+    | Metrics | RDMA Bandwidth (GB/s) | ... | Latency (us) |
+    | Best    | 71.84                 | ... | 1629         |
+    | Worst   | 2.25                  | ... | 52106        |
+    | Average | 48.54                 | ... | 6910         |
+    """
+    results = []
+
+    # Match PrettyTable title lines for dispatch/combine phases
+    # Formats: "Dispatch Performance (bfloat16)" or "Dispatch (bfloat16) block=X warp=Y rdma=Z"
+    table_pattern = re.compile(
+        r'\|\s+(Dispatch|Combine)\s+(?:Performance\s+)?\((\w+)\)',
+        re.IGNORECASE
+    )
+
+    # Match data rows: | Best/Worst/Average | val | val | val | val |
+    row_pattern = re.compile(
+        r'\|\s+(Best|Worst|Average)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|'
+    )
+
+    current_phase = None
+    current_dtype = None
+
+    for line in content.split('\n'):
+        title_m = table_pattern.search(line)
+        if title_m:
+            current_phase = title_m.group(1).lower()
+            current_dtype = title_m.group(2)
+            continue
+
+        row_m = row_pattern.search(line)
+        if row_m and current_phase:
+            metric_type = row_m.group(1)  # Best/Worst/Average
+            rdma_bw = float(row_m.group(2))
+            xgmi_bw = float(row_m.group(3))
+            ll_bw = float(row_m.group(4))
+            latency = float(row_m.group(5))
+
+            if metric_type == 'Best':
+                results.append({
+                    'test': f'mori_{source}_{current_phase}',
+                    'dtype': current_dtype,
+                    'rdma_bw': rdma_bw,
+                    'xgmi_bw': xgmi_bw,
+                    'latency': latency,
+                    'metric_type': 'best',
+                })
+
+    return results
+
+
+def parse_deepep_internode(content: str) -> List[Dict]:
+    """Parse DeepEP test_internode output.
+
+    Format:
+    [tuned] ... X.XX GB/s (RDMA), Y.YY GB/s (NVL) ...
+    Best config: X.XX GB/s (RDMA), Y.YY GB/s (NVL) ...
+    """
+    results = []
+
+    # Match "Best config" or final tuned lines with RDMA/NVL bandwidth
+    best_pattern = re.compile(
+        r'([\d.]+)\s+GB/s\s+\(RDMA\),\s+([\d.]+)\s+GB/s\s+\(NVL\)'
+    )
+
+    # Track which section we're in based on echo markers
+    sections = content.split('-----')
+    for section in sections:
+        # Find the best (last) bandwidth line in each section
+        matches = best_pattern.findall(section)
+        if not matches:
+            continue
+
+        # Determine test type from section header
+        section_lower = section.lower()
+        if 'internode' in section_lower and 'low' not in section_lower:
+            test_type = 'deepep_internode'
+        elif 'low_latency' in section_lower or 'low latency' in section_lower:
+            test_type = 'deepep_low_latency'
+        elif 'intranode' in section_lower:
+            test_type = 'deepep_intranode'
+        else:
+            test_type = 'deepep_unknown'
+
+        # Use the last match as the "best" result
+        rdma_bw, nvl_bw = matches[-1]
+        results.append({
+            'test': test_type,
+            'dtype': 'bf16',
+            'rdma_bw': float(rdma_bw),
+            'xgmi_bw': float(nvl_bw),
+            'latency': 0,
+            'metric_type': 'best',
+        })
+
+    return results
+
+
+def parse_log_file(log_path: str, source_hint: str = "") -> List[Dict]:
+    """Parse a single log file, auto-detecting format."""
+    with open(log_path, 'r') as f:
+        content = f.read()
+
+    results = []
+
+    # Try MoRI PrettyTable format
+    if 'RDMA Bandwidth (GB/s)' in content:
+        source = source_hint or Path(log_path).stem
+        # Determine if internode or intranode from filename/content
+        if 'internode' in log_path.lower() or 'internode' in content.lower():
+            src = 'internode'
+        else:
+            src = 'intranode'
+        if '_ll_' in log_path.lower() or 'low.latency' in content.lower()[:500]:
+            src += '_ll'
+        results.extend(parse_mori_prettytable(content, src))
+
+    # Try DeepEP inline format
+    if 'GB/s (RDMA)' in content:
+        results.extend(parse_deepep_internode(content))
+
+    return results
+
+
+def save_perf_csv(results: List[Dict], output_file: str):
+    """Save results in madengine perf.csv format."""
+    if not results:
+        print("No results to save to perf.csv.")
+        return
+
+    nnodes = os.environ.get('NNODES', os.environ.get('SLURM_NNODES', '1'))
+    gpus = os.environ.get('GPUS_PER_NODE', '8')
+    skip_deepep = os.environ.get('SKIP_DEEPEP', '0')
+
+    if skip_deepep == '1':
+        backend = 'mori_only'
+    else:
+        backend = 'deepep+mori'
+
+    meta = {
+        'pipeline': 'large_ep',
+        'deployment_type': f'ep_bench_{nnodes}N',
+        'tags': f'large_ep,{backend}',
+        'n_gpus': str(int(nnodes) * int(gpus)),
+        'nnodes': nnodes,
+        'gpus_per_node': gpus,
+        'docker_image': os.environ.get('DOCKER_IMAGE', ''),
+        'machine_name': os.environ.get('SLURM_JOB_NODELIST', ''),
+        'launcher': 'slurm_multi',
+        'gpu_architecture': 'gfx942',
+    }
+
+    fieldnames = [
+        'model', 'n_gpus', 'nnodes', 'gpus_per_node', 'training_precision',
+        'pipeline', 'args', 'tags', 'docker_file', 'base_docker', 'docker_sha',
+        'docker_image', 'git_commit', 'machine_name', 'deployment_type', 'launcher',
+        'gpu_architecture', 'performance', 'metric', 'relative_change', 'status',
+        'build_duration', 'test_duration', 'dataname', 'data_provider_type',
+        'data_size', 'data_download_duration', 'build_number',
+        'additional_docker_run_options',
+    ]
+
+    with open(output_file, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for r in results:
+            # Primary metric: RDMA bandwidth
+            row = {
+                'model': r['test'],
+                'performance': f"{r['rdma_bw']:.2f}",
+                'metric': f"GB/s RDMA ({r['dtype']})",
+                'status': 'SUCCESS',
+            }
+            row.update(meta)
+            writer.writerow(row)
+
+            # Secondary metric: latency (if available)
+            if r.get('latency', 0) > 0:
+                row_lat = {
+                    'model': r['test'],
+                    'performance': f"{r['latency']:.0f}",
+                    'metric': f"us latency ({r['dtype']})",
+                    'status': 'SUCCESS',
+                }
+                row_lat.update(meta)
+                writer.writerow(row_lat)
+
+    print(f"Saved {len(results)} benchmark results to {output_file}")
+
+
+def main():
+    import sys
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Parse EP benchmark logs and generate perf.csv')
+    parser.add_argument('log_dir', type=str, help='Directory containing EP benchmark log files')
+    parser.add_argument('-o', '--output', type=str, default='perf.csv', help='Output perf.csv path')
+
+    args = parser.parse_args()
+
+    log_dir = Path(args.log_dir)
+    if not log_dir.exists():
+        print(f"Error: Log directory not found: {log_dir}")
+        sys.exit(1)
+
+    all_results = []
+
+    # Parse individual benchmark log files (skip ep_bench_results.log which
+    # is the combined tee output and would duplicate results)
+    log_files = sorted(f for f in list(log_dir.glob('*.log')) + list(log_dir.glob('*.txt'))
+                       if f.name != 'ep_bench_results.log')
+    for log_file in log_files:
+        print(f"Parsing: {log_file.name}")
+        results = parse_log_file(str(log_file))
+        if results:
+            print(f"  Found {len(results)} results")
+            all_results.extend(results)
+
+    if not all_results:
+        print("No benchmark results found in any log files.")
+        return
+
+    save_perf_csv(all_results, args.output)
+
+    print(f"\nSummary:")
+    print(f"  Total results: {len(all_results)}")
+    print(f"  Output: {args.output}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/large-ep-benchmark/run_benchmark.sbatch
+++ b/scripts/large-ep-benchmark/run_benchmark.sbatch
@@ -8,9 +8,10 @@
 
 USER_NAME=$(whoami)
 PWD=$(pwd)
-LOG_PATH=${LOG_PATH:-"${PWD}/logs"}
+LOG_PATH=${LOG_PATH:-"/shared_inference/${USER_NAME}/model_blog_logs"}
 DOCKER_IMAGE=${DOCKER_IMAGE:-ep-benchmarking:latest}
 IBDEVICES=${IBDEVICES:-mlx5_0}
+SKIP_DEEPEP=${SKIP_DEEPEP:-0}
 
 # ------------------------
 # SLURM Environment Variables
@@ -59,12 +60,8 @@ echo "MASTER_ADDR is ${MASTER_ADDR}"
 echo "MASTER_PORT is ${MASTER_PORT}"
 echo "NNODES is ${NNODES}"
 
-if [ ! -d "$LOG_PATH" ]; then
-    mkdir -p "$LOG_PATH"
-    echo "Created directory: $LOG_PATH"
-else
-    echo "Directory already exists: $LOG_PATH"
-fi
+mkdir -p "$LOG_PATH/${SLURM_JOB_ID}"
+echo "Log directory: $LOG_PATH/${SLURM_JOB_ID}"
 
 export LOG_PATH=$LOG_PATH
 export DOCKER_IMAGE=$DOCKER_IMAGE
@@ -103,7 +100,7 @@ docker run --rm \
     -v /sys/class/net:/sys/class/net:ro \
     -v /sys/bus/pci:/sys/bus/pci:ro \
     --shm-size 64G \
-    -v ${LOG_PATH}:/run_logs \
+    -v ${LOG_PATH}/${SLURM_JOB_ID}:/run_logs \
     -v $MAD_REPO:$MAD_REPO_PATH \
     -e SLURM_JOB_ID=$SLURM_JOB_ID \
     -e SLURM_JOB_NODELIST=$SLURM_JOB_NODELIST \
@@ -113,6 +110,7 @@ docker run --rm \
     -e NNODES=$NNODES \
     -e IPADDRS=$IPADDRS \
     -e IBDEVICES=$IBDEVICES \
+    -e SKIP_DEEPEP=$SKIP_DEEPEP \
     -e MAD_REPO_PATH=$MAD_REPO_PATH \
     -e MAD_REPO_EP_SCRIPTS=$MAD_REPO_EP_SCRIPTS \
     --entrypoint /bin/bash \
@@ -121,7 +119,8 @@ docker run --rm \
         echo Inside docker container ....
         echo ${MAD_REPO_PATH}
         $MAD_REPO_PATH/run_ep_bench.sh 2>&1 | tee /run_logs/ep_bench_results.log
-"    
+"
 '
 
-srun bash -c 'docker stop ep-bench; docker rm ep-bench;'
+srun bash -c 'docker stop ep-bench 2>/dev/null || true; docker rm -f ep-bench 2>/dev/null || true'
+

--- a/scripts/large-ep-benchmark/run_ep_bench.sh
+++ b/scripts/large-ep-benchmark/run_ep_bench.sh
@@ -7,6 +7,7 @@ NODE_RANK="${NODE_RANK:-0}"
 NNODES="${NNODES:-1}"
 IPADDRS="${IPADDRS:-localhost}"
 IBDEVICES="${IBDEVICES:-mlx5_0}"
+SKIP_DEEPEP="${SKIP_DEEPEP:-0}"
 
 host_ip=$(hostname -I | awk '{print $1}')
 host_name=$(hostname)
@@ -28,13 +29,17 @@ cd $DEEPEP_PATH
 MORI_PATH="/app/mori"
 if [ "$NNODES" -eq 1 ]; then
     echo "Total number of nodes - ${NNODES}"
-    python tests/test_intranode.py 2>&1 | tee /run_logs/intranode_results.log
-    #python tests/test_intranode.py
-    sleep 20;
-    
-    export ROCSHMEM_USE_IB_HCA=$IBDEVICES
-    export ROCSHMEM_HEAP_SIZE=4147483648
-    python tests/test_low_latency.py 2>&1 | tee /run_logs/low_latency_1N_results.log 
+
+    if [ "$SKIP_DEEPEP" != "1" ]; then
+        python tests/test_intranode.py 2>&1 | tee /run_logs/intranode_results.log
+        sleep 20;
+
+        export ROCSHMEM_USE_IB_HCA=$IBDEVICES
+        export ROCSHMEM_HEAP_SIZE=4147483648
+        python tests/test_low_latency.py 2>&1 | tee /run_logs/low_latency_1N_results.log
+    else
+        echo "----- Skipping DeepEP benchmarks (SKIP_DEEPEP=1) -----"
+    fi
 
     echo "----- Performing Intranode MoRI -----"
     cd $MORI_PATH
@@ -57,19 +62,23 @@ else
     echo "Node Rank - $NODE_RANK"
     echo "NNODES - $NNODES"
 
-    echo "----- Running internode tests -----"
-    
-    python tests/test_internode.py 2>&1 | tee /run_logs/$LOG_FILE
-    sleep 20;
+    if [ "$SKIP_DEEPEP" != "1" ]; then
+        echo "----- Running internode tests -----"
 
-    echo "----- Running low latency tests -----"
-    export ROCSHMEM_HEAP_SIZE=$((3*1024*1024*1024))
-    export ROCSHMEM_MAX_NUM_CONTEXTS=144
-    #export ROCSHMEM_BACKEND=gda
-    #export ROCSHMEM_DISABLE_MIXED_IPC=0
-    #export ROCSHMEM_USE_IB_HCA=$IBDEVICES
-    python tests/test_low_latency.py 2>&1 | tee /run_logs/low-latency-${NODE_RANK}.log
-    sleep 20;
+        python tests/test_internode.py 2>&1 | tee /run_logs/$LOG_FILE
+        sleep 20;
+
+        echo "----- Running low latency tests -----"
+        export ROCSHMEM_HEAP_SIZE=$((3*1024*1024*1024))
+        export ROCSHMEM_MAX_NUM_CONTEXTS=144
+        #export ROCSHMEM_BACKEND=gda
+        #export ROCSHMEM_DISABLE_MIXED_IPC=0
+        #export ROCSHMEM_USE_IB_HCA=$IBDEVICES
+        python tests/test_low_latency.py 2>&1 | tee /run_logs/low-latency-${NODE_RANK}.log
+        sleep 20;
+    else
+        echo "----- Skipping DeepEP benchmarks (SKIP_DEEPEP=1) -----"
+    fi
 
     echo "---- Running mori internode tests -------"
     cd $MORI_PATH
@@ -89,6 +98,11 @@ else
         --master_addr=$MASTER_ADDR \
         --master_port=$MASTER_PORT \
         examples/ops/dispatch_combine/test_dispatch_combine_internode.py --cmd bench --kernel-type v1_ll 2>&1 | tee /run_logs/mori_ll_${LOG_FILE}
+fi
+
+# Generate perf.csv for madengine from all benchmark logs
+if [[ -f "$MAD_REPO_PATH/parse_ep_to_csv.py" ]]; then
+    python3 $MAD_REPO_PATH/parse_ep_to_csv.py /run_logs -o /run_logs/perf.csv 2>&1
 fi
 
 exit 0

--- a/scripts/sglang_disagg/benchmark_xPyD.sh
+++ b/scripts/sglang_disagg/benchmark_xPyD.sh
@@ -56,4 +56,6 @@ for i in {1..$BENCHMARK_ITR}; do
     done
 done
 python3 parse_to_csv.py ${LOG}_CONCURRENCY.log  -o ${LOG}_CONCURRENCY.csv \
+	--perf-csv /run_logs/${SLURM_JOB_ID}/perf.csv \
+	--model-name "${MODEL_NAME}" \
 	2>&1 | tee -a ${LOG}_CONCURRENCY.log >/dev/null

--- a/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
+++ b/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
@@ -80,28 +80,6 @@ pip install py-spy
 pip install --ignore-installed --force-reinstall flask
 pip install pyyaml
 
-## Workaround for OCI-CX7: install rdma-core v62.0 (container's built-in version is too old).
-## Build once per image version to a shared versioned cache; subsequent runs install from cache.
-_RDMA_VER="v62.0"
-_IMG_TAG=$(echo "${DOCKER_IMAGE_NAME:-unknown}" | tr '/:' '_')
-_RDMA_CACHE="${RDMA_CORE_CACHE:-/shared_inference/rdma-core-cache/${_RDMA_VER}_${_IMG_TAG}}"
-if [[ -f "${_RDMA_CACHE}/lib/libibverbs.so" ]]; then
-    echo "Installing rdma-core ${_RDMA_VER} from cache: ${_RDMA_CACHE}"
-    cp -a "${_RDMA_CACHE}/lib/"* /usr/lib/ 2>/dev/null || true
-    cp -a "${_RDMA_CACHE}/include/"* /usr/include/ 2>/dev/null || true
-    ldconfig
-else
-    echo "Building rdma-core ${_RDMA_VER} (first run for image ${_IMG_TAG} — caching to ${_RDMA_CACHE})"
-    git clone --branch "${_RDMA_VER}" --depth 1 https://github.com/linux-rdma/rdma-core.git /tmp/rdma-core && \
-        cd /tmp/rdma-core && \
-        mkdir -p build && cd build && \
-        cmake -GNinja -DCMAKE_INSTALL_PREFIX=/usr -DNO_MAN_PAGES=1 .. && \
-        ninja && ninja install && ldconfig
-    mkdir -p "${_RDMA_CACHE}/lib" "${_RDMA_CACHE}/include"
-    cp -a /usr/lib/libibverbs* /usr/lib/librdmacm* /usr/lib/libmlx5* "${_RDMA_CACHE}/lib/" 2>/dev/null || true
-    cp -a /usr/include/infiniband "${_RDMA_CACHE}/include/" 2>/dev/null || true
-    rm -rf /tmp/rdma-core
-fi
 
 host_ip=$(ip route get 1.1.1.1 | awk '/src/ {print $7}')
 host_name=$(hostname)

--- a/scripts/vllm_dissag/benchmark_xPyD.sh
+++ b/scripts/vllm_dissag/benchmark_xPyD.sh
@@ -37,7 +37,7 @@ IFS=' ' read -ra COMBINATIONS <<< "${BENCHMARK_COMBINATIONS:-1024/1024 8192/1024
 
 echo "Benchmarking iterations: $BENCHMARK_ITR" | tee -a ${LOG}_CONCURRENCY.log >/dev/null
 for i in $(seq 1 $BENCHMARK_ITR); do
-    echo "Running the benchserving script for iter: $i"
+    echo "Running the benchserving script for iter: $i" | tee -a ${LOG}_CONCURRENCY.log >/dev/null
     for combo in "${COMBINATIONS[@]}"; do
        IFS="/" read -r isl osl <<< "$combo"
        for con in $CON; do
@@ -51,7 +51,8 @@ for i in $(seq 1 $BENCHMARK_ITR); do
            if [ "$_scaled_timeout" -lt "$_base_timeout" ]; then
                _scaled_timeout=$_base_timeout
            fi
-           echo "[RUNNING] prompts $p_con isl $isl osl $osl con $con (timeout ${_scaled_timeout}s)"
+           echo "[RUNNING] prompts $p_con isl $isl osl $osl con $con (timeout ${_scaled_timeout}s)" \
+               | tee -a ${LOG}_CONCURRENCY.log >/dev/null
            timeout $_scaled_timeout vllm bench serve \
            --model $MODEL_PATH \
            --backend vllm \
@@ -76,3 +77,7 @@ for i in $(seq 1 $BENCHMARK_ITR); do
         done
     done
 done
+python3 $NIXL_COOKBOOK_PATH/parse_to_csv.py ${LOG}_CONCURRENCY.log -o ${LOG}_CONCURRENCY.csv \
+	--perf-csv /run_logs/${SLURM_JOB_ID}/perf.csv \
+	--model-name "${MODEL_NAME}" \
+	2>&1 | tee -a ${LOG}_CONCURRENCY.log >/dev/null

--- a/scripts/vllm_dissag/parse_to_csv.py
+++ b/scripts/vllm_dissag/parse_to_csv.py
@@ -1,73 +1,88 @@
 #!/usr/bin/env python3
 """
-Parse SGLang benchmark log file and save results to CSV.
+Parse vLLM benchmark log file and save results to CSV.
 Extracts: Concurrency, Input tokens, Output tokens, Total Token throughput (tok/s)
 For each configuration, takes the MAX Total Token throughput across all iterations.
+
+Log format (from benchmark_xPyD.sh):
+  [RUNNING] prompts <N> isl <ISL> osl <OSL> con <CON> (timeout <T>s)
+  ============ Serving Benchmark Result ============
+  Total token throughput (tok/s):          <VALUE>
 """
 
 import re
 import csv
 from pathlib import Path
-from typing import List, Dict, Tuple
+from typing import Dict, Tuple
 from collections import defaultdict
 
 
 def parse_benchmark_log(log_file: str) -> Dict[Tuple[int, int, int], Dict]:
     """Parse benchmark log file and extract results, keeping max throughput per configuration."""
-    results = defaultdict(lambda: {'concurrency': None, 'input_tokens': None, 
+    results = defaultdict(lambda: {'concurrency': None, 'input_tokens': None,
                                     'output_tokens': None, 'max_throughput': 0.0})
-    
+
     with open(log_file, 'r') as f:
         content = f.read()
-    
+
     # Find the start of the first iteration (ignore warmup)
-    first_iter_match = re.search(r'RUNNING: the benchserving script for iter: 1', content)
+    first_iter_match = re.search(r'Running the benchserving script for iter: 1', content)
     if not first_iter_match:
         print("Warning: No iteration 1 found. Processing entire file.")
         start_pos = 0
     else:
         start_pos = first_iter_match.start()
-    
+
     # Process only from first iteration onwards
     content = content[start_pos:]
-    
+
     # Split by benchmark result sections
     sections = re.split(r'============ Serving Benchmark Result ============', content)
-    
+
     current_input_seq_len = None
     current_output_seq_len = None
     current_concurrency = None
-    
+
     for i, section in enumerate(sections[1:], 1):  # Skip first empty section
-        # Look for configuration in previous sections (from RUNNING line)
+        # Look for configuration in previous sections (from [RUNNING] line)
         if i > 1:
             prev_section = sections[i-1]
-            
-            # Extract config: prompts  isl <num> osl <num> con <num>
-            config_match = re.search(r'RUNNING: prompts\s+isl\s+(\d+)\s+osl\s+(\d+)\s+con\s+(\d+)', prev_section)
+
+            # vllm format: [RUNNING] prompts <N> isl <ISL> osl <OSL> con <CON>
+            config_match = re.search(
+                r'\[RUNNING\]\s+prompts\s+\d+\s+isl\s+(\d+)\s+osl\s+(\d+)\s+con\s+(\d+)',
+                prev_section
+            )
+            # Fallback: extract from Namespace(...) in vllm bench serve output
+            if not config_match:
+                isl_m = re.search(r'random_input_len=(\d+)', prev_section)
+                osl_m = re.search(r'random_output_len=(\d+)', prev_section)
+                con_m = re.search(r'max_concurrency=(\d+)', prev_section)
+                if isl_m and osl_m and con_m:
+                    config_match = type('Match', (), {
+                        'group': lambda self, n: [None, isl_m.group(1), osl_m.group(1), con_m.group(1)][n]
+                    })()
             if config_match:
                 current_input_seq_len = int(config_match.group(1))
                 current_output_seq_len = int(config_match.group(2))
                 current_concurrency = int(config_match.group(3))
-        
+
         # Extract Total token throughput (tok/s) from benchmark result section
         throughput_match = re.search(r'Total token throughput \(tok/s\):\s+([\d.]+)', section)
         throughput = float(throughput_match.group(1)) if throughput_match else None
-        
-        # Only process if we have a valid configuration from RUNNING line and throughput
+
+        # Only process if we have a valid configuration from [RUNNING] line and throughput
         if current_input_seq_len and current_output_seq_len and current_concurrency and throughput is not None:
             config_key = (current_input_seq_len, current_output_seq_len, current_concurrency)
-            
-            # Update results for this configuration
-            # Always use values from RUNNING line (isl, osl, con)
+
             results[config_key]['concurrency'] = current_concurrency
             results[config_key]['input_tokens'] = current_input_seq_len
             results[config_key]['output_tokens'] = current_output_seq_len
-            
+
             # Keep the maximum throughput
             if throughput > results[config_key]['max_throughput']:
                 results[config_key]['max_throughput'] = throughput
-    
+
     return results
 
 
@@ -76,16 +91,15 @@ def save_to_csv(results: Dict[Tuple[int, int, int], Dict], output_file: str):
     if not results:
         print("No results to save.")
         return
-    
-    # Define column order
+
     fieldnames = ['Concurrency', 'Input tokens', 'Output tokens', 'Total Token throughput (tok/s)']
-    
+
     with open(output_file, 'w', newline='') as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
-        
+
         # Sort by concurrency, then input tokens, then output tokens
-        for (input_tokens, output_tokens, concurrency), data in sorted(results.items(), 
+        for (input_tokens, output_tokens, concurrency), data in sorted(results.items(),
                                                                          key=lambda x: (x[0][2], x[0][0], x[0][1])):
             row = {
                 'Concurrency': data['concurrency'],
@@ -94,26 +108,26 @@ def save_to_csv(results: Dict[Tuple[int, int, int], Dict], output_file: str):
                 'Total Token throughput (tok/s)': f"{data['max_throughput']:.2f}"
             }
             writer.writerow(row)
-    
+
     print(f"Saved {len(results)} benchmark configurations to {output_file}")
 
 
-def _get_run_metadata(pipeline: str = "sglang"):
+def _get_run_metadata(pipeline: str = "vllm"):
     """Collect run metadata from environment variables."""
     import os
     xP = os.environ.get('xP', '1')
     yD = os.environ.get('yD', '1')
-    dp_mode = os.environ.get('DP_MODE', '0')
     run_mori = os.environ.get('RUN_MORI', '0')
+    run_deepep = os.environ.get('RUN_DEEPEP', '0')
     gpus = os.environ.get('GPUS_PER_NODE', '8')
 
     # Determine backend tag
-    if dp_mode == '1':
-        backend = 'mori_dp'
-    elif run_mori == '1':
-        backend = 'mori_io'
+    if run_mori == '1':
+        backend = 'mori'
+    elif run_deepep == '1':
+        backend = 'deepep'
     else:
-        backend = 'mooncake'
+        backend = 'nixl'
 
     return {
         'pipeline': pipeline,
@@ -130,7 +144,7 @@ def _get_run_metadata(pipeline: str = "sglang"):
 
 
 def save_perf_csv(results: Dict[Tuple[int, int, int], Dict], output_file: str,
-                  model_name: str = "", pipeline: str = "sglang"):
+                  model_name: str = "", pipeline: str = "vllm"):
     """Save results in madengine perf.csv format."""
     if not results:
         print("No results to save to perf.csv.")
@@ -168,11 +182,10 @@ def save_perf_csv(results: Dict[Tuple[int, int, int], Dict], output_file: str,
 
 
 def main():
-    """Main function."""
     import sys
     import argparse
 
-    parser = argparse.ArgumentParser(description='Parse SGLang benchmark log file and save results to CSV')
+    parser = argparse.ArgumentParser(description='Parse vLLM benchmark log file and save results to CSV')
     parser.add_argument('log_file', type=str, help='Path to benchmark log file')
     parser.add_argument('-o', '--output', type=str, help='Output CSV file name (default: <log_file>_results.csv)')
     parser.add_argument('--perf-csv', type=str, help='Also generate madengine perf.csv at this path')
@@ -182,30 +195,25 @@ def main():
 
     log_file = args.log_file
 
-    # Check if file exists
     if not Path(log_file).exists():
         print(f"Error: Log file not found: {log_file}")
         sys.exit(1)
 
     print(f"Parsing log file: {log_file}")
 
-    # Parse the log file
     results = parse_benchmark_log(log_file)
 
     if not results:
         print("No benchmark results found in log file.")
         return
 
-    # Generate output filename
     if args.output:
         output_file = args.output
     else:
         output_file = Path(log_file).stem + '_results.csv'
 
-    # Save to CSV
     save_to_csv(results, output_file)
 
-    # Save madengine perf.csv if requested
     if args.perf_csv:
         save_perf_csv(results, args.perf_csv, args.model_name)
 

--- a/scripts/vllm_dissag/run_xPyD_models.slurm
+++ b/scripts/vllm_dissag/run_xPyD_models.slurm
@@ -13,17 +13,51 @@
 # Auto-detect and cd to the script directory so that $(pwd) always
 # points to the folder containing the server scripts, regardless of
 # where the user called sbatch from.
-# Under Slurm, $0 points to a spool copy, so prefer SLURM_SUBMIT_DIR.
+#
+# Priority:
+# 1. BASH_SOURCE — works for direct invocation (bash script.sh)
+# 2. SLURM_SUBMIT_DIR + script path — when sbatch submits from repo root,
+#    SLURM_SUBMIT_DIR is the CWD, not the script dir. Append the relative
+#    path from the SBATCH command to get the actual script directory.
+# 3. SLURM_SUBMIT_DIR alone — last resort (assumes sbatch was run from
+#    the script directory).
 # ------------------------
-if [[ -n "${SLURM_SUBMIT_DIR:-}" ]]; then
-    SCRIPT_DIR="$SLURM_SUBMIT_DIR"
-else
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
-    SCRIPT_DIR="${SCRIPT_DIR:-.}"
-fi
+_resolve_script_dir() {
+    # Try BASH_SOURCE first (works for direct invocation)
+    if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+        local _d
+        _d="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+        if [[ -n "$_d" && -f "$_d/vllm_disagg_server.sh" ]]; then
+            echo "$_d"
+            return 0
+        fi
+    fi
+
+    # Try SLURM_SUBMIT_DIR + relative script path
+    # When madengine does: sbatch scripts/vllm_dissag/run_xPyD_models.slurm
+    # SLURM_SUBMIT_DIR = repo root, so we need to append the dirname
+    if [[ -n "${SLURM_SUBMIT_DIR:-}" ]]; then
+        local _candidate="$SLURM_SUBMIT_DIR/scripts/vllm_dissag"
+        if [[ -f "$_candidate/vllm_disagg_server.sh" ]]; then
+            echo "$_candidate"
+            return 0
+        fi
+        # Maybe they ran sbatch from the script dir itself
+        if [[ -f "$SLURM_SUBMIT_DIR/vllm_disagg_server.sh" ]]; then
+            echo "$SLURM_SUBMIT_DIR"
+            return 0
+        fi
+    fi
+
+    # Fallback
+    echo "."
+    return 1
+}
+
+SCRIPT_DIR="$(_resolve_script_dir)"
 cd "$SCRIPT_DIR" || { echo "Error: cannot cd to $SCRIPT_DIR" >&2; exit 1; }
 
-REQUIRED_FILES=("vllm_disagg_server.sh" "vllm_disagg_mori_ep.sh" "vllm_disagg_server_deepep.sh" "benchmark_xPyD.sh")
+REQUIRED_FILES=("vllm_disagg_server.sh" "vllm_disagg_mori_ep.sh" "vllm_disagg_server_deepep.sh" "benchmark_xPyD.sh" "parse_to_csv.py")
 for f in "${REQUIRED_FILES[@]}"; do
     if [[ ! -f "$f" ]]; then
         echo "Error: Required file '$f' not found in $(pwd)." >&2
@@ -376,6 +410,7 @@ SELECTED_NODELIST_SRUN=$(echo "$SELECTED_NODES" | paste -sd,)
 srun --nodelist="$SELECTED_NODELIST_SRUN" bash -c '
 echo "Rank $SLURM_PROCID on $(hostname)";
 docker ps -q | xargs --no-run-if-empty docker stop;
+docker rm -f $DOCKER_CONT_NAME 2>/dev/null || true;
 fuser -k 5000/tcp 2>/dev/null || true;
 fuser -k 2222/tcp 2>/dev/null || true;
 fuser -k 15000/tcp 2>/dev/null || true;
@@ -443,37 +478,37 @@ docker run --rm \
     -e BENCHMARK_ITR=$BENCHMARK_ITR \
     -e BENCHMARK_CON="${BENCHMARK_CON}" \
     -e BENCHMARK_COMBINATIONS="${BENCHMARK_COMBINATIONS}" \
-    -e BENCHMARK_PORT=${BENCHMARK_PORT:-} \
-    -e PROXY_TYPE=${PROXY_TYPE:-} \
-    -e ROUTER_PORT=${ROUTER_PORT:-} \
+    ${BENCHMARK_PORT:+-e BENCHMARK_PORT=$BENCHMARK_PORT} \
+    ${PROXY_TYPE:+-e PROXY_TYPE=$PROXY_TYPE} \
+    ${ROUTER_PORT:+-e ROUTER_PORT=$ROUTER_PORT} \
     -e IPADDRS=$IPADDRS \
-    -e PREFILL_DEEPEP_BACKEND=${PREFILL_DEEPEP_BACKEND:-} \
-    -e DECODE_DEEPEP_BACKEND=${DECODE_DEEPEP_BACKEND:-} \
-    -e ENABLE_DBO=${ENABLE_DBO:-} \
-    -e DBO_COMM_SMS=${DBO_COMM_SMS:-} \
-    -e ENABLE_PROFILING=${ENABLE_PROFILING:-} \
-    -e NCCL_IB_HCA=${NCCL_IB_HCA:-} \
-    -e NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-} \
-    -e NCCL_NET_GDR_LEVEL=${NCCL_NET_GDR_LEVEL:-} \
-    -e NCCL_CROSS_NIC=${NCCL_CROSS_NIC:-} \
-    -e NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-} \
-    -e GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-} \
+    ${PREFILL_DEEPEP_BACKEND:+-e PREFILL_DEEPEP_BACKEND=$PREFILL_DEEPEP_BACKEND} \
+    ${DECODE_DEEPEP_BACKEND:+-e DECODE_DEEPEP_BACKEND=$DECODE_DEEPEP_BACKEND} \
+    ${ENABLE_DBO:+-e ENABLE_DBO=$ENABLE_DBO} \
+    ${DBO_COMM_SMS:+-e DBO_COMM_SMS=$DBO_COMM_SMS} \
+    ${ENABLE_PROFILING:+-e ENABLE_PROFILING=$ENABLE_PROFILING} \
+    ${NCCL_IB_HCA:+-e NCCL_IB_HCA=$NCCL_IB_HCA} \
+    ${NCCL_IB_GID_INDEX:+-e NCCL_IB_GID_INDEX=$NCCL_IB_GID_INDEX} \
+    ${NCCL_NET_GDR_LEVEL:+-e NCCL_NET_GDR_LEVEL=$NCCL_NET_GDR_LEVEL} \
+    ${NCCL_CROSS_NIC:+-e NCCL_CROSS_NIC=$NCCL_CROSS_NIC} \
+    ${NCCL_SOCKET_IFNAME:+-e NCCL_SOCKET_IFNAME=$NCCL_SOCKET_IFNAME} \
+    ${GLOO_SOCKET_IFNAME:+-e GLOO_SOCKET_IFNAME=$GLOO_SOCKET_IFNAME} \
     -e MORI_SOCKET_IFNAME=${MORI_SOCKET_IFNAME:-eth0} \
-    -e MORI_IB_GID_INDEX=${MORI_IB_GID_INDEX:-} \
-    -e MORI_RDMA_DEVICES=${MORI_RDMA_DEVICES:-} \
-    -e MORI_NUM_QP_PER_PE=${MORI_NUM_QP_PER_PE:-} \
-    -e VLLM_MORIIO_QP_PER_TRANSFER=${VLLM_MORIIO_QP_PER_TRANSFER:-} \
-    -e VLLM_MORIIO_NUM_WORKERS=${VLLM_MORIIO_NUM_WORKERS:-} \
+    ${MORI_IB_GID_INDEX:+-e MORI_IB_GID_INDEX=$MORI_IB_GID_INDEX} \
+    ${MORI_RDMA_DEVICES:+-e MORI_RDMA_DEVICES=$MORI_RDMA_DEVICES} \
+    ${MORI_NUM_QP_PER_PE:+-e MORI_NUM_QP_PER_PE=$MORI_NUM_QP_PER_PE} \
+    ${VLLM_MORIIO_QP_PER_TRANSFER:+-e VLLM_MORIIO_QP_PER_TRANSFER=$VLLM_MORIIO_QP_PER_TRANSFER} \
+    ${VLLM_MORIIO_NUM_WORKERS:+-e VLLM_MORIIO_NUM_WORKERS=$VLLM_MORIIO_NUM_WORKERS} \
     -e GPU_MEMORY_UTILIZATION=${GPU_MEMORY_UTILIZATION:-0.8} \
     -e GPUS_PER_NODE=${GPUS_PER_NODE:-8} \
-    -e GPU_MAX_HW_QUEUES=${GPU_MAX_HW_QUEUES:-} \
-    -e HIP_FORCE_DEV_KERNARG=${HIP_FORCE_DEV_KERNARG:-} \
-    -e HSA_NO_SCRATCH_RECLAIM=${HSA_NO_SCRATCH_RECLAIM:-} \
-    -e VLLM_HANDSHAKE_TIMEOUT_MINS=${VLLM_HANDSHAKE_TIMEOUT_MINS:-} \
-    -e VLLM_ENGINE_READY_TIMEOUT_S=${VLLM_ENGINE_READY_TIMEOUT_S:-} \
-    -e ROCSHMEM_HEAP_SIZE=${ROCSHMEM_HEAP_SIZE:-} \
-    -e ROCSHMEM_MAX_NUM_CONTEXTS=${ROCSHMEM_MAX_NUM_CONTEXTS:-} \
-    -e LOG_WAIT_TIMEOUT_SECONDS=${LOG_WAIT_TIMEOUT_SECONDS:-} \
+    ${GPU_MAX_HW_QUEUES:+-e GPU_MAX_HW_QUEUES=$GPU_MAX_HW_QUEUES} \
+    ${HIP_FORCE_DEV_KERNARG:+-e HIP_FORCE_DEV_KERNARG=$HIP_FORCE_DEV_KERNARG} \
+    ${HSA_NO_SCRATCH_RECLAIM:+-e HSA_NO_SCRATCH_RECLAIM=$HSA_NO_SCRATCH_RECLAIM} \
+    ${VLLM_HANDSHAKE_TIMEOUT_MINS:+-e VLLM_HANDSHAKE_TIMEOUT_MINS=$VLLM_HANDSHAKE_TIMEOUT_MINS} \
+    ${VLLM_ENGINE_READY_TIMEOUT_S:+-e VLLM_ENGINE_READY_TIMEOUT_S=$VLLM_ENGINE_READY_TIMEOUT_S} \
+    ${ROCSHMEM_HEAP_SIZE:+-e ROCSHMEM_HEAP_SIZE=$ROCSHMEM_HEAP_SIZE} \
+    ${ROCSHMEM_MAX_NUM_CONTEXTS:+-e ROCSHMEM_MAX_NUM_CONTEXTS=$ROCSHMEM_MAX_NUM_CONTEXTS} \
+    ${LOG_WAIT_TIMEOUT_SECONDS:+-e LOG_WAIT_TIMEOUT_SECONDS=$LOG_WAIT_TIMEOUT_SECONDS} \
     -e TRITON_CACHE_DIR=${TRITON_CACHE_DIR:-/tmp/vllm_cache/triton} \
     -e VLLM_CACHE_ROOT=${VLLM_CACHE_ROOT:-/tmp/vllm_cache/vllm} \
     -e COMGR_CACHE_DIR=${COMGR_CACHE_DIR:-/tmp/vllm_cache/comgr} \
@@ -481,8 +516,8 @@ docker run --rm \
     -e DISTRIBUTED_TIMEOUT_SECONDS=${DISTRIBUTED_TIMEOUT_SECONDS:-7200} \
     -e VLLM_RPC_TIMEOUT=${VLLM_RPC_TIMEOUT:-300000} \
     -e VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-3600} \
-    -e VLLM_CUDAGRAPH_MODE=${VLLM_CUDAGRAPH_MODE:-} \
-    -e CUDAGRAPH_CAPTURE_SIZES="${CUDAGRAPH_CAPTURE_SIZES:-}" \
+    ${VLLM_CUDAGRAPH_MODE:+-e VLLM_CUDAGRAPH_MODE=$VLLM_CUDAGRAPH_MODE} \
+    ${CUDAGRAPH_CAPTURE_SIZES:+-e CUDAGRAPH_CAPTURE_SIZES="$CUDAGRAPH_CAPTURE_SIZES"} \
     --name $DOCKER_CONT_NAME \
     $DOCKER_IMAGE_NAME -c "
         mkdir -p /run_logs/${SLURM_JOB_ID}


### PR DESCRIPTION
 Summary

  ## Summary

  - Add **33 madengine model cards** to `models.json` for three multi-node workloads using the `slurm_multi` launcher
  - Add **perf.csv** reporting across all three workloads for madengine result collection
  - Add benchmark log parsers (`parse_to_csv.py`, `parse_ep_to_csv.py`) for automated CSV generation

  ### Model Cards Breakdown

  | Workload | Cards | Tags | Backends |
  |----------|-------|------|----------|
  | sglang\_disagg | 16 | `pyt_sglang_disagg_{mori_io,mori_dp,mooncake}_<model>` | MoRI IO (7), MoRI DP (2), Mooncake/RIXLE (7) |
  | vllm\_disagg | 12 | `pyt_vllm_disagg_{nixl,mori,deepep}_<model>` | NIXL (6), MoRI (3), DeepEP (3) |
  | large\_ep | 5 | `pyt_large_ep_bench_{1n,2n,4n}[_mori_only]` | DeepEP+MoRI (2), MoRI-only scaling (3) |


<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

All cards use `"distributed": {"launcher": "slurm_multi"}` — madengine generates an SBATCH wrapper that exports `env_vars` (model name, backend flags, docker image) and
  calls the workload's SLURM script directly. No Docker build phase — each script manages its own containers via `srun docker run`.

  After benchmark completion, each workload's parser generates a `perf.csv` at `/run_logs/${SLURM_JOB_ID}/perf.csv` (inside the container), which madengine picks up for
  result reporting.

  ### Key Changes

  - **`models.json`**: 33 new model card entries (additions only, no changes to existing cards)
  - **`scripts/sglang_disagg/parse_to_csv.py`**: Extended with `--perf-csv` flag and madengine metadata columns
  - **`scripts/vllm_dissag/parse_to_csv.py`**: New parser for vLLM benchmark logs
  - **`scripts/vllm_dissag/run_xPyD_models.slurm`**: Script dir resolution fix, stale container cleanup, safe env var passthrough
  - **`scripts/large-ep-benchmark/parse_ep_to_csv.py`**: New parser for MoRI/DeepEP EP benchmark PrettyTable output
  - **`scripts/large-ep-benchmark/run_ep_bench.sh`**: `SKIP_DEEPEP` toggle, perf.csv generation, docker cleanup error suppression
  - **`docker/vllm_disagg_inference.ubuntu.amd.Dockerfile`**: MoRI `MORI_BRANCH` build arg, `pip install .` for MoRI, pyyaml dependency
  - **`README.md`**: Updated SGLang disagg row with backend names and DeepSeek-R1



  ### Test Plan

  - [x] sglang\_disagg: Llama-8B MoRI IO validated via madengine (job 33081, 78k tok/s; job 35868, 37.5k tok/s)
  - [x] sglang\_disagg: DeepSeek-V3 MoRI IO (job 33092, 9.1k tok/s)
  - [x] sglang\_disagg: DeepSeek-R1 MoRI DP (job 33141, 8.3k tok/s)
  - [x] vllm\_disagg: Llama-70B-FP8 NIXL (job 35853, 17.9k tok/s)
  - [x] large\_ep: 2N MoRI-only (job 35962, 69-74 GB/s dispatch/combine)
  - [x] perf.csv generated and collected by madengine for all 3 workloads

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
