### PR TITLE
Update pyt_chai1_inference.ubuntu.amd.Dockerfile

### DIFF
--- a/docker/pyt_chai1_inference.ubuntu.amd.Dockerfile
+++ b/docker/pyt_chai1_inference.ubuntu.amd.Dockerfile
@@ -39,11 +39,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     git && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    python3 -m pip install --upgrade pip
+    python3 -m pip install --no-cache-dir --upgrade "pip>=26.0,<26.2"  # This version is required for chai_lab installation
 
 # numpy is reinstalled because of pandas compatibility issues, remove the lines below once base image moves to numpy>1.20.3
 RUN pip3 install -U numpy
 RUN pip3 install -U scipy
+RUN pip3 install filelock requests #  predict_structure.py imports & runs
 
 # Install pip-tools to compile the requirements.in file into requirements.txt
 RUN pip install pip-tools


### PR DESCRIPTION
Updated the dockerfile as per the failures in ROCM-28890

## Motivation

pip-compile fails during chai-lab install — upgrading pip to the latest release (≥26.2) breaks dependency resolution when compiling requirements.in inside the Dockerfile.
predict_structure.py fails at runtime — the benchmark script (scripts/pyt_chai1_inference/run.sh) invokes chai-lab/examples/predict_structure.py, which requires filelock and requests that are not present in the base image after the chai-lab install path.

## Technical Details

Pin pip to >=26.0,<26.2 (with --no-cache-dir) instead of an unconstrained pip install --upgrade pip, so pip-compile succeeds and chai-lab installs correctly.
Explicitly install filelock and requests before the pip-tools / chai-lab build steps so predict_structure.py imports and runs during the benchmark.

## Test Plan

 Build the Docker image: docker/pyt_chai1_inference.ubuntu.amd.Dockerfile

## Test Result

Validated on the equivalent branch in MAD-private ([AMD-ROCm-Internal/MAD-private#25](https://github.com/AMD-ROCm-Internal/MAD-private/pull/25)). Docker build and live benchmark completed successfully.

[pyt_chai1_inference_pyt_chai1_inference.ubuntu.amd.build.live.log](https://github.com/user-attachments/files/30600963/pyt_chai1_inference_pyt_chai1_inference.ubuntu.amd.build.live.log)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
