### PR TITLE
Update pyt_wan2.1_inference.ubuntu.amd.Dockerfile

### DIFF
--- a/docker/pyt_wan2.1_inference.ubuntu.amd.Dockerfile
+++ b/docker/pyt_wan2.1_inference.ubuntu.amd.Dockerfile
@@ -53,8 +53,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 #For multigpu run, install following
 RUN pip install "xfuser>=0.4.1"
 
-# ROCm gpg key
-RUN wget -q -O - http://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+# ROCm gpg key (keyring method — avoids deprecated apt-key / gpg-agent)
+RUN apt-get update && apt-get install -y --no-install-recommends wget gnupg ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /etc/apt/trusted.gpg.d && \
+    wget -qO- https://repo.radeon.com/rocm/rocm.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/rocm.gpg
 RUN apt update && apt install -y \
     unzip \
     jq

--- a/docker/pyt_wan2.1_inference.ubuntu.amd.Dockerfile
+++ b/docker/pyt_wan2.1_inference.ubuntu.amd.Dockerfile
@@ -55,7 +55,7 @@ RUN pip install "xfuser>=0.4.1"
 
 # ROCm gpg key (keyring method — avoids deprecated apt-key / gpg-agent)
 RUN apt-get update && apt-get install -y --no-install-recommends wget gnupg ca-certificates && \
-    rm -rf /var/lib/apt/lists/* && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
     mkdir -p /etc/apt/trusted.gpg.d && \
     wget -qO- https://repo.radeon.com/rocm/rocm.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/rocm.gpg
 RUN apt update && apt install -y \


### PR DESCRIPTION
Motivation
The pyt_wan2.1_inference Docker build fails during the step that adds the ROCm APT repository key and installs unzip / jq. The existing Dockerfile uses the deprecated apt-key add flow:
wget ... rocm.gpg.key | sudo apt-key add -

apt-key is deprecated/removed
gpg-agent / keyring handling errors can block the build
The build never reaches later steps (flash-attention, Wan2.1 setup, benchmark run)
This blocks MAD validation for pyt_wan2.1_inference (Wan2.1-T2V-14B text-to-video, perf ID 2a7a4).

This PR fixes the GPG key installation so the Docker image can build and proceed to install required packages.

Technical Details
Replace deprecated apt-key add with the supported APT keyring flow: download https://repo.radeon.com/rocm/rocm.gpg.key, run gpg --dearmor, and write it to /etc/apt/trusted.gpg.d/rocm.gpg.

This avoids Ubuntu 24.04 / headless Docker build failures from apt-key and gpg-agent, so the following apt install unzip jq step can run for pyt_wan2.1_inference.

Tkt: https://amd-hub.atlassian.net/browse/ROCM-26422

Test Result
[pyt_wan2.1_inference_pyt_wan2.1_inference.txt](https://github.com/user-attachments/files/30258109/pyt_wan2.1_inference_pyt_wan2.1_inference.txt)



## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
