### PR TITLE
pytorch-xdit:v26.6 release

### DIFF
--- a/docker/pyt_xdit.ubuntu.amd.Dockerfile
+++ b/docker/pyt_xdit.ubuntu.amd.Dockerfile
@@ -24,7 +24,7 @@
 # SOFTWARE.
 #
 #################################################################################
-ARG BASE_DOCKER=rocm/pytorch-xdit:v26.5
+ARG BASE_DOCKER=rocm/pytorch-xdit:v26.6
 FROM ${BASE_DOCKER} AS base
 
 RUN apt-get update && apt install -y lshw && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Purpose is to add pytorch-xdit:v26.6 image to MAD workflows and to publish it.

Work here contains

    Updated Dockerfile wrapping amdsiloai/pytorch-xdit:v26.6

which checked should be complete.

