### PR TITLE
added vllm_disagg profiling

### DIFF
--- a/docker/vllm_disagg_inference.profiling.ubuntu.amd.Dockerfile
+++ b/docker/vllm_disagg_inference.profiling.ubuntu.amd.Dockerfile
@@ -1,0 +1,349 @@
+# CONTEXT {'gpu_vendor': 'AMD', 'guest_os': 'UBUNTU'}
+###############################################################################
+#
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#################################################################################
+# =============================================================================
+# vllm_disagg_inference.profiling.ubuntu.amd.Dockerfile
+#   ALL connectors in one image: moriio (TP + MoRI-EP wideEP) + rixl (NIXL TP +
+#   DeepEP wideEP). = the fullsource MoRI stack, plus a UCX/RIXL/rocSHMEM/DeepEP
+#   transport layer gated by --build-arg WITH_NIXL (default 1 = everything).
+#
+#   docker build --target profiling -f docker/vllm_disagg_inference.profiling.ubuntu.amd.Dockerfile \
+#     -t <your-registry>/vllm-disagg:local .
+#   export DOCKER_IMAGE_NAME=<your-registry>/vllm-disagg:local
+#
+#   WITH_NIXL=1 (default) => builds UCX + RIXL(+nixlbench) + rocSHMEM + DeepEP from
+#     source, so all four connector combos (moriio TP/wideEP, rixl NIXL TP, DeepEP
+#     wideEP) are present (~+30-45 min build vs WITH_NIXL=0).
+#   WITH_NIXL=0 => MoRI-EP only (moriio TP/wideEP + deepep-from-base); lean, faster.
+#
+# STATUS: built + validated on ci_base (WITH_NIXL=1). The moriio paths (TP + MoRI-EP
+# wideEP, incl. full DeepSeek-V3) are live-proven. rixl+TP builds and NIXL initializes,
+# but has an image-level PyNCCL all-reduce issue on this stack (tracked separately).
+# (BASE_IMAGE is a gated nightly; override --build-arg BASE_IMAGE=... as needed.)
+# =============================================================================
+# Reconstructs the validated v1.2.1 (mori121) runtime stack by applying the recipe's
+# component pins ON TOP of the open ROCm vLLM ci_base, cloning each source from
+# public Git (no local build-contexts). Mirrors dist-inf-cookbook
+# Dockerfile.vllm.mori121_shareable:
+#
+#   - BASE: rocm/vllm-dev:ci_base-0fcd9b99... (open ROCm 7.2 / cp312 CI base).
+#   - MoRI  -> built from ROCm/MoRI @ v1.2.1 (BUILD_UMBP=OFF).
+#   - AITER -> 0.1.16.post3 prebuilt rocm7.2 wheel + flydsl 0.2.2; stale JIT wiped.
+#   - vLLM  -> COMPILED from shikamd123/vllm @
+#     vllm_2p2d_wide-ep_write_shikpate_test_06_29_customer (Wide-EP multi-pod PD, the
+#     connector/router reference for the 2P2D DP=EP=16 topology). Full compile: it is
+#     a different commit than the base's, so a .py-only overlay would be ABI-mismatched.
+#   - RDMA fix (expandable_segments:False x2 + HSA_ENABLE_IPC_MODE_LEGACY=0) is NOT baked
+#     here — it lives in scripts/vllm_dissag/connectors/<connector>.env and the launcher
+#     forwards it via docker -e. ROCm 7.2.3 cannot dmabuf-export VMM memory, else MoRI
+#     RegisterRdmaMemoryRegion EFAULTs (errno 14) on the first disagg WRITE.
+#   - vllm-router (vllm-project/router PR#181 = DP-rank round-robin + 2P2D KV-notify
+#     dpfix) built in -> no external router binary needed.
+#   - validated recipe knobs baked as ENV. The MoRIIO disagg fixes (#39276 notify,
+#     #41751 LL split, DP-rank hash-failsafe) are native in this vLLM (no runtime patcher).
+#
+# Build context = repo root:
+#   docker build --target profiling -f docker/vllm_disagg_inference.profiling.ubuntu.amd.Dockerfile -t <registry>/<tag> .
+#
+# BASE_IMAGE is the open rocm/vllm-dev ci_base pinned by the validated recipe
+# (dist-inf-cookbook Dockerfile.vllm.mori121_shareable). Override --build-arg
+# BASE_IMAGE=... to build on a different ROCm base. vLLM compile is long (~30-60 min).
+# =============================================================================
+
+ARG BASE_IMAGE=rocm/vllm-dev:ci_base-0fcd9b99cc9d63202da4c858d8ebc6582c9e2491
+FROM ${BASE_IMAGE} AS perfetto_builder
+ARG PERFETTO_REPO=https://github.com/google/perfetto.git
+ARG PERFETTO_COMMIT=c794fceabe584dc9172e5512aaaeecc21019a635
+
+RUN git clone --filter=blob:none "${PERFETTO_REPO}" /perfetto && \
+    git -C /perfetto checkout --detach "${PERFETTO_COMMIT}" && \
+    test "$(git -C /perfetto rev-parse HEAD)" = "${PERFETTO_COMMIT}" && \
+    cd /perfetto && \
+    tools/install-build-deps --no-dev-tools \
+        --build-os linux --build-arch x64 && \
+    tools/gn gen out/linux --args='is_debug=false' && \
+    tools/ninja -C out/linux traceconv && \
+    test -x out/linux/traceconv && \
+    out/linux/traceconv --version
+FROM ${BASE_IMAGE} AS runtime
+
+ENTRYPOINT []
+WORKDIR /app
+
+ARG GFX_COMPILATION_ARCH="gfx942"
+ARG PYTORCH_ROCM_ARCH="gfx942"
+ARG MAX_JOBS=32
+# NIXL/RIXL transport for the rixl connector. Default 1 => all connectors built
+# (UCX/RIXL/rocSHMEM/DeepEP). Set --build-arg WITH_NIXL=0 for a lean MoRI-EP-only image.
+ARG WITH_NIXL=1
+ARG NIC_COMPILATION_ARCH="cx7"
+
+# -----------------------------------------------------------------------------
+# 1. MoRI: replace the base's bundled MoRI with the validated ROCm/MoRI @ v1.2.1
+#    (the version for the 06_29 mori121 image, dist-inf-cookbook
+#    Dockerfile.vllm.mori121_shareable). v1.2.1 carries the EP/RDMA correctness fixes
+#    plus the ROCm-7.2.3 dmabuf registration path used by the connector .env
+#    (expandable_segments:False). MoRI is JIT-built, so this swaps the JIT sources the
+#    kernels compile from at runtime.
+#    BUILD CONFIG: match the cookbook build — MORI_GPU_ARCHS=gfx942, BUILD_UMBP=OFF,
+#    DEFAULT NIC backends. Do NOT pass USE_IONIC=OFF / USE_BNXT=OFF: disabling NIC
+#    backends produced a MoRI that deadlocked at the cross-node EP all-to-all init.
+# -----------------------------------------------------------------------------
+ARG MORI_REPO=https://github.com/ROCm/mori.git
+ARG MORI_REF=v1.2.1
+ENV MORI_GPU_ARCHS=gfx942
+# Newer MoRI added the UMBP subsystem which requires gRPC (grpcpp/grpcpp.h) not
+# present in this base; UMBP is unrelated to the EP dispatch/combine kernels, so
+# disable it to avoid pulling in a gRPC build dependency.
+ENV BUILD_UMBP=OFF BUILD_UMBP_SPDK=OFF
+# Build/install matches dist-inf-cookbook Dockerfile.vllm.mori121_shareable for v1.2.1:
+# `BUILD_UMBP=OFF pip install .` (default build isolation). apt/pip build tooling kept
+# for bases that lack it; harmless where already present.
+RUN sed -i 's|http://|https://|g' /etc/apt/sources.list 2>/dev/null || true && \
+    sed -i 's|http://|https://|g' /etc/apt/sources.list.d/*.list 2>/dev/null || true && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        git build-essential cmake ninja-build ccache libssl-dev pkg-config curl ca-certificates \
+        libpci-dev libibverbs-dev && \
+    pip install meson==0.64.0 "pybind11[global]" tqdm prettytable && \
+    pip uninstall -y amd_mori amd-mori amd-mori-nightly mori 2>/dev/null || true && \
+    rm -rf /tmp/mori-src && \
+    git clone --recursive "${MORI_REPO}" /tmp/mori-src && \
+    cd /tmp/mori-src && git checkout "${MORI_REF}" && git submodule update --init --recursive && cd / && \
+    BUILD_UMBP=OFF pip install /tmp/mori-src && \
+    python3 -c "import mori, mori.io, mori.ops; print('MoRI OK at', mori.__path__[0])" && \
+    mkdir -p /app && echo "MORI_REF=${MORI_REF}@$(git -C /tmp/mori-src rev-parse HEAD)" >> /app/versions.txt && \
+    rm -rf /tmp/mori-src
+
+# -----------------------------------------------------------------------------
+# 2. AITER: install 0.1.16.post3 (prebuilt rocm7.2 wheel + flydsl 0.2.2), then
+#    invalidate the stale prewarmed AITER JIT cache compiled against the old .so.
+# -----------------------------------------------------------------------------
+ARG AITER_VERSION=0.1.16.post3
+ARG AITER_WHEEL_URL="https://github.com/ROCm/aiter/releases/download/v0.1.16.post3/amd_aiter-0.1.16.post3%2Brocm7.2.manylinux.2.28-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+RUN echo "Bumping AITER to ${AITER_VERSION} from ${AITER_WHEEL_URL}" && \
+    _W="/tmp/$(basename "${AITER_WHEEL_URL}" | sed 's/%2B/+/g')" && \
+    curl -fL --retry 3 --retry-delay 2 -o "${_W}" "${AITER_WHEEL_URL}" && \
+    (pip uninstall -y amd_aiter amd-aiter aiter 2>/dev/null || true) && \
+    pip install --no-deps "${_W}" && \
+    pip install "flydsl==0.2.2" && \
+    rm -f "${_W}" && \
+    python3 - <<'PYEOF'
+from importlib.metadata import version as v, PackageNotFoundError
+vm = None
+for n in ("amd-aiter", "amd_aiter", "aiter"):
+    try: vm = v(n); break
+    except PackageNotFoundError: pass
+assert vm and vm.split("+", 1)[0] == "0.1.16.post3", f"AITER not 0.1.16.post3: {vm!r}"
+print("AITER OK:", vm)
+PYEOF
+RUN rm -rf /opt/vllm_cache/aiter_jit /root/.aiter && echo "cleared stale AITER JIT cache" && \
+    echo "AITER_VERSION=${AITER_VERSION}" >> /app/versions.txt
+
+# -----------------------------------------------------------------------------
+# 3. vLLM: compile from source at the 06_29 validated Wide-EP WRITE-mode branch
+#    (matches the published dist-inf-cookbook mori121 image). Full source compile
+#    (the base ships a different commit). The MoRIIO disagg fixes (#39276 notify,
+#    #41751 LL split, DP-rank hash-failsafe) are native in this branch, so no runtime
+#    patcher is needed. Override VLLM_REF to rebuild a different commit; build only
+#    committed commits (no working-tree edits).
+# -----------------------------------------------------------------------------
+# VLLM_REPO/REF are a PUBLIC GitHub repo + branch (the Wide-EP WRITE-mode vLLM the
+# dist-inf-cookbook mori121 image builds from). Override to your own vLLM fork/branch.
+ARG VLLM_REPO=https://github.com/shikamd123/vllm.git
+ARG VLLM_REF=vllm_2p2d_wide-ep_write_shikpate_test_06_29_customer
+ENV VLLM_TARGET_DEVICE=rocm \
+    PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} \
+    MAX_JOBS=${MAX_JOBS}
+RUN rm -rf /tmp/vllm-src && \
+    git clone "${VLLM_REPO}" /tmp/vllm-src && \
+    cd /tmp/vllm-src && git checkout "${VLLM_REF}" && \
+    echo "VLLM_REF=${VLLM_REF}@$(git rev-parse HEAD)" >> /app/versions.txt && \
+    pip uninstall -y vllm 2>/dev/null || true && \
+    pip install setuptools_rust && \
+    pip install --no-deps --no-build-isolation -v . && \
+    python3 -c "import vllm; print('vLLM', vllm.__version__, 'from', vllm.__file__)" && \
+    rm -rf /tmp/vllm-src
+
+# Cross-check MoRI + AITER survived the vLLM install (no silent downgrade).
+RUN python3 - <<'PYEOF'
+from importlib.metadata import version as v, PackageNotFoundError
+def get(names):
+    for n in names:
+        try: return v(n)
+        except PackageNotFoundError: pass
+    return None
+av = get(("amd-aiter", "amd_aiter", "aiter"))
+assert av and av.split("+", 1)[0] == "0.1.16.post3", f"AITER downgraded: {av!r}"
+import mori, mori.io, mori.ops
+print("Post-vLLM check OK: AITER", av, "+ MoRI importable")
+PYEOF
+
+# -----------------------------------------------------------------------------
+# 4. vllm-router (DP-rank round-robin + MoRIIO connector) — built in, so NO
+#    external vllm-router binary is needed (leave ROUTER_BINARY unset).
+#    Source = vllm-project/router PR #181 branch, which now carries BOTH the
+#    round-robin DP-rank fix (11841c0d) AND the 2P2D KV-notify fix (6409ac1:
+#    remote_dp_rank_override + remote_dp_size). The KV-notify fix is REQUIRED:
+#    without it the 2P2D EP=16 run reproducibly wedges with "remote blocks never
+#    arrived" deferred-write expiries (decode notify targets the wrong DP rank).
+#    This is the exact source of the validated vllm-router-2p2d-dpfix binary.
+#    Pinned Rust toolchain (>=1.88: router deps time/home require rustc 1.88).
+# -----------------------------------------------------------------------------
+ARG ROUTER_REPO=https://github.com/raviguptaamd/router.git
+ARG ROUTER_REF=ravgupta/discovery-dp-rank-roundrobin
+ARG RUST_TOOLCHAIN=1.88.0
+RUN if ! command -v cargo >/dev/null 2>&1; then \
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "${RUST_TOOLCHAIN}"; \
+    fi && \
+    export PATH="/root/.cargo/bin:${PATH}" && \
+    rm -rf /tmp/vllm-router-src && \
+    git clone --filter=blob:none "${ROUTER_REPO}" /tmp/vllm-router-src && \
+    cd /tmp/vllm-router-src && git checkout "${ROUTER_REF}" && \
+    cargo build --release && \
+    install -m 755 target/release/vllm-router /usr/local/bin/vllm-router && \
+    vllm-router --help 2>&1 | grep -q moriio && \
+    echo "VLLM_ROUTER_REF=${ROUTER_REPO}@${ROUTER_REF}@$(git -C /tmp/vllm-router-src rev-parse HEAD)" >> /app/versions.txt && \
+    rm -rf /tmp/vllm-router-src
+
+# -----------------------------------------------------------------------------
+# 4b. WITH_NIXL=1 (default): UCX + RIXL(+nixlbench) + rocSHMEM + DeepEP from source,
+#     so the rixl connector (NIXL TP + DeepEP wideEP) is present. Single guarded RUN so
+#     WITH_NIXL=0 skips it entirely (no layers, no cost). Build-verified on ci_base.
+# -----------------------------------------------------------------------------
+ENV _ROCM_DIR=/opt/rocm \
+    _UCX_SOURCE=https://github.com/ROCm/ucx.git \
+    _UCX_BRANCH=da3fac2a \
+    _UCX_INSTALL_DIR=/usr/local/ucx/ \
+    _RIXL_SOURCE=https://github.com/ROCm/RIXL.git \
+    _RIXL_BRANCH=f33a5599 \
+    _RIXL_INSTALL_DIR=/usr/local/RIXL/install \
+    _NIXLBENCH_INSTALL_DIR=/usr/local/RIXL
+RUN if [ "${WITH_NIXL}" != "1" ]; then \
+      echo "WITH_NIXL=${WITH_NIXL}: skipping UCX/RIXL/rocSHMEM/DeepEP (MoRI-EP + base DeepEP only)"; \
+    else set -e && \
+      echo "WITH_NIXL=1: building UCX + RIXL + rocSHMEM + DeepEP" && \
+      apt-get update && apt-get install -y \
+        autoconf automake libtool autogen pkg-config m4 gcc make \
+        librdmacm-dev rdmacm-utils infiniband-diags ibverbs-utils perftest ethtool \
+        libibverbs-dev rdma-core strace libgflags-dev \
+        libaio-dev liburing-dev libcpprest-dev libgrpc-dev libgrpc++-dev \
+        libprotobuf-dev protobuf-compiler-grpc wget && \
+      pip install meson==0.64.0 "pybind11[global]" pyyaml && \
+      # UCX
+      cd /tmp && git clone "${_UCX_SOURCE}" && cd ucx && git checkout "${_UCX_BRANCH}" && \
+        ./autogen.sh && mkdir -p build && cd build && \
+        ../configure --prefix="${_UCX_INSTALL_DIR}" --with-rocm="${_ROCM_DIR}" \
+          --disable-go --disable-java --disable-assertions --enable-mt && \
+        make -j && make install && \
+      # googletest (RIXL dep)
+      cd /tmp && wget -q https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz && \
+        tar -xzf v1.14.0.tar.gz && cd googletest-1.14.0 && mkdir -p build && cd build && \
+        cmake -DBUILD_SHARED_LIBS=on .. && make -j && make install && \
+      # RIXL + python bindings
+      cd /tmp && git clone "${_RIXL_SOURCE}" && cd RIXL && git checkout "${_RIXL_BRANCH}" && \
+        meson setup build/ --prefix="${_RIXL_INSTALL_DIR}" -Ducx_path="${_UCX_INSTALL_DIR}" \
+          -Ddisable_gds_backend=true -Dcudapath_inc="${_ROCM_DIR}/include" -Dcudapath_lib="${_ROCM_DIR}/lib" && \
+        cd build && ninja && ninja install && cd /tmp/RIXL && \
+        pip install --config-settings=setup-args="-Dcudapath_inc=${_ROCM_DIR}/include" \
+                    --config-settings=setup-args="-Dcudapath_lib=${_ROCM_DIR}/lib" \
+                    --config-settings=setup-args="-Ducx_path=${_UCX_INSTALL_DIR}" \
+                    --config-settings=setup-args="-Ddisable_gds_backend=true" . && \
+      # rocSHMEM (DeepEP dep)
+      cd /tmp && git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-systems.git && \
+        cd rocm-systems && git sparse-checkout set --cone projects/rocshmem && git checkout develop && \
+        mkdir -p /tmp/rocshmem-build && cd /tmp/rocshmem-build && \
+        /tmp/rocm-systems/projects/rocshmem/scripts/build_configs/all_backends \
+          -DUSE_EXTERNAL_MPI=OFF -DGPU_TARGETS="${GFX_COMPILATION_ARCH}" && \
+      # DeepEP (build develop against the installed vLLM/torch)
+      cd /tmp && git clone https://github.com/ROCm/DeepEP.git && cd DeepEP && \
+        PYTORCH_ROCM_ARCH="${GFX_COMPILATION_ARCH}" CFLAGS="-O3 -fPIC" \
+          CXXFLAGS="-O3 -fPIC --offload-arch=${GFX_COMPILATION_ARCH}" HIP_CXX_FLAGS="-O3 -fPIC" \
+          python3 setup.py --variant rocm --nic "${NIC_COMPILATION_ARCH}" build develop && \
+      echo "WITH_NIXL build complete" >> /app/versions.txt && \
+      rm -rf /tmp/ucx /tmp/googletest-1.14.0 /tmp/v1.14.0.tar.gz /tmp/rocm-systems /tmp/rocshmem-build; \
+    fi
+ENV LD_LIBRARY_PATH="/usr/local/ucx/lib:/usr/local/lib:/usr/local/RIXL/install/lib:${LD_LIBRARY_PATH}" \
+    PATH="/usr/local/ucx/bin:${PATH}"
+
+# -----------------------------------------------------------------------------
+# 5. Cache locations (structural: WHERE the JIT/compile caches live in the image).
+#    These are the mount target for the launcher's persistent host JIT cache.
+# -----------------------------------------------------------------------------
+# The image ships NO runtime recipe / tuning / platform ENV. By design, everything
+# run-tunable is applied at launch, so this image stays a clean binary/library artifact
+# and the same image serves any model/cluster without a rebuild:
+#   - model-serving recipe (KV_BLOCK_SIZE, KV_CACHE_DTYPE, *_CUDAGRAPH_MODE, *_MORI_BACKEND,
+#     GPU_MEMORY_UTILIZATION, KV_CACHE_MEMORY_BYTES, VLLM_ROCM_USE_AITER_MLA, ...)
+#       -> scripts/vllm_dissag/models.yaml   (per-model env:, so dense vs MoE differ)
+#   - ROCm-7.2.3 GPU-RDMA platform env (expandable_segments:False x2, MORI_GPU_ARCHS,
+#     HSA_ENABLE_IPC_MODE_LEGACY=0, HSA_NO_SCRATCH_RECLAIM) and the MoRI/RDMA fabric
+#     tuning (MORI_RDMA_TC/SL, MORI_IB_GID_INDEX, MORI_NUM_QP_PER_PE, VLLM_MORIIO_*, ...)
+#       -> scripts/vllm_dissag/connectors/<connector>.env  (cluster-editable, no rebuild)
+# The slurm launcher forwards both via `docker -e` (platform env must reach PID 1 -
+# PyTorch reads alloc-conf at import). Running this image WITHOUT the launcher: set the
+# vars you need yourself (see connectors/moriio.env + models.yaml for the values).
+ENV AITER_JIT_DIR=/opt/vllm_cache/aiter_jit \
+    VLLM_CACHE_ROOT=/opt/vllm_cache/vllm \
+    TRITON_CACHE_DIR=/opt/vllm_cache/triton \
+    COMGR_CACHE_DIR=/opt/vllm_cache/comgr
+
+# -----------------------------------------------------------------------------
+# 6. CRITICAL: scrub build-time MoRI JIT state. The `import mori` verification
+#    steps above compile/lock MoRI EP kernels under /root/.mori/jit on THIS build
+#    host, leaving stale .hsaco.lock files (ep_internode_v1, ep_internode_v1ll, ...).
+#    At runtime on the cluster, MoriAll2AllManager finds those locks, waits on a
+#    build-in-progress whose owner PID is long gone, and DEADLOCKS at ep:0 init.
+#    A clean image ships /root/.mori empty -> runtime compiles fresh.
+#    Clearing these makes the from-source image boot clean on 2P2D/4P4D.
+# -----------------------------------------------------------------------------
+RUN rm -rf /root/.mori /tmp/mori_jit_* && mkdir -p /root/.mori && \
+    echo "JIT_SCRUBBED: /root/.mori + /tmp/mori_jit_* cleared at build end" >> /app/versions.txt
+
+RUN cat /app/versions.txt 2>/dev/null | tail -20 || true
+
+FROM runtime AS profiling
+ARG PROFILING_MORI_REPO=https://github.com/AakarshAMD/mori-fork.git
+ARG PROFILING_MORI_COMMIT=ac44f1aaeb1887985dce2b9bdf82f54c19d008f9
+RUN (pip uninstall -y amd_mori amd-mori amd-mori-nightly mori 2>/dev/null || true) && \
+    rm -rf /tmp/mori-src && \
+    git clone "${PROFILING_MORI_REPO}" /tmp/mori-src && \
+    git -C /tmp/mori-src checkout --detach "${PROFILING_MORI_COMMIT}" && \
+    test "$(git -C /tmp/mori-src rev-parse HEAD)" = "${PROFILING_MORI_COMMIT}" && \
+    git -C /tmp/mori-src submodule update --init --recursive \
+        3rdparty/spdlog 3rdparty/msgpack-c && \
+    BUILD_UMBP=OFF pip install /tmp/mori-src && \
+    python3 -c "import mori, mori.io, mori.ops; print('Profiling MoRI OK at', mori.__path__[0])" && \
+    sed -i '/^MORI_REF=/d' /app/versions.txt && \
+    echo "MORI_REF=${PROFILING_MORI_REPO}@${PROFILING_MORI_COMMIT}" >> /app/versions.txt && \
+    rm -rf /tmp/mori-src /root/.mori /tmp/mori_jit_* && \
+    mkdir -p /root/.mori
+COPY --from=perfetto_builder \
+    /perfetto/out/linux/traceconv \
+    /usr/local/bin/traceconv
+ENV TRACECONV=/usr/local/bin/traceconv
+RUN /usr/local/bin/traceconv --version
+
+FROM runtime AS normal

--- a/scripts/vllm_dissag/ARCHITECTURE.md
+++ b/scripts/vllm_dissag/ARCHITECTURE.md
@@ -15,7 +15,7 @@ flowchart TB
     user([user / CI]) -->|"sbatch + env\n(CONNECTOR, WIDE_EP, EP_BACKEND,\nMODEL_NAME, xP, yD, RUN_MORI/RUN_DEEPEP)"| slurm
 
     subgraph host["Submit host"]
-        slurm["run_xPyD_models.slurm\n• resolve script dir\n• validate MODEL_NAME (VALID_MODELS)\n• axis resolution + back-compat shim\n• pick nodes, gather IPs\n• docker run per node (-e env plumb)"]
+        slurm["run_xPyD_models.slurm\n• resolve script dir\n• validate MODEL_NAME (VALID_MODELS)\n• axis resolution + back-compat shim\n• pick nodes, gather IPs\n• docker run per node (-e env plumb)\n• profile post-processing + status propagation"]
     end
 
     slurm -->|"srun + docker run\n(one container per node)"| n0
@@ -31,7 +31,7 @@ flowchart TB
     end
 
     subgraph driverbox["Inside each container: vllm_disagg.sh (the one launcher)"]
-        driver["DRIVER\n• axis select + validate\n• topology math\n• models.yaml parse\n• role branch\n• barrier / benchmark / cleanup"]
+        driver["DRIVER\n• axis select + validate\n• topology math\n• models.yaml parse\n• role branch\n• barrier / benchmark / cleanup\n• profile shutdown/failure handling"]
         para["parallelism.sh\nTP vs wideEP arg helpers"]
         yaml[("models.yaml\nper-model flags + env")]
         conn{{"connectors/<CONNECTOR>.sh"}}
@@ -47,7 +47,7 @@ flowchart TB
     n0 --> driverbox
     driver -->|connector_launch_worker| vllm[["vllm serve\n(prefill / decode worker)"]]
     driver -->|rank 0 only| proxy[["proxy / router\n(co-located)"]]
-    proxy --> bench["benchmark_xPyD.sh\n→ *_CONCURRENCY.log"]
+    proxy --> bench["RUN_PROFILE=0: benchmark_xPyD.sh\nRUN_PROFILE=1: benchmark_xPyD_profile.sh\n→ *_CONCURRENCY.log"]
 ```
 
 ---
@@ -96,7 +96,7 @@ flowchart TD
 flowchart LR
     subgraph TP["WIDE_EP=0  (TP, PARALLEL_MODE=tp)"]
         rt["rixl + TP\nNixlConnector\n--tensor-parallel-size"]
-        mt["moriio + TP  (NEW)\nMoRIIOConnector\n--tensor-parallel-size"]
+        mt["moriio + TP\nMoRIIOConnector\n--tensor-parallel-size"]
     end
     subgraph EP["WIDE_EP=1  (wideEP, PARALLEL_MODE=dp)"]
         rd["rixl + deepep\nNixlConnector\n-tp 1 --data-parallel-size\n--enable-expert-parallel\n--all2all-backend deepep_*"]
@@ -239,5 +239,6 @@ flowchart TD
 | `tests/run_all.sh` | runs all offline gates (gate_check + argv_assert) |
 | `tests/{drive_cell,harvest,run_interactive}.sh` | interactive-allocation live-test drivers |
 | `tests/TEST_PLAN.md` | before/after verification plan |
-| `benchmark_xPyD.sh`, `benchmark_long_context.sh`, `benchmark_niah.{sh,py}`, `benchmark_parser.py`, `parse_to_csv.py` | benchmark + parsing (NIAH = long-context retrieval, vllm#47042) |
+| `benchmark_xPyD.sh`, `benchmark_xPyD_profile.sh`, `benchmark_long_context.sh`, `benchmark_niah.{sh,py}`, `benchmark_parser.py`, `parse_to_csv.py` | normal/profile benchmark + parsing (NIAH = long-context retrieval, vllm#47042) |
+| `moriio_profiling/{hooks.sh,process_kernels.sh,trace_tools.py}` | profiling wrap, bounded shutdown/failure handling, and post-processing |
 | `socket_barrier.py`, `socket_wait.py`, `salloc_launch.sh` | node coordination + salloc helper |

--- a/scripts/vllm_dissag/README.MD
+++ b/scripts/vllm_dissag/README.MD
@@ -82,6 +82,62 @@ Then `export DOCKER_IMAGE_NAME=<tag>` (or a published image) before submitting. 
 `docker pull`s the image on every node, so a local-only tag must be pushed to a registry the nodes
 can reach.
 
+### MoRIIO profiling
+
+From the repository root, build the dedicated profiling target. The normal
+`docker/vllm_disagg_inference.ubuntu.amd.Dockerfile` is not used for profiling.
+
+```bash
+PROFILING_IMAGE="<profiling-image>"  # replace with a registry tag you will push
+docker build --target profiling --build-arg WITH_NIXL=0 \
+  -f docker/vllm_disagg_inference.profiling.ubuntu.amd.Dockerfile \
+  -t "$PROFILING_IMAGE" .
+```
+
+From the repository root, submit this bounded 1P/1D MoRIIO TP profile:
+
+```bash
+cd scripts/vllm_dissag
+PROFILING_IMAGE="<profiling-image>"  # replace with the pushed tag or digest
+RUN_PROFILE=1 \
+CONNECTOR=moriio \
+RUN_MORI=0 \
+RUN_DEEPEP=0 \
+MORIIO_REQID_MAP=1 \
+DOCKER_IMAGE_NAME="$PROFILING_IMAGE" \
+MODEL_NAME=amd-Llama-3.3-70B-Instruct-FP8-KV \
+WIDE_EP=0 \
+xP=1 \
+yD=1 \
+GPUS_PER_NODE=8 \
+SKIP_WARMUP=1 \
+BENCHMARK_SCRIPT=sweep \
+BENCHMARK_ITR=1 \
+BENCHMARK_NUM_PROMPTS=1 \
+BENCHMARK_CON="1" \
+BENCHMARK_COMBINATIONS="256/8" \
+sbatch --export=ALL --partition=amd-rccl --time=02:00:00 --gres=gpu:8 \
+  -N 2 -n 2 run_xPyD_models.slurm
+```
+
+`RUN_PROFILE=1` does not select the connector. Profiling requires the effective
+connector to be `moriio`; otherwise `run_xPyD_models.slurm` prints
+`CONNECTOR=moriio is required when RUN_PROFILE=1`, while direct
+`vllm_disagg.sh` invocation prints `mori must be on for profiling`. Both write
+to stderr and exit `1` before profile-helper checks, sourcing, or container
+launch. `MORIIO_REQID_MAP` defaults to `0`; exact
+`1` enables request mapping. Profiling defaults `SKIP_WARMUP=1`, which keeps
+warmup traffic out of the measured trace; set it explicitly to `0` to include
+warmup.
+
+**Because rocprof records one continuous server-lifetime trace, use one
+preferably small concurrency value, one preferably small ISL/OSL combination,
+one iteration, and one preferably small request count; keep OSL especially
+small.**
+
+See [moriio_profiling/README.md](moriio_profiling/README.md) for detailed model,
+topology, artifact, and validation guidance.
+
 ## Quick start
 
 ```bash
@@ -200,7 +256,7 @@ but each combo also needs the connector's transport built into the image:
 | rixl + TP | needs a NIXL-validated image | NixlConnector + working NCCL TP path |
 | rixl + wideEP (deepep) | needs a DeepEP-validated image | DeepEP all2all kernels |
 
-The `mori_ep_fullsource` Dockerfile builds the MoRI stack; rixl/DeepEP combos need an image
+The `docker/vllm_disagg_inference.ubuntu.amd.Dockerfile` builds the MoRI stack; rixl/DeepEP combos need an image
 where those transports are validated (e.g. develop's `vllm_disagg_inference` for NIXL).
 
 ## DeepEP options (optional)

--- a/scripts/vllm_dissag/benchmark_xPyD_profile.sh
+++ b/scripts/vllm_dissag/benchmark_xPyD_profile.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -uo pipefail
+
+timestamp=$(date "+%Y%m%d_%H%M%S")
+BENCHMARK_PORT="${BENCHMARK_PORT:-2584}"
+BENCHMARK_ITR="${BENCHMARK_ITR:-1}"
+LOG="/run_logs/${SLURM_JOB_ID}/benchmark_${SLURM_JOB_ID}_${timestamp}_xP${xP}_yD${yD}_$MODEL_NAME"
+TIMING_LOG="/run_logs/${SLURM_JOB_ID}/benchmark_timing.jsonl"
+TRACE_TOOLS="$NIXL_COOKBOOK_PATH/moriio_profiling/trace_tools.py"
+
+record_benchmark_marker() {
+    local event="$1" step_id="$2" iteration="$3" isl="$4" osl="$5" con="$6" prompts="$7" rc="${8:-}"
+    local -a args=(benchmark-marker --out "$TIMING_LOG" --event "$event" --step-id "$step_id"
+        --iteration "$iteration" --isl "$isl" --osl "$osl" --concurrency "$con" --num-prompts "$prompts")
+    [[ -z "$rc" ]] || args+=(--return-code "$rc")
+    PYTHONDONTWRITEBYTECODE=1 python3 "$TRACE_TOOLS" "${args[@]}" || {
+        echo "ERROR: failed to record benchmark $event marker for $step_id" >&2
+        return 1
+    }
+}
+
+echo "==== Benchmark Serving Concurrency Sweep Test ${LOG} ===== "
+echo "Benchmark Port: ${BENCHMARK_PORT}"
+echo "UTC Time: $(TZ=UTC date '+%Y-%m-%d %H:%M:%S %Z')" | tee -a ${LOG}_CONCURRENCY.log >/dev/null
+echo "PST Time: $(TZ=America/Los_Angeles date '+%Y-%m-%d %H:%M:%S %Z')" | tee -a ${LOG}_CONCURRENCY.log >/dev/null
+
+sleep 10
+if [[ "${SKIP_WARMUP:-0}" != "1" ]]; then
+    WARMUP_CON="${WARMUP_CON:-1}"
+    WARMUP_PROMPTS="${WARMUP_PROMPTS:-16}"
+    WARMUP_ISL="${WARMUP_ISL:-32}"
+    WARMUP_OSL="${WARMUP_OSL:-32}"
+    echo "Warmup run: ${WARMUP_PROMPTS} prompts @ con=${WARMUP_CON} isl=${WARMUP_ISL} osl=${WARMUP_OSL}" | tee -a ${LOG}_CONCURRENCY.log >/dev/null
+    vllm bench serve \
+        --model $MODEL_PATH \
+        --backend vllm \
+        --host 127.0.0.1 \
+        --port $BENCHMARK_PORT \
+        --dataset-name "random" \
+        --random-input-len $WARMUP_ISL \
+        --random-output-len $WARMUP_OSL \
+        --random-prefix-len 0 \
+        --num-prompts $WARMUP_PROMPTS \
+        --request-rate "inf" \
+        --ignore-eos \
+        --max-concurrency $WARMUP_CON \
+        2>&1 | tee -a ${LOG}_CONCURRENCY.log >/dev/null
+    echo ""
+else
+    echo "Warmup skipped (SKIP_WARMUP=1)" | tee -a ${LOG}_CONCURRENCY.log >/dev/null
+fi
+
+CON="${BENCHMARK_CON:-8 16 32 64 128 256 512}"
+IFS=' ' read -ra COMBINATIONS <<< "${BENCHMARK_COMBINATIONS:-1024/1024 8192/1024 1024/8192}"
+
+echo "Benchmarking iterations: $BENCHMARK_ITR" | tee -a ${LOG}_CONCURRENCY.log >/dev/null
+for i in $(seq 1 $BENCHMARK_ITR); do
+    echo "Running the benchserving script for iter: $i" | tee -a ${LOG}_CONCURRENCY.log >/dev/null
+    for combo in "${COMBINATIONS[@]}"; do
+       IFS="/" read -r isl osl <<< "$combo"
+       for con in $CON; do
+           p_con=$(($con * 2))
+           if [ "$p_con" -lt 16 ]; then
+               p_con=16
+           fi
+           if [ -n "${BENCHMARK_NUM_PROMPTS:-}" ]; then
+               p_con=$BENCHMARK_NUM_PROMPTS
+           fi
+           _base_timeout="${STEP_TIMEOUT:-1800}"
+           _total_tok=$(( isl + osl ))
+           _scaled_timeout=$(( _base_timeout * _total_tok / 2048 ))
+           if [ "$_scaled_timeout" -lt "$_base_timeout" ]; then
+               _scaled_timeout=$_base_timeout
+           fi
+           echo "[RUNNING] prompts $p_con isl $isl osl $osl con $con (timeout ${_scaled_timeout}s)" \
+               | tee -a ${LOG}_CONCURRENCY.log >/dev/null
+           _step_id="iter${i}_isl${isl}_osl${osl}_con${con}"
+           record_benchmark_marker start "$_step_id" "$i" "$isl" "$osl" "$con" "$p_con" || exit 1
+           timeout $_scaled_timeout vllm bench serve \
+           --model $MODEL_PATH \
+           --backend vllm \
+           --host 127.0.0.1 \
+           --port $BENCHMARK_PORT \
+           --dataset-name "random" \
+           --random-input-len $isl \
+           --random-output-len $osl \
+           --random-prefix-len 0 \
+           --num-prompts $p_con \
+           --request-rate "inf" \
+           --ignore-eos \
+           --max-concurrency $con \
+           2>&1 | tee -a ${LOG}_CONCURRENCY.log >/dev/null
+           rc=${PIPESTATUS[0]}
+           record_benchmark_marker end "$_step_id" "$i" "$isl" "$osl" "$con" "$p_con" "$rc" || exit 1
+           if [ $rc -eq 124 ]; then
+               echo "[STALL] isl=$isl osl=$osl con=$con timed out after ${_scaled_timeout}s" \
+                   | tee -a ${LOG}_CONCURRENCY.log ${LOG}_STALLS.log >/dev/null
+           fi
+
+       sleep 10
+        done
+    done
+done
+python3 $NIXL_COOKBOOK_PATH/parse_to_csv.py ${LOG}_CONCURRENCY.log -o ${LOG}_CONCURRENCY.csv \
+	--perf-csv /run_logs/${SLURM_JOB_ID}/perf.csv \
+	--model-name "${MODEL_NAME}" \
+	2>&1 | tee -a ${LOG}_CONCURRENCY.log >/dev/null

--- a/scripts/vllm_dissag/connectors/moriio.env
+++ b/scripts/vllm_dissag/connectors/moriio.env
@@ -29,3 +29,9 @@ VLLM_MORIIO_QP_PER_TRANSFER=2
 VLLM_MORIIO_NUM_WORKERS=4
 HSA_FORCE_FINE_GRAIN_PCIE=1
 HSA_ENABLE_SDMA=1
+# Profiling defaults; submit-time exports override these values.
+MORIIO_REQID_MAP=0
+MORI_ROCTX_TRANSFER=0
+ROCPROF=0
+ROCPROF_FLAGS=--kernel-trace --marker-trace
+ROCPROF_DIR_BASE=/run_logs

--- a/scripts/vllm_dissag/connectors/moriio.sh
+++ b/scripts/vllm_dissag/connectors/moriio.sh
@@ -155,7 +155,8 @@ connector_launch_worker() {
     # So even "no cudagraph" is expressed as cudagraph_mode:NONE WITH +quant_fp8.
     # Per-role mode: DECODE_CUDAGRAPH_MODE / PREFILL_CUDAGRAPH_MODE, falling back to
     # the global VLLM_CUDAGRAPH_MODE (back-compat).
-    local exec_args=()
+    local exec_args=() shutdown_args=()
+    [[ "${RUN_PROFILE:-0}" == "1" ]] && shutdown_args+=(--shutdown-timeout "${VLLM_PROFILING_SHUTDOWN_TIMEOUT_S:-120}")
     local _cudagraph_mode="${VLLM_CUDAGRAPH_MODE:-}"
     if [[ "$log_prefix" == "decode" ]]; then
         _cudagraph_mode="${DECODE_CUDAGRAPH_MODE:-$_cudagraph_mode}"
@@ -174,6 +175,12 @@ connector_launch_worker() {
     local model_args=()
     local _mc; if [[ "$log_prefix" == "prefill" ]]; then _mc="${MODEL_CONFIG_PREFILL:-}"; else _mc="${MODEL_CONFIG_DECODE:-}"; fi
     [[ -n "$_mc" ]] && eval "model_args=(${_mc})"
+
+    local _RP=""
+    if [[ "${RUN_PROFILE:-0}" == "1" ]]; then
+        moriio_profiling_hook_start "${log_prefix}"
+        _RP="${MORIIO_PROFILING_RUN_PREFIX}"
+    fi
 
     if parallelism_is_wide_ep; then
         # ---- WIDE_EP=1 (MoriEP) ----
@@ -203,7 +210,7 @@ connector_launch_worker() {
 
         if [[ "${DRY_RUN:-0}" == "1" ]]; then
             _dryrun_emit "moriio" "${log_prefix}" "${role}" \
-                vllm serve "${MODEL_PATH}" \
+                ${_RP}vllm serve "${MODEL_PATH}" \
                     -tp 1 \
                     --data-parallel-size "${dp_size}" \
                     --data-parallel-size-local "${DP_PARALLEL_SIZE_LOCAL}" \
@@ -219,11 +226,10 @@ connector_launch_worker() {
                     --all2all-backend "${_all2all}" \
                     --trust-remote-code \
                     --distributed-timeout-seconds "${DISTRIBUTED_TIMEOUT_SECONDS:-7200}" \
-                    "${exec_args[@]}" "${extra_args[@]}" "${kv_args[@]}"
+                    "${shutdown_args[@]}" "${exec_args[@]}" "${extra_args[@]}" "${kv_args[@]}"
             WORKER_PID=0; return 0
         fi
-
-        vllm serve ${MODEL_PATH} \
+	${_RP}vllm serve ${MODEL_PATH} \
             -tp 1 \
             --data-parallel-size "${dp_size}" \
             --data-parallel-size-local ${DP_PARALLEL_SIZE_LOCAL} \
@@ -239,10 +245,11 @@ connector_launch_worker() {
             --all2all-backend "${_all2all}" \
             --trust-remote-code \
             --distributed-timeout-seconds ${DISTRIBUTED_TIMEOUT_SECONDS:-7200} \
+            "${shutdown_args[@]}" \
             "${exec_args[@]}" \
             "${extra_args[@]}" \
             "${kv_args[@]}" \
-            2>&1 | tee /run_logs/${SLURM_JOB_ID}/${log_prefix}_NODE${NODE_RANK}.log >/dev/null &
+            > >(tee /run_logs/${SLURM_JOB_ID}/${log_prefix}_NODE${NODE_RANK}.log >/dev/null) 2>&1 &
         WORKER_PID=$!
         return 0
     fi
@@ -269,27 +276,27 @@ connector_launch_worker() {
 
     if [[ "${DRY_RUN:-0}" == "1" ]]; then
         _dryrun_emit "moriio" "${log_prefix}" "${role}" \
-            vllm serve "${MODEL_PATH}" \
+            ${_RP}vllm serve "${MODEL_PATH}" \
                 --tensor-parallel-size "${_tp_size}" \
                 --port "${SERVE_PORT}" \
                 --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION:-0.8}" \
                 --trust-remote-code \
                 --distributed-timeout-seconds "${DISTRIBUTED_TIMEOUT_SECONDS:-7200}" \
                 --kv-transfer-config "${kv_config}" \
-                "${exec_args[@]}" "${model_args[@]}"
+                "${shutdown_args[@]}" "${exec_args[@]}" "${model_args[@]}"
         WORKER_PID=0; return 0
     fi
-
-    vllm serve ${MODEL_PATH} \
+    ${_RP}vllm serve ${MODEL_PATH} \
         --tensor-parallel-size "${_tp_size}" \
         --port ${SERVE_PORT} \
         --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION:-0.8} \
         --trust-remote-code \
         --distributed-timeout-seconds ${DISTRIBUTED_TIMEOUT_SECONDS:-7200} \
         --kv-transfer-config "${kv_config}" \
+        "${shutdown_args[@]}" \
         "${exec_args[@]}" \
         "${model_args[@]}" \
-        2>&1 | tee /run_logs/${SLURM_JOB_ID}/${log_prefix}_NODE${NODE_RANK}.log >/dev/null &
+        > >(tee /run_logs/${SLURM_JOB_ID}/${log_prefix}_NODE${NODE_RANK}.log >/dev/null) 2>&1 &
     WORKER_PID=$!
 }
 

--- a/scripts/vllm_dissag/moriio_profiling/README.md
+++ b/scripts/vllm_dissag/moriio_profiling/README.md
@@ -1,0 +1,682 @@
+# MoRIIO profiling for vLLM disaggregated runs
+
+This is the operator reference for the current working-tree implementation. The
+repository spelling is `scripts/vllm_dissag/` (not `vllm_disagg/`). Submit
+`scripts/vllm_dissag/run_xPyD_models.slurm`; it is the normal entrypoint and
+invokes `vllm_disagg.sh` inside each container.
+
+## Execution path
+
+`run_xPyD_models.slurm` resolves the model and topology, loads
+`connectors/moriio.env`, launches one container per selected node, and records
+the distributed and post-processing status. Inside each container,
+`vllm_disagg.sh` sources `connectors/moriio.sh`; the connector calls
+`moriio_profiling/hooks.sh` to put each prefill or decode server under
+rocprofv3.
+
+The launcher bind-mounts the checkout at `/opt/nixl-vllm-cookbook` and
+`${LOG_PATH}` at `/run_logs`. Raw shards therefore persist on the host. After
+the containers exit, `process_kernels.sh` runs `trace_tools.py` on a compute
+node to combine CSV shards and, when enabled, extract request mappings.
+TraceLens analysis is separate and optional.
+
+## Build the profiling image
+
+### Targets and source versions
+
+The Dockerfile is
+`docker/vllm_disagg_inference.profiling.ubuntu.amd.Dockerfile`. Its last target is
+`normal`, so omitting `--target` builds the non-profile target.
+
+- `normal` uses the shared `runtime` stage. The Dockerfile pins the base to
+  `rocm/vllm-dev:ci_base-0fcd9b99cc9d63202da4c858d8ebc6582c9e2491`,
+  ROCm/MoRI to `v1.2.1`, AITER to `0.1.16.post3` with `flydsl==0.2.2`,
+  and Rust to `1.88.0`. Its vLLM ref
+  `vllm_2p2d_wide-ep_write_shikpate_test_06_29_customer` and router ref
+  `ravgupta/discovery-dp-rank-roundrobin` are branch names, not immutable
+  commit pins. The build records their resolved SHAs in `/app/versions.txt`.
+- `profiling` starts from the same runtime, replaces MoRI with
+  `https://github.com/AakarshAMD/mori-fork.git` at immutable commit
+  `ac44f1aaeb1887985dce2b9bdf82f54c19d008f9`, and initializes its
+  `spdlog` and `msgpack-c` submodules.
+- The profiling target also builds Perfetto at immutable commit
+  `c794fceabe584dc9172e5512aaaeecc21019a635`, installs
+  `/usr/local/bin/traceconv`, and sets
+  `TRACECONV=/usr/local/bin/traceconv`. That commit reports Perfetto
+  `v56.1-c794fceab`.
+- The normal target neither copies this binary nor sets `TRACECONV`.
+- `WITH_NIXL=0` is sufficient and preferred for a MoRIIO-only image.
+  `WITH_NIXL=1` is needed only when the same runtime must also support the
+  `rixl` connector (NIXL TP or DeepEP wideEP); it adds UCX at `da3fac2a`,
+  RIXL at `f33a5599`, rocSHMEM, and DeepEP builds.
+
+### Build from the login node through Slurm
+
+Do not run the build on the login node. Submit it to one compute node, push
+there, and use a unique tag so another node cannot reuse an older image under
+the same name. This template deliberately invokes Bash because Slurm
+`--wrap` otherwise uses `/bin/sh`, which does not support `pipefail`.
+
+Run from the remote repository root:
+
+```bash
+cd /path/to/MAD
+
+IMAGE_TAG="<your-vllm-profiling-image>"
+export IMAGE_TAG
+
+sbatch --parsable \
+  --export=ALL,IMAGE_TAG \
+  --job-name=moriio-profile-build \
+  --partition="<compute-partition>" \
+  --time=03:00:00 \
+  --gres=gpu:1 \
+  -N 1 -n 1 \
+  --output="<shared-output-root>/moriio-build-%j.out" \
+  --error="<shared-output-root>/moriio-build-%j.err" \
+  --wrap="exec bash -lc 'set -euo pipefail
+    cd /path/to/MAD
+    DOCKER_BUILDKIT=1 docker build \
+      --target profiling \
+      --build-arg WITH_NIXL=0 \
+      -f docker/vllm_disagg_inference.profiling.ubuntu.amd.Dockerfile \
+      -t \"\$IMAGE_TAG\" .
+    docker push \"\$IMAGE_TAG\"
+    docker image inspect --format \"{{.Id}}\" \"\$IMAGE_TAG\"
+    docker run --rm --entrypoint bash \"\$IMAGE_TAG\" -lc \
+      \"cat /app/versions.txt; traceconv --version\"
+  '"
+```
+
+Add the site's current bad-node exclusion to `sbatch` when required. After the
+job completes, retain the tag and registry digest and verify the version output
+in the compute-node build log.
+
+## What `RUN_PROFILE` does
+
+`RUN_PROFILE=1` is the supported master capture gate. After normal model
+validation, connector defaults and legacy axis selection resolve first.
+Profiling requires the effective connector to be `moriio`; `RUN_PROFILE=1`
+never selects it. With no explicit connector or legacy selector, the connector
+defaults to `rixl`, so `run_xPyD_models.slurm` prints
+`CONNECTOR=moriio is required when RUN_PROFILE=1`; direct `vllm_disagg.sh`
+invocation prints `mori must be on for profiling`. Both write to stderr and
+exit `1` before profiling helper checks, sourcing, or container launch. Legacy
+`RUN_MORI=1` can still resolve the effective connector to `moriio`; commands
+should set `CONNECTOR=moriio` explicitly.
+
+Only in this profile path, `run_xPyD_models.slurm` requires
+`moriio_profiling/hooks.sh` and `moriio_profiling/process_kernels.sh`, sources
+`hooks.sh`, and later verifies `benchmark_xPyD_profile.sh`. After the containers
+exit, it sources `process_kernels.sh` for post-processing. Inside each container,
+`vllm_disagg.sh` independently requires and sources `hooks.sh`. The ordinary
+`RUN_PROFILE=0` path does not perform these profile-helper checks.
+
+When both gates are enabled, the workflow:
+
+- rejects conflicting legacy `RUN_DEEPEP=1`;
+- sets `ROCPROF=1`;
+- defaults `ROCPROF_FLAGS` to
+  `--kernel-trace --marker-trace`;
+- defaults `ROCPROF_DIR_BASE` to `/run_logs`;
+- forces `MORI_ROCTX_TRANSFER=1`;
+- defaults `MORIIO_REQID_MAP=0`;
+- forces `ANALYZE_KERNELS=0`; and
+- overrides the selected benchmark file with
+  `benchmark_xPyD_profile.sh`.
+
+Each server command is prefixed with:
+
+```text
+rocprofv3 --kernel-trace --marker-trace --disable-signal-handlers \
+  --output-format pftrace csv json -d <role-dir> \
+  -o %hostname%_%pid% --
+```
+
+`--disable-signal-handlers` is appended if absent so vLLM owns graceful
+shutdown. Leave `RUN_PROFILE` unset or set it to `0` for the ordinary
+non-profile path. Any other value is rejected.
+
+`MORIIO_REQID_MAP` is an optional profiling subfeature and defaults to `0`.
+Omit it for kernels, markers, and combined traces without request correlation.
+Set it to exact `1` only when the request map is needed; this enables the
+installed-vLLM patch and post-run extraction of `reqid_map.csv`.
+
+## Models, topology, and router controls
+
+Model names are case-sensitive.
+
+- `DOCKER_IMAGE_NAME` is mandatory and must identify the profiling image.
+- `MODEL_NAME` selects the model catalog entry.
+- `DeepSeek-V3`, `DeepSeek-V3-5layer`, and `DeepSeek-R1` are wideEP-only and
+  are the only model keys accepted for MoRIIO wideEP. Use `WIDE_EP=1`.
+- WideEP uses local DP equal to `GPUS_PER_NODE` and global per-role DP of
+  `xP * GPUS_PER_NODE` or `yD * GPUS_PER_NODE`. vLLM is launched with
+  `-tp 1`; `IO_TP_SIZE` is ignored.
+- `Llama-3.1-405B-Instruct-FP8-KV`,
+  `amd-Llama-3.3-70B-Instruct-FP8-KV`, `gpt-oss-120b`, `Qwen3-32B`, and
+  `Qwen3-30B-A3B` pass the TP model gate with `WIDE_EP=0`. Catalog acceptance
+  is not proof of runtime validation; `models.yaml` records a known
+  `device_gemm` failure for `Qwen3-30B-A3B` on this stack.
+- In ordinary Slurm submissions, MoRIIO TP resolves to tensor-parallel size
+  `8`. The connector checks `IO_TP_SIZE`, then `GENERIC_TP_SIZE`, but
+  `run_xPyD_models.slurm` forwards neither as a submit-time override.
+- `GPUS_PER_NODE` defaults to `8`; keep it equal to the Slurm GPU allocation.
+- `xP` and `yD` each default to `1`. Allocate exactly `xP + yD` nodes and
+  tasks. The proxy is co-located on prefill rank 0.
+- `PROXY_TYPE` defaults to `vllm_router`. Use it for wideEP; the toy proxy
+  cannot perform the required wideEP KV notification routing.
+- `ROUTER_PORT` defaults to `30000`. `ROUTER_BINARY` can select an alternate
+  executable. `MORIIO_TOY_PROXY` can select the toy proxy script only when
+  `PROXY_TYPE=moriio_toy`.
+- The model probe checks every allocated node before the launcher selects the
+  first `xP + yD` nodes. Over-allocation can therefore fail on an unused node
+  that lacks the node-local model.
+
+Do not set legacy `RUN_MORI=1` for a dense Llama profile merely to correct
+metadata. Outside exact profile selection it means MoRIIO wideEP, which is
+unsupported for Llama. Leave `RUN_MORI` and `RUN_DEEPEP` unset or set both to
+`0`, and set `CONNECTOR=moriio` explicitly; `RUN_PROFILE=1` never selects it.
+The current `perf.csv` backend tag bug is documented below.
+
+### DeepSeek wideEP template
+
+Run from `scripts/vllm_dissag/`. Replace the placeholder with the unique tag
+or digest just built.
+
+```bash
+IMAGE="<PROFILING_IMAGE_TAG_OR_DIGEST>"
+
+RUN_PROFILE=1 \
+CONNECTOR=moriio \
+MORIIO_REQID_MAP=1 \
+RUN_MORI=0 \
+RUN_DEEPEP=0 \
+DOCKER_IMAGE_NAME="$IMAGE" \
+MODEL_NAME=DeepSeek-V3 \
+WIDE_EP=1 \
+xP=2 \
+yD=2 \
+GPUS_PER_NODE=8 \
+PROXY_TYPE=vllm_router \
+SKIP_WARMUP=1 \
+BENCHMARK_SCRIPT=sweep \
+BENCHMARK_ITR=1 \
+BENCHMARK_NUM_PROMPTS=8 \
+BENCHMARK_CON="1" \
+BENCHMARK_COMBINATIONS="256/8" \
+sbatch --export=ALL --partition="<compute-partition>" --time=02:00:00 --gres=gpu:8 \
+  -N 4 -n 4 run_xPyD_models.slurm
+```
+
+### Llama TP template
+
+```bash
+IMAGE="<PROFILING_IMAGE_TAG_OR_DIGEST>"
+
+RUN_PROFILE=1 \
+CONNECTOR=moriio \
+MORIIO_REQID_MAP=1 \
+RUN_MORI=0 \
+RUN_DEEPEP=0 \
+DOCKER_IMAGE_NAME="$IMAGE" \
+MODEL_NAME=amd-Llama-3.3-70B-Instruct-FP8-KV \
+WIDE_EP=0 \
+xP=1 \
+yD=1 \
+GPUS_PER_NODE=8 \
+PROXY_TYPE=vllm_router \
+SKIP_WARMUP=1 \
+BENCHMARK_SCRIPT=sweep \
+BENCHMARK_ITR=1 \
+BENCHMARK_NUM_PROMPTS=8 \
+BENCHMARK_CON="1" \
+BENCHMARK_COMBINATIONS="256/8" \
+sbatch --export=ALL --partition="<compute-partition>" --time=02:00:00 --gres=gpu:8 \
+  -N 2 -n 2 run_xPyD_models.slurm
+```
+
+Assignments must be in the environment of `sbatch`; keep them immediately
+before it and use `--export=ALL`. Choose a site-appropriate compute partition
+and add current site exclusions as needed.
+
+## Benchmark contract
+
+With `RUN_PROFILE=0`, `BENCHMARK_SCRIPT=sweep` selects
+`benchmark_xPyD.sh`; `long_context` selects
+`benchmark_long_context.sh`. With exact `RUN_PROFILE=1`, either valid selector
+is subsequently replaced by `benchmark_xPyD_profile.sh`. Use `sweep` to avoid
+misleading logs.
+
+The profile benchmark receives these launcher-supported controls:
+
+- `BENCHMARK_ITR=1`
+- `BENCHMARK_CON="8 16 32 64 128 256 512"`
+- `BENCHMARK_COMBINATIONS="1024/1024 8192/1024 1024/8192"`
+- `SKIP_WARMUP=1`
+- `BENCHMARK_NUM_PROMPTS`, unset by default
+
+`RUN_PROFILE=1` defaults `SKIP_WARMUP=1`; keeping it skipped reserves the capture
+for measured requests and avoids warmup traffic in the trace. Set `SKIP_WARMUP=0` explicitly to include warmup.
+
+The quoted values above are defaults, not recommended profile sizes.
+`BENCHMARK_CON` is a space-separated list. `BENCHMARK_COMBINATIONS` is a
+space-separated list of `ISL/OSL` pairs. Quote either assignment whenever it
+contains spaces. If `BENCHMARK_NUM_PROMPTS` is unset, each point uses
+`max(2 * concurrency, 16)` prompts.
+
+When warmup is not skipped, the script itself defaults to concurrency `1`,
+`16` prompts, ISL `32`, and OSL `32`. It also has a `STEP_TIMEOUT` default of
+`1800` seconds and scales that floor for token counts above 2048. The current
+Slurm docker argument list does not forward `WARMUP_CON`, `WARMUP_PROMPTS`,
+`WARMUP_ISL`, `WARMUP_OSL`, or `STEP_TIMEOUT` from submission, so ordinary
+profile jobs should use `SKIP_WARMUP=1` and should not claim those names as
+working `sbatch` overrides.
+
+**For profiling, use exactly one concurrency, one ISL/OSL pair, and
+`BENCHMARK_ITR=1`. Submit a separate job for every additional point.**
+
+rocprof wraps the entire server lifetime: model load, JIT, warmup, every
+benchmark point, and shutdown all append to the same per-process shards.
+There is no per-point capture boundary. More points increase raw output,
+three combined outputs, finalization time, merge time, and persistent storage.
+
+The current aggregate parser keys results only by `(ISL, OSL, concurrency)`
+and keeps the maximum total-token throughput across repeated iterations.
+Iterations with the same key therefore collapse to one aggregate CSV and
+`perf.csv` row. The raw capture remains one job-wide trace regardless of the
+number of points.
+
+The benchmark shell does not reliably propagate every non-timeout client
+failure, and `parse_to_csv.py` can still exit successfully. A zero Slurm exit
+or a `SUCCESS` row in `perf.csv` is not benchmark validation.
+
+## Supported controls
+
+### Capture paths, flags, and mapping
+
+These values are carried through `connectors/moriio.env`, so submit-time
+exports override the file defaults:
+
+- `MORIIO_REQID_MAP=0`: exact `1` enables patching and extraction.
+- `ROCPROF=0`: `RUN_PROFILE=1` sets it to `1`.
+- `ROCPROF_FLAGS="--kernel-trace --marker-trace"`: keep both for the supported
+  workflow; the hook appends `--disable-signal-handlers`.
+- `ROCPROF_DIR_BASE=/run_logs`: keep output under the persistent bind mount.
+- `MORI_ROCTX_TRANSFER=0`: `RUN_PROFILE=1` forces it to `1`.
+
+`LOG_PATH` controls the host root mounted at `/run_logs`; set it to a shared
+location such as `<shared-output-root>`. Keep `ROCPROF_DIR_BASE` under that
+mount or capture can be ephemeral.
+
+`ANALYZE_KERNELS` is host-side post-processing state. Profile mode forces it
+to `0`; do not attempt to enable TraceLens during capture.
+
+The mapping patcher supports manual CLI options `--check`, `--revert`, and
+`--moriio-dir`; `--moriio-dir` is not a launcher environment variable. The
+patch is idempotent, validates all source anchors before writing, and creates
+`.orig_moriio_reqid_map` backups inside the installed package in the
+ephemeral container.
+
+### Shutdown and readiness
+
+The effective profiled shutdown defaults are:
+
+- `VLLM_PROFILING_SHUTDOWN_TIMEOUT_S=120`, passed to vLLM as
+  `--shutdown-timeout`;
+- `VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS=120`;
+- `ROCPROF_FINALIZE_TIMEOUT_S=180`; and
+- `ROCPROF_KILL_TIMEOUT_S=10`.
+
+The hook sends `TERM` only to the waitable vLLM/rocprofv3 parent, waits for
+vLLM to stop EngineCore and workers in order, verifies a kernel CSV, and uses
+a recursive `KILL` only after the finalize timeout.
+
+The current Slurm docker argument list does not forward submit-time values
+for those four names. Ordinary `sbatch` runs therefore use the defaults above
+unless the launcher or connector environment file is changed. Other
+forwarded lifecycle controls are `LOG_WAIT_TIMEOUT_SECONDS` (connector
+default `4000`), `VLLM_HANDSHAKE_TIMEOUT_MINS` (`30`),
+`VLLM_ENGINE_READY_TIMEOUT_S` (`10800`),
+`DISTRIBUTED_TIMEOUT_SECONDS` (`7200`), `VLLM_RPC_TIMEOUT` (`300000`), and
+`VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` (`3600`).
+
+### Connector and fabric environment
+
+`connectors/moriio.env` is the source of the current ROCm/RDMA platform
+values. Every non-comment key is forwarded with submit-time environment
+precedence. In particular:
+
+- `PYTORCH_ALLOC_CONF=expandable_segments:False`
+- `PYTORCH_HIP_ALLOC_CONF=expandable_segments:False`
+- `HSA_ENABLE_IPC_MODE_LEGACY=0`
+- `MORI_GPU_ARCHS=gfx942`
+- `HSA_NO_SCRATCH_RECLAIM=1`
+- `MORI_RDMA_TC=41`, `MORI_RDMA_SL=0`, `MORI_IO_SL=1`
+- `MORI_IB_ENABLE_RELAXED_ORDERING=1`, `MORI_IB_GID_INDEX=1`
+- `MORI_NUM_QP_PER_PE=8`
+- `VLLM_MORIIO_QP_PER_TRANSFER=2`
+- `VLLM_MORIIO_NUM_WORKERS=4`
+- `HSA_FORCE_FINE_GRAIN_PCIE=1`, `HSA_ENABLE_SDMA=1`
+
+These fabric values were chosen for the current cluster and are not portable
+defaults. The launcher also supports submitted overrides for
+`MORI_SOCKET_IFNAME`, `MORI_RDMA_DEVICES`, `NCCL_IB_HCA`,
+`NCCL_IB_GID_INDEX`, `NCCL_NET_GDR_LEVEL`, `NCCL_CROSS_NIC`,
+`NCCL_SOCKET_IFNAME`, and `GLOO_SOCKET_IFNAME`.
+
+Current vLLM warns that `VLLM_MORIIO_QP_PER_TRANSFER` is deprecated and
+ignored in favor of `qp_per_transfer` inside
+`kv_connector_extra_config`. Do not treat the environment value as evidence
+that the requested QP count took effect.
+
+`ROUTER_PORT` is a working submit-time override and defaults to `30000`.
+Most other connector ports are fixed at their in-container defaults because
+the Slurm wrapper does not forward their environment names:
+RPC `13345`, serve `20005`, KV `9711`, discovery/ping `36367`, local ping
+`61555`, handshake `8405`, notify `61005`, and barrier `2222`.
+`MASTER_PORT` is hard-coded to `39566`. These host-network ports can collide
+with another job on the same node.
+
+Generic launcher controls such as model recipe flags, cache locations,
+memory utilization, Docker shared memory, and persistent JIT caching still
+apply, but they are not profiling-specific. Consult the launcher,
+`models.yaml`, and `connectors/moriio.env` rather than treating them as
+profile controls.
+
+### Analysis controls
+
+`process_kernels.sh --kernels` supports:
+
+- `LOG_PATH` for job lookup;
+- `DOCKER_IMAGE_NAME`, which should always be set explicitly;
+- `NIXL_COOKBOOK_PATH` (default `/opt/nixl-vllm-cookbook`);
+- `SBATCH_PARTITION`, set to a site-appropriate compute partition such as
+  `<analysis-partition>` (code fallbacks are site-specific);
+- `SBATCH_GRES` (default `gpu:1`);
+- `SBATCH_TIME` (default `02:00:00`); and
+- `DRY_RUN=1`.
+
+The analysis library uses `TRACELENS_REPO` (default
+`https://github.com/AMD-AGI/TraceLens.git`), `VENV` (default
+`moriio_profiling/external_copies/venv`), `TRACECONV`, and `TRIM_PCT`
+(default `5`). The convenience `--kernels` Docker command does not pass host
+values for those four names. The profiling image supplies `TRACECONV`;
+custom values require an image environment or a manual `docker run -e`.
+
+## Lifecycle
+
+1. Resolved `CONNECTOR=moriio` plus `RUN_PROFILE=1` enables capture,
+   transfer markers, mapping state, and the profile benchmark on the Slurm side.
+2. Connector and model environment is forwarded to each host-network
+   container.
+3. If mapping is enabled, each container patches its installed vLLM package
+   before its first worker launch.
+4. Each role starts under rocprofv3. Model initialization, barriers, server
+   readiness, router registration, and a bring-up completion request occur
+   before the benchmark.
+5. `benchmark_xPyD_profile.sh` writes the client log, aggregate CSV, and
+   `perf.csv`.
+6. The proxy stops, each vLLM parent receives `TERM`, and rocprofv3 flushes
+   process shards. The hook requires at least one kernel CSV with a header
+   and data row per role/node.
+7. Containers are removed after the distributed `srun` returns.
+8. Post-processing always attempts the three CSV-based combinations, then
+   conditionally extracts request mappings. Profile mode skips TraceLens.
+9. Distributed-run or post-processing failures are propagated in profile
+   mode, and raw shards are retained.
+
+Benchmark output can stop minutes before trace flush and combination finish.
+Wait for terminal Slurm state and stable artifact sizes.
+
+## Artifacts
+
+With `LOG_PATH=<shared-output-root>`, the host job directory is:
+
+```text
+<shared-output-root>/<JOB_ID>/
+```
+
+With `LOG_PATH=/some/root`, it is `/some/root/<JOB_ID>/`. Container
+`/run_logs/<JOB_ID>/` is the bind-mounted view of the same directory. Slurm
+stdout and stderr remain beside it as `slurm-<JOB_ID>.out` and
+`slurm-<JOB_ID>.err` under the default log root.
+
+A 2P2D job has:
+
+```text
+rocprof_prefill_NODE0/
+rocprof_prefill_NODE1/
+rocprof_decode_NODE2/
+rocprof_decode_NODE3/
+```
+
+Each role/node directory contains `%hostname%_%pid%` process shards:
+
+- `*_kernel_trace.csv`: per-dispatch GPU kernel records; these are the
+  required combine inputs.
+- `*_marker_api_trace.csv`: ROCTx records. A file may be absent for a process
+  that emitted no markers.
+- `*_agent_info.csv`: rocprofiler agent metadata.
+- `*_results.json`: native rocprofiler-SDK JSON. It is not a combine input.
+- `*_results.pftrace`: native binary Perfetto trace. It is not a combine
+  input, but optional TraceLens analysis prefers it.
+
+Job-level logs and results include:
+
+- `prefill_NODE*.log` and `decode_NODE*.log`: server, mapping, and shutdown
+  evidence.
+- `vllm_router_NODE*.log` or `proxy_NODE*.log`: routing and registration.
+- `pd_vllm_bench_NODE*.log`: full per-node launcher output.
+- `benchmark_<JOB_ID>_<timestamp>_xP<xP>_yD<yD>_<model>_CONCURRENCY.log` and
+  `.csv`: client results and aggregate throughput.
+- `perf.csv`: madengine aggregate rows. It is performance metadata, not trace
+  validation.
+- `reqid_map.csv`: opt-in request correlation output.
+- `kernel_analysis_v2/<role_NODE>/`: strict TraceLens and first-party summaries (name is configurable with `KERNEL_ANALYSIS_OUTPUT_NAME`).
+
+Automatic combination writes:
+
+- `combined_all.pftrace`: every discovered prefill and decode process;
+- `combined_rank0.pftrace`: exactly the manifest worker whose emitted
+  `local_rank` is `0` for each role/node; and
+- `combined_prefill.chrome.json`: every discovered prefill process.
+
+All three combined files are Chrome-trace JSON assembled from CSV, including
+the files whose names end in `.pftrace`. Do not pass a combined `.pftrace` to
+native `traceconv`. The combiner normalizes timestamps independently to each
+node's first selected kernel timestamp. Durations and ordering within a node
+are useful, but lanes on different nodes do not share a synchronized global
+clock. The three combined files can also have different per-node origins.
+
+## Request and transfer correlation
+
+With `MORIIO_REQID_MAP=1`, the patch logs mappings for `write`,
+`write_single`, and `read` calls. Automatic extraction currently reads only
+`prefill_NODE*.log`, which matches the current MoRIIO WRITE path.
+
+The current CSV field order is:
+
+```text
+write_uid,direction,request_id,transfer_id,layer,role,node_rank,pid
+```
+
+MoRI WRITE markers look like:
+
+```text
+mori.rdma.kv_transfer bytes=<n> wrs=<n> merged=<n> id=<write_uid>
+```
+
+**Never join on bare `write_uid`.** UIDs are process-local and routinely
+collide across workers. Build marker identity from the role/node directory,
+the marker CSV `Process_Id`, the marker direction, and the marker ID. The
+required join key is:
+
+```text
+(role, node_rank, pid, direction, write_uid)
+```
+
+For current WRITE markers, infer direction `write`. Hostname is unnecessary
+because `node_rank` identifies the job node and `pid` identifies the process
+on that node. A bare UID can appear independently in many workers while the
+composite keys remain unique.
+
+In WRITE mode, markers and extracted maps normally occur on active prefill
+master workers. Prefill child nodes and decode nodes can have zero markers.
+Even some prefill master workers can have zero markers when no request is
+routed to them; their marker CSV may be absent. This is not data loss when
+the active workers' composite keys match exactly and kernel capture is
+complete. A header-only map after successful transfers is not a pass.
+
+Manual extraction from `scripts/vllm_dissag/`:
+
+```bash
+python3 moriio_profiling/trace_tools.py extract-reqid \
+  /path/to/<JOB_ID>/prefill_NODE*.log \
+  -o /path/to/<JOB_ID>/reqid_map.csv
+```
+
+Include decode logs manually only when analyzing a READ-mode path.
+
+## Automatic and optional post-processing
+
+Automatic post-processing:
+
+- the `RUN_PROFILE=1` workflow, which forces `ROCPROF=1`, always builds
+  the three combined traces;
+- extracts `reqid_map.csv` only for `MORIIO_REQID_MAP=1`;
+- never needs `traceconv`, native PFTrace, or native JSON; and
+- preserves raw output and returns a post-processing failure to the profile
+  launcher.
+
+Optional analysis should run only after capture validation:
+
+```bash
+SBATCH_PARTITION="<analysis-partition>" \
+DOCKER_IMAGE_NAME="<your-vllm-profiling-image>" \
+bash moriio_profiling/process_kernels.sh --kernels <JOB_ID>
+```
+
+The script accepts a numeric job ID or directory and starts a one-GPU `srun`
+when it is not already in an allocation. Choose a site-appropriate compute
+partition and do not rely on its hard-coded fallback image.
+
+First use clones TraceLens and creates a Python venv under
+`moriio_profiling/external_copies/`, then installs TraceLens editable plus
+`pandas`, `plotly`, `matplotlib`, `openpyxl`, `ijson`, `perfetto`, and
+`numpy`. The mounted checkout must be writable and network/package access is
+needed when dependencies are not cached.
+
+Treat `external_copies/` as third-party/generated operational content and
+exclude it from source-only clone transfers. An optional executable at
+`external_copies/traceconv_bin/traceconv`, when present, is only the
+`trace_tools.py` fallback when `TRACECONV` is unset. It is not copied by the
+Dockerfile and is never used by automatic CSV combination. Source-only
+transfers may omit it. The profiling image's `/usr/local/bin/traceconv` is
+authoritative in the normal analysis container.
+
+Analysis first reconstructs `rank_manifest.json` from the archived worker
+rank lines and requires one unambiguous `local_rank=0` PID for every role/node.
+It prefers that PID's native PFTrace; captures without PFTrace use TraceLens's
+native rocprof JSON path. Raw kernel CSV is never a TraceLens fallback (it is
+used only for the separately labeled trimmed summary). Every TraceLens,
+conversion, normalization, and bucketing result is checked, every node must
+produce the required outputs, and any node failure makes the job fail after
+other nodes finish diagnostic collection.
+
+TraceLens is invoked with `--min_event_ns 0`, overriding its 5000 ns default.
+First-party categorization puts intra-node and inter-node EpDispatch/EpCombine
+payload in `MORI EP`, keeps `EP_Barrier` separate, leaves staging/sync/support
+in `Communication`, and applies the corrected fmoe/opus classifications.
+
+Converted Perfetto JSON is streamed through a narrow sanitizer before
+TraceLens. It removes only duration-bearing records with `end < begin` or an
+unsigned duration above signed int64, recording exact correlation IDs and
+counts. The default corruption guard is both at most 100 records and at most
+`0.0001` (0.01%) of duration records; explicit overrides are
+`INVALID_EVENT_MAX_COUNT` and `INVALID_EVENT_MAX_FRACTION`.
+
+`kernel_analysis_v2/<role_NODE>/` contains TraceLens JSON/reports/CSVs,
+`sanitizer_report.json`, selection/window metadata, and first-party normalized,
+per-kernel, category, and trimmed summaries. For each exact kernel name with at
+least 20 calls, the default `TRIM_PCT=5` drops the slowest `ceil(5%)`, retains
+at least one call, then recomputes the denominator and percentages. This is a
+heuristic for whole-capture data, not benchmark-window filtering.
+Benchmark-window filtering is applied only when boundary and per-node
+clock-correlation data are available; historical results may remain
+`whole_capture`.
+
+## Full validation criteria
+
+Slurm `COMPLETED` or exit `0:0` is necessary but not sufficient. Validate all
+of the following.
+
+1. **Benchmark:** every intended point appears once; each reports the expected
+   successful request count, zero failures, no `[STALL]`, and nonzero request,
+   output-token, and total-token throughput. The bring-up completion request
+   is separate from the benchmark.
+2. **Topology:** every expected role/node directory exists. With the current
+   launcher, full validation expects `GPUS_PER_NODE` kernel process shards per
+   role/node, not merely the one good shard enforced by the hook. Every kernel
+   CSV must have a header and data.
+3. **Raw finalization:** expected `agent_info`, native PFTrace, and native JSON
+   files are nonempty when those output formats are required. Parse large JSON
+   from a fresh handle after size and mtime stabilize.
+4. **Combined traces:** all three files are nonempty, stable, and fully parse
+   as Chrome JSON. Their process-lane and kernel-event counts must agree with
+   discovered CSV inputs; zero kernel events is a failure.
+5. **Markers:** require nonzero `mori.rdma.kv_transfer` markers on the workers
+   that performed transfers. Do not require a marker file from every worker.
+6. **Mapping:** when enabled, require the exact eight-column header, populated
+   `role/node_rank/pid`, rows beyond the header, unique composite keys, and an
+   exact composite-key join to WRITE markers. Mapping request count can include
+   the bring-up request, so it need not equal benchmark request count.
+7. **Finalization:** every role log must show readiness, orderly parent-driven
+   shutdown, profiler finalization inside the timeout, and kernel verification.
+   Slurm and post-processing logs must have no propagated error.
+8. **Provenance:** record the command, source checkout, image tag and digest,
+   node list, model path, and workload independently of `perf.csv`.
+
+## Known warnings, hiccups, and limits
+
+- `correlation_id.cpp:176] empty thread-local correlation id stack` appears at
+  error severity for the asynchronous MoRI marker path. It does not by itself
+  prove data loss. Treat it as benign only when kernels are complete,
+  finalization is clean, and the composite map/marker join is exact.
+- The pinned vLLM emits repeated "Unknown vLLM environment variable" warnings.
+  Llama also emits the deprecated checkpoint `kv_scale` warning and the
+  deprecated/ignored `VLLM_MORIIO_QP_PER_TRANSFER` warning.
+- Cold AITER JIT compilation, missing tuned-GEMM fallback messages, FP8
+  accuracy cautions, resource-tracker messages, and API-worker
+  "port 20005 is used" messages can occur during coordinated shutdown. They
+  are not a substitute for validation and should be investigated if
+  readiness, serving, or finalization differs.
+- `perf.csv` currently derives the backend only from legacy `RUN_MORI` and
+  `RUN_DEEPEP`. A correct `CONNECTOR=moriio`, `RUN_PROFILE=1`, `RUN_MORI=0` run is therefore
+  mislabeled `vllm_disagg,nixl`. The Docker image, Docker SHA, Git commit, and
+  several other provenance fields are blank because the launcher does not
+  pass or populate them in the benchmark container. Record provenance
+  separately; do not set `RUN_MORI=1` on dense Llama to work around the tag.
+- Large multi-point captures can contain stable interior corruption in native
+  `*_results.json` even when CSV-derived combined traces parse. Native PFTrace,
+  native JSON, and CSV are separate outputs; parse each required format and
+  preserve the healthy shards when one format is bad.
+- Fixed host-network ports can collide with a lingering or concurrent job,
+  especially router discovery port `36367`. Inspect router bind and
+  registration logs, coordinate cleanup with the owning user, or exclude the
+  node. The registration timeout only warns and then proceeds.
+- Broken node libraries such as `libionic.so.1` and AMD-SMI startup failures
+  are allocation or node-health problems rather than profiling defects. Use
+  the site's current bad-node list rather than a historical exclusion.
+- The node-local model probe is allowed to fail before the shared-model probe
+  succeeds. Slurm can retain a nonzero `DerivedExitCode` from that first
+  `srun` even when the launcher selects `<shared-model-root>` and
+  continues. Read the model-selection log, final `ExitCode`, and artifacts;
+  do not classify any one field in isolation.
+- Shared storage can briefly expose stale metadata. Wait for terminal job
+  state and stable size/mtime, close the old reader, and reopen the canonical
+  host path. Repeated failure at the same offset after stabilization is strong
+  corruption evidence.
+- Combined timestamps are node-relative, `combined_rank0` is manifest-selected
+  local rank zero, and optional analysis covers one process per role/node. None of these artifacts
+  alone is a globally synchronized, all-worker kernel analysis.

--- a/scripts/vllm_dissag/moriio_profiling/SKILL.md
+++ b/scripts/vllm_dissag/moriio_profiling/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: moriio-profiling
+description: Builds, runs, validates, and analyzes short vLLM disaggregated MoRIIO profiles. Use for profiling image builds, rocprofv3 capture, request-to-transfer mapping, trace processing, artifact validation, or MoRIIO profiling troubleshooting.
+---
+
+# MoRIIO profiling
+
+Read [README.md](README.md) before operating or changing this workflow. It is
+the detailed source for pins, defaults, forwarding limits, artifacts, and
+warnings. Keep this skill prescriptive and concise.
+
+## Non-negotiable rules
+
+1. Use the exact path `scripts/vllm_dissag/`.
+2. Submit `run_xPyD_models.slurm`; it is the normal entrypoint.
+3. Build on a compute node through `sbatch`, not on the login node.
+4. Build with `--target profiling`. Omitting it builds the final `normal`
+   target without the instrumented MoRI or image-built `traceconv`.
+5. Use `--build-arg WITH_NIXL=0` for MoRIIO-only work. Use `1` only if the
+   image must also run `CONNECTOR=rixl`.
+6. Give every build a unique registry tag, push it, and record its digest.
+7. Each profile job is one continuous server-lifetime trace. Use one small
+   concurrency value, one small ISL/OSL pair, one iteration
+   (`BENCHMARK_ITR=1`), and one small request count; keep OSL especially small.
+   Submit separate jobs for additional points.
+8. Never infer success from Slurm state, `perf.csv`, or command exit alone.
+
+## Build
+
+Follow the compute-node `sbatch --wrap="exec bash -lc ..."` template in the
+README. The inner build must include:
+
+```bash
+DOCKER_BUILDKIT=1 docker build \
+  --target profiling \
+  --build-arg WITH_NIXL=0 \
+  -f docker/vllm_disagg_inference.profiling.ubuntu.amd.Dockerfile \
+  -t "$IMAGE_TAG" .
+docker push "$IMAGE_TAG"
+```
+
+Verify `/app/versions.txt` and `traceconv --version` from the pushed image.
+Do not rely on a reused tag or a node-local image cache.
+
+## Submit a bounded capture
+
+Run from `scripts/vllm_dissag/` and keep assignments in the environment of
+`sbatch --export=ALL`. Profiling requires the effective connector to be
+`moriio`; `RUN_PROFILE=1` never selects it. Without it,
+`run_xPyD_models.slurm` prints
+`CONNECTOR=moriio is required when RUN_PROFILE=1`; direct `vllm_disagg.sh`
+invocation prints `mori must be on for profiling`. Both write to stderr and
+exit `1` before profile-helper checks, sourcing, or container launch. Set
+`CONNECTOR=moriio` explicitly:
+
+```bash
+RUN_PROFILE=1 \
+CONNECTOR=moriio \
+MORIIO_REQID_MAP=1 \
+RUN_MORI=0 \
+RUN_DEEPEP=0 \
+DOCKER_IMAGE_NAME="<PROFILING_IMAGE_TAG_OR_DIGEST>" \
+MODEL_NAME="<MODEL_NAME>" \
+WIDE_EP="<0_OR_1>" \
+xP="<PREFILL_NODES>" \
+yD="<DECODE_NODES>" \
+GPUS_PER_NODE=8 \
+PROXY_TYPE=vllm_router \
+SKIP_WARMUP=1 \
+BENCHMARK_SCRIPT=sweep \
+BENCHMARK_ITR=1 \
+BENCHMARK_NUM_PROMPTS=1 \
+BENCHMARK_CON="1" \
+BENCHMARK_COMBINATIONS="256/8" \
+sbatch --export=ALL --partition="<compute-partition>" --time=02:00:00 --gres=gpu:8 \
+  -N "<P_PLUS_D>" -n "<P_PLUS_D>" run_xPyD_models.slurm
+```
+
+`RUN_PROFILE=1` defaults `SKIP_WARMUP=1`; keeping it skipped reserves the capture
+for measured requests and avoids warmup traffic in the trace. Set `SKIP_WARMUP=0` explicitly to include warmup.
+Choose a site-appropriate compute partition.
+
+For `DeepSeek-V3`, `DeepSeek-V3-5layer`, or `DeepSeek-R1`, set
+`WIDE_EP=1`; vLLM uses DP with `-tp 1`. For dense Llama, set `WIDE_EP=0`;
+ordinary Slurm submissions use TP size `8` because `IO_TP_SIZE` and
+`GENERIC_TP_SIZE` are not forwarded.
+
+Do not set legacy `RUN_MORI=1` on dense Llama to work around the incorrect
+`nixl` tag in `perf.csv`.
+
+Request mapping defaults off (`MORIIO_REQID_MAP=0`). Set it to exact `1`
+only when request correlation is needed; omit the assignment when uncorrelated
+kernels and markers are sufficient.
+
+## Wait through finalization
+
+Benchmark completion is not job completion. Wait for:
+
+- proxy shutdown;
+- each vLLM/rocprofv3 parent to finalize;
+- kernel CSV verification on every role/node;
+- container cleanup;
+- `combined_all.pftrace`, `combined_rank0.pftrace`, and
+  `combined_prefill.chrome.json`; and
+- conditional `reqid_map.csv` extraction.
+
+Profile mode forces `ANALYZE_KERNELS=0`; TraceLens must not run during capture.
+
+## Validate
+
+Require all of the following:
+
+- every intended benchmark point reports the expected successful requests,
+  zero failures, no `[STALL]`, and nonzero throughput;
+- every expected role/node and worker kernel CSV exists with a header and
+  data;
+- all required native outputs are nonempty and parse after size/mtime
+  stabilizes;
+- all three combined files fully parse as Chrome JSON and contain nonzero
+  kernel events with the expected process lanes;
+- transfer markers exist on active WRITE workers; zero-marker prefill child,
+  decode, or unrouted workers are allowed;
+- every role log shows readiness and clean bounded finalization; and
+- image tag/digest, source, model path, topology, node list, and workload are
+  recorded outside `perf.csv`.
+
+The combined files ending in `.pftrace` are Chrome JSON, not native PFTrace.
+`combined_rank0` means the manifest worker with exact `local_rank=0` per
+role/node. Timestamps are normalized per node, not globally synchronized.
+
+## Correlate mappings correctly
+
+The current map columns are:
+
+```text
+write_uid,direction,request_id,transfer_id,layer,role,node_rank,pid
+```
+
+Never join on bare `write_uid`; it is process-local. Join mapping rows to
+marker rows on:
+
+```text
+(role, node_rank, pid, direction, write_uid)
+```
+
+Take role/node from the marker shard directory, PID from marker
+`Process_Id`, and current WRITE direction as `write`. Hostname is unnecessary
+when `node_rank` identifies the job node.
+
+When mapping is enabled, require populated identity columns, unique composite
+keys, rows beyond the header, and an exact map/marker join for active workers.
+
+## Run optional analysis
+
+After full capture validation:
+
+```bash
+SBATCH_PARTITION="<analysis-partition>" \
+DOCKER_IMAGE_NAME="<PROFILING_IMAGE_TAG_OR_DIGEST>" \
+bash moriio_profiling/process_kernels.sh --kernels <JOB_ID>
+```
+
+Set the image explicitly. The script writes versioned TraceLens and first-party
+outputs under `kernel_analysis_v2/<role_NODE>/` by default and creates or reuses
+`moriio_profiling/external_copies/tracelens` and `venv`; the checkout must be
+writable. Choose a site-appropriate compute partition.
+
+Analysis requires an unambiguous emitted PID/rank manifest and selects exact
+`local_rank=0`. PFTrace is preferred; TraceLens's native rocprof JSON path is
+used when PFTrace was not emitted. Raw CSV is never a TraceLens fallback.
+Malformed converted events are narrowly discarded under the documented count
+and fraction guard. TraceLens is invoked with `--min_event_ns 0`, overriding
+its 5000 ns default. Intra-node and inter-node EpDispatch/EpCombine payload is
+`MORI EP`; `EP_Barrier` is separate, staging/sync/support remains
+`Communication`, and corrected fmoe/opus classifications are applied.
+
+For each exact kernel name with at least 20 calls, default `TRIM_PCT=5` drops
+the slowest `ceil(5%)`, retains at least one call, then recomputes the
+denominator and percentages. This is a heuristic for whole-capture data, not
+benchmark-window filtering. Benchmark-window filtering is applied only when
+boundary and per-node clock-correlation data are available; historical results
+may remain `whole_capture`. All node failures are collected, then propagated
+nonzero. Do not analyze `combined_*.pftrace` as native PFTrace.
+
+## Triage known noise
+
+Treat these as conditionally benign only after full validation:
+
+- `empty thread-local correlation id stack`;
+- unknown or deprecated vLLM environment warnings;
+- AITER JIT and missing tuned-GEMM fallback messages;
+- FP8 accuracy cautions and shutdown/resource-tracker noise.
+
+Always investigate:
+
+- missing or corrupt required raw JSON;
+- empty kernel CSVs or combined traces;
+- unmatched composite mapping keys;
+- profiler finalization timeout;
+- router registration/bind failures on fixed host-network ports; and
+- node-library, AMD-SMI, model-path, or other allocation failures.
+
+## Maintenance guardrails
+
+- Treat current implementation as source of truth, not historical runs.
+- Keep request mapping opt-in.
+- Keep capture-time `ANALYZE_KERNELS=0`.
+- Preserve raw shards on every failure.
+- Keep third-party/generated `external_copies/` out of source-only transfers.
+- Do not claim submit-time overrides work unless the Slurm docker invocation
+  actually forwards them.
+- Put detailed rationale in [README.md](README.md), not in this skill.

--- a/scripts/vllm_dissag/moriio_profiling/hooks.sh
+++ b/scripts/vllm_dissag/moriio_profiling/hooks.sh
@@ -1,0 +1,264 @@
+#!/bin/bash
+
+moriio_profiling_configure_run() {
+    local run_deepep="${1:-0}"
+    RUN_PROFILE="${RUN_PROFILE:-0}"
+    case "$RUN_PROFILE" in
+        0) return 0 ;;
+        1)
+            if [[ "${CONNECTOR:-}" != "moriio" ]]; then
+                echo "mori must be on for profiling" >&2
+                return 1
+            fi
+            if [[ "$run_deepep" == "1" ]]; then
+                echo "Error: RUN_PROFILE=1 is incompatible with legacy RUN_DEEPEP=1; use CONNECTOR=moriio." >&2
+                return 1
+            fi
+            ROCPROF=1
+            ROCPROF_FLAGS="${ROCPROF_FLAGS:---kernel-trace --marker-trace}"
+            ROCPROF_DIR_BASE="${ROCPROF_DIR_BASE:-/run_logs}"
+            MORI_ROCTX_TRANSFER=1
+            MORIIO_REQID_MAP="${MORIIO_REQID_MAP:-0}"
+            ANALYZE_KERNELS=0
+            export RUN_PROFILE CONNECTOR ROCPROF ROCPROF_FLAGS ROCPROF_DIR_BASE \
+                MORI_ROCTX_TRANSFER MORIIO_REQID_MAP ANALYZE_KERNELS
+            echo "RUN_PROFILE=1: moriio rocprof kernel/marker capture enabled (ANALYZE_KERNELS=0)"
+            ;;
+        *)
+            echo "Error: RUN_PROFILE must be 0 or 1 (got '$RUN_PROFILE')." >&2
+            return 1
+            ;;
+    esac
+}
+
+moriio_profiling_append_env_args() {
+    local env_file="$1" array_name="$2" line key value
+    local -n env_args="$array_name"
+    if [[ ! -f "$env_file" ]]; then
+        echo "WARN: connector env file not found: $env_file" >&2
+        return 0
+    fi
+    echo "Loading connector platform env: $env_file"
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*# || -z "${line// }" ]] && continue
+        key="${line%%=*}"
+        value="${line#*=}"
+        env_args+=( -e "${key}=${!key:-$value}" )
+    done < "$env_file"
+}
+
+moriio_profiling_propagate_status() {
+    local run_rc="$1" posthoc_rc="$2"
+    [[ "${RUN_PROFILE:-0}" == "1" ]] || return 0
+    if (( run_rc != 0 )); then
+        echo "ERROR: profiled server run/finalization failed with status ${run_rc}" >&2
+        return "$run_rc"
+    fi
+    if (( posthoc_rc != 0 )); then
+        echo "ERROR: profiling post-processing failed with status ${posthoc_rc}" >&2
+        return "$posthoc_rc"
+    fi
+}
+
+
+_MORIIO_PROFILING_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# rocprofv3 writes results below per-host subdirectories.
+
+moriio_rocprof_prefix() {
+    local role="$1"
+    if [[ "${ROCPROF:-0}" != "1" ]]; then
+        echo ""
+        return 0
+    fi
+    local base="${ROCPROF_DIR_BASE:-/run_logs}"
+    local rpdir="${base}/${SLURM_JOB_ID:-0}/rocprof_${role}_NODE${NODE_RANK:-0}"
+    mkdir -p "$rpdir"
+    local flags="${ROCPROF_FLAGS:---kernel-trace}"
+    # vLLM owns graceful SIGTERM handling. rocprofiler-sdk 1.1.0 signal
+    # prioritization can deadlock while finalizing a multiprocess application.
+    [[ " ${flags} " == *" --disable-signal-handlers "* ]] || flags+=" --disable-signal-handlers"
+    echo "rocprofv3 ${flags} --output-format pftrace csv json -d ${rpdir} -o %hostname%_%pid% -- "
+}
+
+moriio_profiling_apply_reqid_patch() {
+    [[ "${ROCPROF:-0}" == "1" && "${MORIIO_REQID_MAP:-0}" == "1" ]] || return 0
+    python3 "${_MORIIO_PROFILING_DIR}/patch_moriio_reqid_map.py" \
+        || { echo "moriio_profiling: reqid-map patch failed" >&2; exit 1; }
+}
+
+moriio_profiling_hook_start() {
+    local log_prefix="$1"
+    if [[ "${DRY_RUN:-0}" != "1" && "${ROCPROF:-0}" == "1" && \
+          "${MORIIO_REQID_MAP:-0}" == "1" && "${_MORIIO_REQID_PATCH_APPLIED:-0}" != "1" ]]; then
+        moriio_profiling_apply_reqid_patch
+        _MORIIO_REQID_PATCH_APPLIED=1
+    fi
+    # vLLM waits only five seconds for workers by default. Large rocprof traces
+    # need longer to flush during vLLM's own parent-driven shutdown.
+    if [[ "${ROCPROF:-0}" == "1" ]]; then
+        export VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS="${VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS:-120}"
+    fi
+    MORIIO_PROFILING_ROLE_DIR="${ROCPROF_DIR_BASE:-/run_logs}/${SLURM_JOB_ID:-0}/rocprof_${log_prefix}_NODE${NODE_RANK:-0}"
+    MORIIO_PROFILING_RUN_PREFIX="$(moriio_rocprof_prefix "${log_prefix}")"
+}
+
+moriio_profiling_verify_trace() {
+    local trace_dir="${MORIIO_PROFILING_ROLE_DIR:-}"
+    local trace_file found=0
+    [[ -n "$trace_dir" && -d "$trace_dir" ]] || {
+        echo "[moriio_profiling] ERROR: missing trace directory: ${trace_dir:-<unset>}" >&2
+        return 1
+    }
+    shopt -s nullglob
+    for trace_file in "$trace_dir"/*_kernel_trace.csv; do
+        if [[ -s "$trace_file" ]] && {
+            IFS= read -r _trace_header && IFS= read -r _trace_record
+        } < "$trace_file"; then
+            found=1
+            break
+        fi
+    done
+    shopt -u nullglob
+    (( found == 1 )) || {
+        echo "[moriio_profiling] ERROR: no nonempty kernel trace was finalized in ${trace_dir}" >&2
+        return 1
+    }
+}
+
+# Recursive shutdown is used as bounded KILL escalation if a profiled,
+# parent-driven shutdown fails. `pkill -P "$pid"` reaches direct children only,
+# while vLLM descendants span API server, EngineCore, and worker levels.
+kill_tree() {
+    local pid="$1" sig="${2:-TERM}"
+    local child
+    for child in $(pgrep -P "$pid" 2>/dev/null); do
+        kill_tree "$child" "$sig"
+    done
+    kill -"$sig" "$pid" 2>/dev/null || true
+}
+
+stop_worker() {
+    local worker_pid="$1"
+    if [[ "${ROCPROF:-0}" == "1" ]] && declare -f moriio_profiling_hook_stop >/dev/null; then
+        moriio_profiling_hook_stop "$worker_pid"
+    else
+        # Preserve the established fallback if profiling was not fully configured.
+        pkill -P "$worker_pid" 2>/dev/null; kill "$worker_pid" 2>/dev/null || true
+    fi
+}
+
+_moriio_profiling_wait_and_verify() {
+    local worker_pid="$1" intentional_term="${2:-0}"
+    local worker_rc=0 trace_rc=0
+
+    if wait "$worker_pid" 2>/dev/null; then
+        worker_rc=0
+    else
+        worker_rc=$?
+    fi
+    if (( worker_rc == 127 )); then
+        echo "[moriio_profiling] ERROR: PID ${worker_pid} is not waitable by this shell" >&2
+    fi
+    if (( intentional_term == 1 && worker_rc == 143 )); then
+        worker_rc=0
+    fi
+    if moriio_profiling_verify_trace; then
+        trace_rc=0
+    else
+        trace_rc=$?
+    fi
+    if (( worker_rc != 0 )); then
+        return "$worker_rc"
+    fi
+    return "$trace_rc"
+}
+
+# With rocprof signal-handler prioritization disabled, terminate only the vLLM
+# application parent. vLLM then shuts down EngineCore and workers in its required
+# order; each instrumented process flushes its own trace during normal exit.
+# Polling checks zombie state because kill -0 succeeds for an unreaped child.
+moriio_profiling_hook_stop() {
+    local worker_pid="$1"
+    [[ "${ROCPROF:-0}" == "1" ]] || return 0
+
+    local grace_s="${ROCPROF_FINALIZE_TIMEOUT_S:-180}"
+    local kill_grace_s="${ROCPROF_KILL_TIMEOUT_S:-10}"
+    local elapsed=0 state worker_ppid shell_pid="${BASHPID:-$$}"
+    local intentional_term=0 finalize_rc=0
+
+    if [[ ! "$worker_pid" =~ ^[0-9]+$ ]] || (( worker_pid <= 1 )) || (( worker_pid == shell_pid )); then
+        echo "[moriio_profiling] ERROR: refusing to manage invalid vLLM PID '${worker_pid}'" >&2
+        return 1
+    fi
+    if [[ ! "$grace_s" =~ ^[0-9]+$ ]] || [[ ! "$kill_grace_s" =~ ^[0-9]+$ ]]; then
+        echo "[moriio_profiling] ERROR: finalization timeouts must be non-negative integers" >&2
+        return 1
+    fi
+
+    if ! kill -0 "$worker_pid" 2>/dev/null; then
+        echo "[moriio_profiling] vLLM/rocprofv3 PID ${worker_pid} already exited"
+        _moriio_profiling_wait_and_verify "$worker_pid" 0
+        return $?
+    fi
+
+    worker_ppid="$(ps -o ppid= -p "$worker_pid" 2>/dev/null || true)"
+    worker_ppid="${worker_ppid//[[:space:]]/}"
+    if [[ "$worker_ppid" != "$shell_pid" ]]; then
+        echo "[moriio_profiling] ERROR: refusing to manage PID ${worker_pid}; it is not a child of this shell" >&2
+        return 1
+    fi
+
+    state="$(ps -o stat= -p "$worker_pid" 2>/dev/null || true)"
+    if [[ "$state" != Z* ]] && kill -TERM "$worker_pid" 2>/dev/null; then
+        intentional_term=1
+    fi
+
+    while kill -0 "$worker_pid" 2>/dev/null; do
+        state="$(ps -o stat= -p "$worker_pid" 2>/dev/null || true)"
+        if [[ "$state" == Z* ]]; then
+            echo "[moriio_profiling] vLLM/rocprofv3 PID ${worker_pid} finalized in ${elapsed}s"
+            _moriio_profiling_wait_and_verify "$worker_pid" "$intentional_term"
+            return $?
+        fi
+        if (( elapsed >= grace_s )); then
+            echo "[moriio_profiling] ERROR: PID ${worker_pid} did not exit after ${grace_s}s; process snapshot follows" >&2
+            ps -o pid,ppid,pgid,sid,stat,etime,comm,args -p "$worker_pid" --ppid "$worker_pid" >&2 || true
+            echo "[moriio_profiling] ERROR: escalating stuck profiling tree to KILL" >&2
+            if declare -f kill_tree >/dev/null; then
+                kill_tree "$worker_pid" KILL
+            else
+                kill -KILL "$worker_pid" 2>/dev/null || true
+            fi
+            for ((elapsed = 0; elapsed < kill_grace_s; elapsed++)); do
+                state="$(ps -o stat= -p "$worker_pid" 2>/dev/null || true)"
+                [[ -z "$state" || "$state" == Z* ]] && break
+                sleep 1
+            done
+            state="$(ps -o stat= -p "$worker_pid" 2>/dev/null || true)"
+            if [[ -z "$state" || "$state" == Z* ]]; then
+                if _moriio_profiling_wait_and_verify "$worker_pid" 0; then
+                    finalize_rc=0
+                else
+                    finalize_rc=$?
+                fi
+            else
+                echo "[moriio_profiling] ERROR: PID ${worker_pid} remains after KILL cleanup timeout" >&2
+                if moriio_profiling_verify_trace; then
+                    finalize_rc=0
+                else
+                    finalize_rc=$?
+                fi
+            fi
+            if (( finalize_rc != 0 )); then
+                return "$finalize_rc"
+            fi
+            return 1
+        fi
+        sleep 1
+        ((elapsed++)) || true
+    done
+
+    echo "[moriio_profiling] vLLM/rocprofv3 PID ${worker_pid} finalized in ${elapsed}s"
+    _moriio_profiling_wait_and_verify "$worker_pid" "$intentional_term"
+}

--- a/scripts/vllm_dissag/moriio_profiling/patch_moriio_reqid_map.py
+++ b/scripts/vllm_dissag/moriio_profiling/patch_moriio_reqid_map.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+'Idempotently patch installed vLLM MoRIIO sources to log request and write UID mappings.'
+
+import argparse
+import importlib.util
+import os
+import sys
+
+BACKUP_SUFFIX = ".orig_moriio_reqid_map"
+
+
+_HELPER_BLOCK = '''
+# --- BEGIN moriio_profiling: request_id <-> MoRI write_uid map -------------------
+#     Added by moriio_profiling/patch_moriio_reqid_map.py. Gated on env
+#     MORIIO_REQID_MAP=1; when off this is a single module-level bool check.
+import os as _moriio_os
+
+_MORIIO_REQID_MAP_ENABLED = _moriio_os.environ.get("MORIIO_REQID_MAP", "0") == "1"
+
+
+def _moriio_log_reqid_map(request_id, transfer_id, layer_name, write_uid, direction):
+    if not _MORIIO_REQID_MAP_ENABLED:
+        return
+    logger.info(
+        "moriio_reqid_map dir=%s request_id=%s transfer_id=%s layer=%s write_uid=%s",
+        direction,
+        request_id,
+        transfer_id,
+        layer_name,
+        write_uid,
+    )
+# --- END moriio_profiling --------------------------------------------------------
+'''
+
+
+# Anchors must be unique or patching aborts.
+
+_ENGINE_EDITS = [
+    (
+        "engine: insert _moriio_log_reqid_map helper after logger",
+        "logger = init_logger(__name__)\n",
+        "logger = init_logger(__name__)\n" + _HELPER_BLOCK,
+    ),
+    (
+        "engine: write_remote_data signature (+ reqid kwargs)",
+        "    def write_remote_data(\n"
+        "        self, transfer_size_byte, local_offset=0, remote_offset=0, session=None\n"
+        "    ):\n",
+        "    def write_remote_data(\n"
+        "        self, transfer_size_byte, local_offset=0, remote_offset=0, session=None,\n"
+        "        request_id=None, transfer_id=None, layer_name=None,\n"
+        "    ):\n",
+    ),
+    (
+        "engine: write_remote_data body (log after write_uid alloc)",
+        "        write_uid = self.moriio_engine.allocate_transfer_uid()\n"
+        "\n"
+        "        transfer_status = session.batch_write(\n",
+        "        write_uid = self.moriio_engine.allocate_transfer_uid()\n"
+        '        _moriio_log_reqid_map(request_id, transfer_id, layer_name, write_uid, "write")\n'
+        "\n"
+        "        transfer_status = session.batch_write(\n",
+    ),
+    (
+        "engine: write_remote_data_single signature (+ reqid kwargs)",
+        "    def write_remote_data_single(\n"
+        "        self, transfer_size_byte, local_offset=0, remote_offset=0, sess_idx=0\n"
+        "    ):\n",
+        "    def write_remote_data_single(\n"
+        "        self, transfer_size_byte, local_offset=0, remote_offset=0, sess_idx=0,\n"
+        "        request_id=None, transfer_id=None, layer_name=None,\n"
+        "    ):\n",
+    ),
+    (
+        "engine: write_remote_data_single body (hoist uid + log)",
+        "        transfer_status = self.sessions[sess_idx].write(\n"
+        "            local_offset,\n"
+        "            remote_offset,\n"
+        "            transfer_size_byte,\n"
+        "            self.moriio_engine.allocate_transfer_uid(),\n"
+        "        )\n",
+        "        write_uid = self.moriio_engine.allocate_transfer_uid()\n"
+        '        _moriio_log_reqid_map(request_id, transfer_id, layer_name, write_uid, "write_single")\n'
+        "        transfer_status = self.sessions[sess_idx].write(\n"
+        "            local_offset,\n"
+        "            remote_offset,\n"
+        "            transfer_size_byte,\n"
+        "            write_uid,\n"
+        "        )\n",
+    ),
+    (
+        "engine: read_remote_data signature (+ reqid kwargs)",
+        "    def read_remote_data(\n"
+        "        self, transfer_size_byte, local_offset=0, remote_offset=0, session=None\n"
+        "    ):\n",
+        "    def read_remote_data(\n"
+        "        self, transfer_size_byte, local_offset=0, remote_offset=0, session=None,\n"
+        "        request_id=None, transfer_id=None, layer_name=None,\n"
+        "    ):\n",
+    ),
+    (
+        "engine: read_remote_data body (hoist uid + log)",
+        "        transfer_status = session.batch_read(\n"
+        "            local_offset,\n"
+        "            remote_offset,\n"
+        "            transfer_size_byte,\n"
+        "            self.moriio_engine.allocate_transfer_uid(),\n"
+        "        )\n",
+        "        read_uid = self.moriio_engine.allocate_transfer_uid()\n"
+        '        _moriio_log_reqid_map(request_id, transfer_id, layer_name, read_uid, "read")\n'
+        "        transfer_status = session.batch_read(\n"
+        "            local_offset,\n"
+        "            remote_offset,\n"
+        "            transfer_size_byte,\n"
+        "            read_uid,\n"
+        "        )\n",
+    ),
+    (
+        "engine: _do_layer_write batch call (pass reqid through)",
+        "                self.worker.moriio_wrapper.write_remote_data(\n"
+        "                    plan.transfer_sizes,\n"
+        "                    plan.transfer_local_offsets,\n"
+        "                    plan.transfer_remote_offsets,\n"
+        "                    sessions[plan.sess_idx],\n"
+        "                )\n",
+        "                self.worker.moriio_wrapper.write_remote_data(\n"
+        "                    plan.transfer_sizes,\n"
+        "                    plan.transfer_local_offsets,\n"
+        "                    plan.transfer_remote_offsets,\n"
+        "                    sessions[plan.sess_idx],\n"
+        "                    request_id=plan.request_id,\n"
+        "                    transfer_id=plan.transfer_id,\n"
+        "                    layer_name=plan.layer_name,\n"
+        "                )\n",
+    ),
+    (
+        "engine: _do_layer_write single call (pass reqid through)",
+        "                self.worker.moriio_wrapper.write_remote_data_single(\n"
+        "                    plan.transfer_sizes[i],\n"
+        "                    plan.transfer_local_offsets[i],\n"
+        "                    plan.transfer_remote_offsets[i],\n"
+        "                    plan.sess_idx,\n"
+        "                )\n",
+        "                self.worker.moriio_wrapper.write_remote_data_single(\n"
+        "                    plan.transfer_sizes[i],\n"
+        "                    plan.transfer_local_offsets[i],\n"
+        "                    plan.transfer_remote_offsets[i],\n"
+        "                    plan.sess_idx,\n"
+        "                    request_id=plan.request_id,\n"
+        "                    transfer_id=plan.transfer_id,\n"
+        "                    layer_name=plan.layer_name,\n"
+        "                )\n",
+    ),
+]
+
+_CONNECTOR_EDITS = [
+    (
+        "connector: _read_blocks read_remote_data call (pass reqid through)",
+        "            transfer_status = self.moriio_wrapper.read_remote_data(\n"
+        "                offs[2], offs[0], offs[1], sessions[sess_idx]\n"
+        "            )\n",
+        "            transfer_status = self.moriio_wrapper.read_remote_data(\n"
+        "                offs[2],\n"
+        "                offs[0],\n"
+        "                offs[1],\n"
+        "                sessions[sess_idx],\n"
+        "                request_id=request_id,\n"
+        "                transfer_id=transfer_id,\n"
+        "                layer_name=layer_name,\n"
+        "            )\n",
+    ),
+]
+
+# Per-file markers provide idempotency and status checks.
+
+
+FILES = [
+    ("moriio_engine.py", "def _moriio_log_reqid_map(", _ENGINE_EDITS),
+    (
+        "moriio_connector.py",
+        "                sessions[sess_idx],\n                request_id=request_id,",
+        _CONNECTOR_EDITS,
+    ),
+]
+
+
+def locate_moriio_dir(override):
+    if override:
+        if not os.path.isdir(override):
+            fail(f"--moriio-dir does not exist: {override}")
+        return override
+    try:
+        spec = importlib.util.find_spec("vllm")
+    except Exception as e:  # pragma: no cover - depends on runtime env
+        fail(
+            "could not locate the installed vllm package; pass "
+            f"--moriio-dir explicitly. (discovery error: {e})"
+        )
+    if spec is None:
+        fail(
+            "could not locate the installed vllm package; pass "
+            "--moriio-dir explicitly."
+        )
+    package_dirs = list(spec.submodule_search_locations or ())
+    if not package_dirs and spec.origin:
+        package_dirs.append(os.path.dirname(spec.origin))
+    if not package_dirs:
+        fail(
+            "could not determine the installed vllm package directory; pass "
+            "--moriio-dir explicitly."
+        )
+    d = os.path.join(
+        package_dirs[0],
+        "distributed", "kv_transfer", "kv_connector", "v1", "moriio",
+    )
+    if not os.path.isdir(d):
+        fail(f"expected moriio dir not found under installed vllm: {d}")
+    return d
+
+
+def fail(msg):
+    print(f"[patch_moriio_reqid_map] ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def apply_edits(text, edits):
+    'Apply unique-anchor edits or raise without writing.'
+    problems = []
+    out = text
+    for label, old, new in edits:
+        n = out.count(old)
+        if n != 1:
+            problems.append(f"  - {label}: anchor found {n} times (expected 1)")
+            continue
+        out = out.replace(old, new)
+    if problems:
+        raise ValueError("\n".join(problems))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Patch installed vLLM MoRIIO for reqid<->write_uid mapping.")
+    ap.add_argument("--moriio-dir", default=None, help="path to .../kv_connector/v1/moriio")
+    ap.add_argument("--check", action="store_true", help="report status only; change nothing")
+    ap.add_argument("--revert", action="store_true", help="restore the .orig backups")
+    args = ap.parse_args()
+
+    moriio_dir = locate_moriio_dir(args.moriio_dir)
+    print(f"[patch_moriio_reqid_map] target dir: {moriio_dir}")
+
+    if args.revert:
+        reverted = 0
+        for fname, _marker, _ in FILES:
+            path = os.path.join(moriio_dir, fname)
+            bak = path + BACKUP_SUFFIX
+            if os.path.exists(bak):
+                with open(bak, "r", encoding="utf-8") as f:
+                    orig = f.read()
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(orig)
+                os.remove(bak)
+                print(f"[patch_moriio_reqid_map] reverted {fname} from backup")
+                reverted += 1
+            else:
+                print(f"[patch_moriio_reqid_map] no backup for {fname}, skipping")
+        print(f"[patch_moriio_reqid_map] revert done ({reverted} file(s)).")
+        return
+
+    if args.check:
+        for fname, marker, _ in FILES:
+            path = os.path.join(moriio_dir, fname)
+            with open(path, "r", encoding="utf-8") as f:
+                patched = marker in f.read()
+            print(f"[patch_moriio_reqid_map] {fname}: {'PATCHED' if patched else 'unpatched'}")
+        return
+
+    # Validate every edit before writing to avoid partial patches.
+
+    staged = []
+    for fname, marker, edits in FILES:
+        path = os.path.join(moriio_dir, fname)
+        if not os.path.exists(path):
+            fail(f"file not found: {path}")
+        with open(path, "r", encoding="utf-8") as f:
+            text = f.read()
+        if marker in text:
+            print(f"[patch_moriio_reqid_map] {fname}: already patched, skipping")
+            continue
+        try:
+            new_text = apply_edits(text, edits)
+        except ValueError as e:
+            fail(
+                f"anchors did not match cleanly in {fname} (vLLM source may have "
+                f"drifted from the version this patcher targets). Nothing written.\n{e}"
+            )
+        staged.append((path, text, new_text))
+
+    if not staged:
+        print("[patch_moriio_reqid_map] nothing to do (all files already patched).")
+        return
+
+    for path, orig, new_text in staged:
+        bak = path + BACKUP_SUFFIX
+        if not os.path.exists(bak):
+            with open(bak, "w", encoding="utf-8") as f:
+                f.write(orig)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(new_text)
+        print(f"[patch_moriio_reqid_map] patched {os.path.basename(path)} (backup: {os.path.basename(bak)})")
+
+    print("[patch_moriio_reqid_map] done. Enable at runtime with MORIIO_REQID_MAP=1.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vllm_dissag/moriio_profiling/process_kernels.sh
+++ b/scripts/vllm_dissag/moriio_profiling/process_kernels.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+
+# Post-processing continues after failures, preserves raw traces, and returns failure.
+
+_moriio_profiling_setup_kernel_analysis() (
+    set -euo pipefail
+
+    local here ext_dir tracelens_repo venv
+    local -a venv_extra_deps
+    here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+    ext_dir="$here/external_copies"
+    tracelens_repo="${TRACELENS_REPO:-https://github.com/AMD-AGI/TraceLens.git}"
+    venv="${VENV:-$ext_dir/venv}"
+    venv_extra_deps=(pandas plotly matplotlib openpyxl ijson perfetto numpy)
+
+    mkdir -p "$ext_dir" || exit
+
+    echo "=== [1/4] tracelens (clone) ==="
+    if [ -d "$ext_dir/tracelens/.git" ]; then
+        echo "already cloned at $ext_dir/tracelens -- skipping (no git network calls)"
+    else
+        git clone "$tracelens_repo" "$ext_dir/tracelens" || exit
+    fi
+
+    echo "=== [2/4] venv ($venv) ==="
+    if [ ! -f "$venv/bin/activate" ]; then
+        python3 -m venv "$venv" || exit
+    fi
+    # shellcheck disable=SC1091
+    source "$venv/bin/activate" || exit
+    python3 -V || exit
+
+    echo "=== [3/4] pip install (into venv, NOT --user) ==="
+    pip install -e "$ext_dir/tracelens" || exit
+    pip install "${venv_extra_deps[@]}" || exit
+
+    echo "=== [4/4] traceconv (vendored check) ==="
+    if [ -f "$ext_dir/traceconv_bin/traceconv" ]; then
+        echo "traceconv present: $ext_dir/traceconv_bin/traceconv"
+    else
+        echo "WARN: traceconv missing at $ext_dir/traceconv_bin/traceconv -- .pftrace analysis will fail until vendored" >&2
+    fi
+
+    echo "=== verify (imports must resolve from the venv alone) ==="
+    python3 -c "import TraceLens, pandas, plotly, matplotlib, ijson; print('OK TraceLens import:', TraceLens.__file__)" || exit
+    echo "=== kernel-analysis setup DONE -> $ext_dir ==="
+)
+
+_moriio_profiling_analyze_job() (
+    set -euo pipefail
+
+    local here jobdir output_name out d label node_rc
+    local found=0 failures=0
+    here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    jobdir="${1:?usage: _moriio_profiling_analyze_job /path/to/jobdir [output-name]}"
+    output_name="${2:-${KERNEL_ANALYSIS_OUTPUT_NAME:-kernel_analysis_v2}}"
+
+    if [[ ! -d "$jobdir" ]]; then
+        echo "ERROR: job dir not found: $jobdir" >&2
+        exit 2
+    fi
+    if [[ ! "$output_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+        echo "ERROR: invalid analysis output name: $output_name" >&2
+        exit 2
+    fi
+    out="$jobdir/$output_name"
+    if [[ -e "$out" ]]; then
+        echo "ERROR: analysis output already exists; choose a new versioned name: $out" >&2
+        exit 2
+    fi
+    mkdir -p "$out"
+
+    python3 "$here/trace_tools.py" rank-manifest "$jobdir" --out "$out/rank_manifest.json"
+    python3 "$here/trace_tools.py" window-manifest "$jobdir" \
+        --rank-manifest "$out/rank_manifest.json" --out "$out/window_manifest.json"
+    printf 'role_node\tstatus\texit_code\n' > "$out/node_status.tsv"
+
+    shopt -s nullglob
+    for d in "$jobdir"/rocprof_prefill_NODE* "$jobdir"/rocprof_decode_NODE*; do
+        [[ -d "$d" ]] || continue
+        found=$((found + 1))
+        label="${d##*/}"
+        label="${label#rocprof_}"
+        echo "===== analyze_job: $label ($d) ====="
+        if python3 "$here/trace_tools.py" analyze "$d" "$out/$label" "$label" \
+            --rank-manifest "$out/rank_manifest.json" \
+            --window-manifest "$out/window_manifest.json"; then
+            printf '%s\tsuccess\t0\n' "$label" >> "$out/node_status.tsv"
+        else
+            node_rc=$?
+            failures=$((failures + 1))
+            printf '%s\tfailed\t%s\n' "$label" "$node_rc" >> "$out/node_status.tsv"
+            echo "[analyze_job] ERROR: $label failed with status $node_rc; continuing for diagnostics" >&2
+        fi
+    done
+    shopt -u nullglob
+
+    if (( found == 0 )); then
+        echo "ERROR: no rocprof_{prefill,decode}_NODE* dirs found under $jobdir" >&2
+        exit 2
+    fi
+    if (( failures != 0 )); then
+        echo "[analyze_job] ERROR: $failures of $found node analyses failed; see $out/node_status.tsv" >&2
+        exit 1
+    fi
+    echo "[analyze_job] all $found node analyses succeeded -> $out"
+)
+
+
+moriio_profiling_run_posthoc() {
+    local job_id="$1" log_path="$2" master_node="$3" repo_dir="$4" cookbook_path="$5" docker_image="$6"
+    local rc=0
+
+    [[ "${ROCPROF:-0}" == "1" ]] || return 0
+
+    echo "[moriio_profiling] ROCPROF=1 -> combining rocprofv3 traces for job ${job_id}"
+    srun --nodes=1 --ntasks=1 --nodelist="${master_node}" bash -c "
+        docker run --rm \
+            -v ${log_path}:/run_logs \
+            -v ${repo_dir}:${cookbook_path} \
+            --entrypoint /bin/bash \
+            ${docker_image} -c '
+                python3 ${cookbook_path}/moriio_profiling/trace_tools.py combine /run_logs/${job_id}
+            '
+    " || { echo "[moriio_profiling] ERROR: trace_tools.py combine failed; raw per-rank output is untouched" >&2; rc=1; }
+
+    if [[ "${MORIIO_REQID_MAP:-0}" == "1" ]]; then
+        echo "[moriio_profiling] MORIIO_REQID_MAP=1 -> extracting reqid map for job ${job_id}"
+        srun --nodes=1 --ntasks=1 --nodelist="${master_node}" bash -c "
+            docker run --rm \
+                -v ${log_path}:/run_logs \
+                -v ${repo_dir}:${cookbook_path} \
+                --entrypoint /bin/bash \
+                ${docker_image} -c '
+                    shopt -s nullglob
+                    logs=(/run_logs/${job_id}/prefill_NODE*.log)
+                    if [ \${#logs[@]} -eq 0 ]; then
+                        echo \"[trace_tools extract-reqid] WARNING: no prefill_NODE*.log files found under /run_logs/${job_id} -- skipping\" >&2
+                        exit 0
+                    fi
+                    python3 ${cookbook_path}/moriio_profiling/trace_tools.py extract-reqid \"\${logs[@]}\" -o /run_logs/${job_id}/reqid_map.csv
+                '
+        " || { echo "[moriio_profiling] ERROR: trace_tools.py extract-reqid failed; prefill logs are untouched" >&2; rc=1; }
+    else
+        echo "[moriio_profiling] MORIIO_REQID_MAP!=1 -> skipping reqid map extraction for job ${job_id}"
+    fi
+
+    [[ "${ANALYZE_KERNELS:-1}" == "1" ]] || return "$rc"
+
+    echo "[moriio_profiling] ANALYZE_KERNELS=1 -> running kernel analysis for job ${job_id}"
+    srun --nodes=1 --ntasks=1 --nodelist="${master_node}" bash -c "
+        docker run --rm \
+            -v ${log_path}:/run_logs \
+            -v ${repo_dir}:${cookbook_path} \
+            --entrypoint /bin/bash \
+            ${docker_image} -c '
+                source ${cookbook_path}/moriio_profiling/process_kernels.sh &&
+                _moriio_profiling_setup_kernel_analysis &&
+                _moriio_profiling_analyze_job /run_logs/${job_id}
+            '
+    " || { echo "[moriio_profiling] ERROR: kernel analysis failed; raw output and combined traces are untouched" >&2; rc=1; }
+    return "$rc"
+}
+
+_moriio_profiling_kernels_cli() (
+    set -euo pipefail
+
+    if [[ $# -ne 2 || "$1" != "--kernels" || -z "$2" ]]; then
+        echo "usage: $0 --kernels <job-id|job-dir>" >&2
+        exit 2
+    fi
+
+    local arg="$2"
+    local here repo_dir user jobdir job_root job_name cookbook_path image base
+    local -a srun_args cmd
+    here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    repo_dir="$(cd "$here/.." && pwd)"
+    user="${USER:-$(id -un)}"
+
+    if [[ -d "$arg" ]]; then
+        jobdir="$(realpath "$arg")"
+    elif [[ "$arg" =~ ^[0-9]+$ ]]; then
+        jobdir=""
+        for base in "${LOG_PATH:-}" "/shared_inference/${user}/model_blog_logs" "/shared_inference/${user}/moriio_prof_runs"; do
+            [[ -n "$base" && -d "$base/$arg" ]] || continue
+            jobdir="$(realpath "$base/$arg")"
+            break
+        done
+        if [[ -z "$jobdir" ]]; then
+            echo "ERROR: job $arg not found under LOG_PATH, model_blog_logs, or moriio_prof_runs" >&2
+            exit 2
+        fi
+    else
+        echo "ERROR: not a job ID or directory: $arg" >&2
+        exit 2
+    fi
+
+    job_root="$(dirname "$jobdir")"
+    job_name="$(basename "$jobdir")"
+    cookbook_path="${NIXL_COOKBOOK_PATH:-/opt/nixl-vllm-cookbook}"
+    image="${DOCKER_IMAGE_NAME:-rocmshared/pytorch-private:aarai_vllm_moriio_srcinstrumented_20260722_r1}"
+
+    srun_args=(--nodes=1 --ntasks=1)
+    if [[ -z "${SLURM_JOB_ID:-}" ]]; then
+        srun_args+=(--partition="${SBATCH_PARTITION:-amd-rccl}" --gres="${SBATCH_GRES:-gpu:1}" --time="${SBATCH_TIME:-02:00:00}")
+    fi
+    cmd=(srun "${srun_args[@]}" docker run --rm
+        -v "$job_root:/run_logs"
+        -v "$repo_dir:$cookbook_path"
+        --entrypoint /bin/bash "$image" -lc
+        "source '$cookbook_path/moriio_profiling/process_kernels.sh' && _moriio_profiling_setup_kernel_analysis && _moriio_profiling_analyze_job '/run_logs/$job_name' '${KERNEL_ANALYSIS_OUTPUT_NAME:-kernel_analysis_v2}'")
+
+    echo "[process_kernels.sh --kernels] job: $jobdir"
+    echo "[process_kernels.sh --kernels] image: $image"
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+        printf '[process_kernels.sh --kernels] DRY_RUN:'
+        printf ' %q' "${cmd[@]}"
+        printf '\n'
+        exit 0
+    fi
+    exec "${cmd[@]}"
+)
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    _moriio_profiling_kernels_cli "$@"
+fi

--- a/scripts/vllm_dissag/moriio_profiling/trace_tools.py
+++ b/scripts/vllm_dissag/moriio_profiling/trace_tools.py
@@ -1,0 +1,3075 @@
+#!/usr/bin/env python3
+'''Combine traces, bucket kernels, extract request mappings, build trimmed summaries, and run the single-trace analysis pipeline.'''
+import argparse, csv, fnmatch, glob, io, json, math, os, re, shutil, signal, socket, statistics, subprocess, sys, time
+
+csv.field_size_limit(sys.maxsize)
+
+
+def log(msg):
+    print(f"[combine_traces] {msg}", flush=True)
+
+
+_NODE_DIR_RE = re.compile(r"^rocprof_(prefill|decode)_NODE(\d+)$")
+_RANK_RE = re.compile(r"^(?P<host>.+)_(?P<pid>\d+)_kernel_trace\.csv$")
+_REQID_LOG_RE = re.compile(r"^(?P<role>prefill|decode)_NODE(?P<node_rank>\d+)\.log$")
+_REQID_PID_RE = re.compile(r"\bpid=(?P<pid>\d+)\b")
+_REQID_LINE_RE = re.compile(
+    r"moriio_reqid_map\s+"
+    r"dir=(?P<direction>\S+)\s+"
+    r"request_id=(?P<request_id>\S+)\s+"
+    r"transfer_id=(?P<transfer_id>\S+)\s+"
+    r"layer=(?P<layer>\S+)\s+"
+    r"write_uid=(?P<write_uid>\S+)"
+)
+_WORKER_RANK_RE = re.compile(
+    r"\(Worker(?:_[^)]*)? pid=(?P<pid>\d+)\).*?"
+    r"world_size=(?P<world_size>\d+)\s+rank=(?P<global_rank>\d+)\s+"
+    r"local_rank=(?P<local_rank>\d+)\b"
+)
+_WORKER_ASSIGN_RE = re.compile(
+    r"\(Worker(?:_[^)]*)? pid=(?P<pid>\d+)\).*?"
+    r"rank (?P<global_rank>\d+) in world size (?P<world_size>\d+) is assigned as "
+    r"DP rank (?P<dp_rank>\d+), PP rank (?P<pp_rank>\d+), "
+    r"PCP rank (?P<pcp_rank>\d+), TP rank (?P<tp_rank>\d+), "
+    r"EP rank (?P<ep_rank>\d+)"
+)
+
+
+def parse_reqid_maps(paths):
+    rows = []
+    for path in paths:
+        path_match = _REQID_LOG_RE.fullmatch(os.path.basename(path))
+        path_fields = (path_match.groupdict() if path_match
+                       else {"role": "", "node_rank": ""})
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                match = _REQID_LINE_RE.search(line)
+                if match:
+                    row = match.groupdict()
+                    row.update(path_fields)
+                    pid_match = _REQID_PID_RE.search(line, 0, match.start())
+                    row["pid"] = pid_match.group("pid") if pid_match else ""
+                    rows.append(row)
+    return rows
+
+
+def discover_node_dirs(jobdir):
+    out = []
+    for name in sorted(os.listdir(jobdir)):
+        m = _NODE_DIR_RE.match(name)
+        if not m:
+            continue
+        full = os.path.join(jobdir, name)
+        if os.path.isdir(full):
+            out.append((m.group(1), int(m.group(2)), full))
+    out.sort(key=lambda x: (x[0], x[1]))
+    return out
+
+
+class RankManifestError(ValueError):
+    pass
+
+
+def _artifact_rows(dirpath):
+    rows = {}
+    for kcsv in sorted(glob.glob(os.path.join(dirpath, "*_kernel_trace.csv"))):
+        match = _RANK_RE.fullmatch(os.path.basename(kcsv))
+        if not match:
+            continue
+        pid = int(match.group("pid"))
+        if pid in rows:
+            raise RankManifestError(f"duplicate kernel trace for PID {pid} in {dirpath}")
+        host = match.group("host")
+        prefix = os.path.join(dirpath, f"{host}_{pid}")
+        rows[pid] = {
+            "hostname": host,
+            "kernel_csv": kcsv,
+            "pftrace": prefix + "_results.pftrace" if os.path.isfile(prefix + "_results.pftrace") else None,
+            "rocprof_json": prefix + "_results.json" if os.path.isfile(prefix + "_results.json") else None,
+        }
+    return rows
+
+
+def _parse_worker_log(path):
+    workers = {}
+    assignments = {}
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        for lineno, line in enumerate(f, 1):
+            match = _WORKER_RANK_RE.search(line)
+            if match:
+                row = {key: int(value) for key, value in match.groupdict().items()}
+                row["source_line"] = lineno
+                pid = row["pid"]
+                old = workers.get(pid)
+                comparable = {k: row[k] for k in ("pid", "world_size", "global_rank", "local_rank")}
+                if old and any(old[k] != comparable[k] for k in comparable):
+                    raise RankManifestError(f"conflicting worker-rank lines for PID {pid} in {path}")
+                workers[pid] = comparable | {"source_line": old["source_line"] if old else lineno}
+
+            match = _WORKER_ASSIGN_RE.search(line)
+            if match:
+                row = {key: int(value) for key, value in match.groupdict().items()}
+                row["source_line"] = lineno
+                pid = row["pid"]
+                old = assignments.get(pid)
+                if old and any(old[k] != row[k] for k in row if k != "source_line"):
+                    raise RankManifestError(f"conflicting rank-assignment lines for PID {pid} in {path}")
+                assignments[pid] = old or row
+    return workers, assignments
+
+
+def build_rank_manifest(jobdir):
+    jobdir = os.path.abspath(jobdir)
+    node_dirs = discover_node_dirs(jobdir)
+    if not node_dirs:
+        raise RankManifestError(f"no rocprof_{{prefill,decode}}_NODE* dirs found under {jobdir}")
+
+    manifest_rows = []
+    selections = []
+    for role, node_rank, dirpath in node_dirs:
+        log_path = os.path.join(jobdir, f"{role}_NODE{node_rank}.log")
+        if not os.path.isfile(log_path):
+            raise RankManifestError(f"missing worker log for {role} NODE{node_rank}: {log_path}")
+        workers, assignments = _parse_worker_log(log_path)
+        artifacts = _artifact_rows(dirpath)
+        if not workers:
+            raise RankManifestError(f"no worker rank mappings found in {log_path}")
+        if set(workers) != set(artifacts):
+            missing_logs = sorted(set(artifacts) - set(workers))
+            missing_traces = sorted(set(workers) - set(artifacts))
+            raise RankManifestError(
+                f"PID mapping/trace mismatch for {role} NODE{node_rank}: "
+                f"unmapped_trace_pids={missing_logs}, mapped_pids_without_trace={missing_traces}"
+            )
+
+        local_ranks = [row["local_rank"] for row in workers.values()]
+        if len(local_ranks) != len(set(local_ranks)):
+            raise RankManifestError(f"duplicate local_rank in {log_path}: {sorted(local_ranks)}")
+        expected = list(range(len(local_ranks)))
+        if sorted(local_ranks) != expected:
+            raise RankManifestError(
+                f"missing/ambiguous local ranks in {log_path}: got {sorted(local_ranks)}, expected {expected}"
+            )
+
+        rank0 = [row for row in workers.values() if row["local_rank"] == 0]
+        if len(rank0) != 1:
+            raise RankManifestError(
+                f"expected exactly one local_rank=0 for {role} NODE{node_rank}, found {len(rank0)}"
+            )
+
+        for pid, worker in sorted(workers.items(), key=lambda item: item[1]["local_rank"]):
+            assignment = assignments.get(pid)
+            if assignment and (
+                assignment["global_rank"] != worker["global_rank"]
+                or assignment["world_size"] != worker["world_size"]
+            ):
+                raise RankManifestError(f"rank assignment conflicts with init mapping for PID {pid} in {log_path}")
+            artifact = artifacts[pid]
+            row = {
+                "role": role,
+                "node_rank": node_rank,
+                "hostname": artifact["hostname"],
+                "pid": pid,
+                "world_size": worker["world_size"],
+                "global_rank": worker["global_rank"],
+                "local_rank": worker["local_rank"],
+                "dp_rank": assignment["dp_rank"] if assignment else None,
+                "ep_rank": assignment["ep_rank"] if assignment else None,
+                "pp_rank": assignment["pp_rank"] if assignment else None,
+                "tp_rank": assignment["tp_rank"] if assignment else None,
+                "source_log": os.path.relpath(log_path, jobdir),
+                "source_line": worker["source_line"],
+                "assignment_source_line": assignment["source_line"] if assignment else None,
+                "artifacts": {
+                    key: os.path.relpath(value, jobdir) if value else None
+                    for key, value in artifact.items() if key != "hostname"
+                },
+            }
+            manifest_rows.append(row)
+            if row["local_rank"] == 0:
+                selections.append({key: row[key] for key in (
+                    "role", "node_rank", "hostname", "pid", "world_size",
+                    "global_rank", "local_rank", "dp_rank", "ep_rank", "pp_rank", "tp_rank"
+                )})
+
+    manifest = {
+        "schema_version": 1,
+        "job_dir": jobdir,
+        "selection_rule": "exactly local_rank == 0 per role/node; no PID or filename ordering fallback",
+        "workers": manifest_rows,
+        "selections": selections,
+    }
+    for key in sorted({(row["role"], int(row["node_rank"])) for row in manifest_rows}):
+        selected_workers(manifest, *key)
+    return manifest
+
+
+def write_rank_manifest(jobdir, out_path):
+    manifest = build_rank_manifest(jobdir)
+    os.makedirs(os.path.dirname(os.path.abspath(out_path)), exist_ok=True)
+    tmp = f"{out_path}.tmp.{os.getpid()}"
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, indent=2, sort_keys=True)
+            f.write("\n")
+        os.replace(tmp, out_path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+    return manifest
+
+
+def load_rank_manifest(path, jobdir=None):
+    with open(path, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+    if manifest.get("schema_version") != 1:
+        raise RankManifestError(f"unsupported rank manifest schema in {path}")
+    if jobdir and os.path.abspath(manifest.get("job_dir", "")) != os.path.abspath(jobdir):
+        raise RankManifestError(f"rank manifest {path} belongs to {manifest.get('job_dir')}, not {jobdir}")
+    try:
+        keys = [(row["role"], int(row["node_rank"])) for row in manifest.get("workers", [])]
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RankManifestError(f"malformed worker row in rank manifest {path}: {exc}") from exc
+    for key in sorted(set(keys)):
+        selected_workers(manifest, *key)
+    return manifest
+
+
+def selected_workers(manifest, role, node_rank):
+    """Return every validated worker for one role/node in local-rank order."""
+    if role not in ("prefill", "decode"):
+        raise RankManifestError(f"invalid worker role {role!r}")
+    try:
+        workers = manifest["workers"]
+        role_rows = [row for row in workers if row["role"] == role]
+        world_sizes = {int(row["world_size"]) for row in role_rows}
+        role_nodes = sorted({int(row["node_rank"]) for row in role_rows})
+        global_ranks = [int(row["global_rank"]) for row in role_rows]
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RankManifestError(f"malformed worker manifest for role {role}: {exc}") from exc
+    if not role_rows or not role_nodes:
+        raise RankManifestError(f"manifest has no workers for role {role}")
+    if len(world_sizes) != 1:
+        raise RankManifestError(f"ambiguous world_size values for role {role}: {sorted(world_sizes)}")
+    world_size = next(iter(world_sizes))
+    if world_size <= 0 or sorted(global_ranks) != list(range(world_size)):
+        raise RankManifestError(
+            f"missing/duplicate global ranks for role {role}: "
+            f"got {sorted(global_ranks)}, expected {list(range(world_size))}"
+        )
+    if world_size % len(role_nodes):
+        raise RankManifestError(
+            f"world_size {world_size} is not divisible by {len(role_nodes)} nodes for role {role}"
+        )
+    expected_local_world_size = world_size // len(role_nodes)
+    requested = []
+    seen_artifacts = set()
+    for current_node in role_nodes:
+        rows = [row for row in role_rows if int(row["node_rank"]) == current_node]
+        try:
+            local_ranks = [int(row["local_rank"]) for row in rows]
+            pids = [int(row["pid"]) for row in rows]
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RankManifestError(
+                f"malformed worker identity for {role} NODE{current_node}: {exc}"
+            ) from exc
+        expected_ranks = list(range(expected_local_world_size))
+        if sorted(local_ranks) != expected_ranks:
+            raise RankManifestError(
+                f"missing/duplicate local ranks for {role} NODE{current_node}: "
+                f"got {sorted(local_ranks)}, expected {expected_ranks}"
+            )
+        if len(pids) != len(set(pids)):
+            raise RankManifestError(f"duplicate worker PID for {role} NODE{current_node}: {pids}")
+        hosts = {str(row.get("hostname", "")) for row in rows}
+        if len(hosts) != 1 or not next(iter(hosts)):
+            raise RankManifestError(
+                f"ambiguous worker host for {role} NODE{current_node}: {sorted(hosts)}"
+            )
+        for row in rows:
+            if row.get("source_log") != f"{role}_NODE{current_node}.log":
+                raise RankManifestError(
+                    f"wrong-role/node source log for PID {row['pid']}: {row.get('source_log')}"
+                )
+            artifact = row.get("artifacts", {}).get("kernel_csv")
+            if not isinstance(artifact, str) or not artifact:
+                raise RankManifestError(f"missing kernel CSV artifact for PID {row['pid']}")
+            normalized = os.path.normpath(artifact).replace("\\", "/")
+            parts = normalized.split("/")
+            expected_dir = f"rocprof_{role}_NODE{current_node}"
+            if (os.path.isabs(artifact) or normalized == ".." or normalized.startswith("../")
+                    or len(parts) != 2 or parts[0] != expected_dir):
+                raise RankManifestError(
+                    f"wrong-role/node kernel CSV for PID {row['pid']}: {artifact}"
+                )
+            match = _RANK_RE.fullmatch(parts[1])
+            if (not match or int(match.group("pid")) != int(row["pid"])
+                    or match.group("host") != row["hostname"]):
+                raise RankManifestError(
+                    f"ambiguous kernel CSV identity for PID {row['pid']}: {artifact}"
+                )
+            if normalized in seen_artifacts:
+                raise RankManifestError(f"duplicate kernel CSV in manifest: {artifact}")
+            seen_artifacts.add(normalized)
+        if current_node == int(node_rank):
+            requested = sorted(rows, key=lambda row: int(row["local_rank"]))
+    if not requested:
+        raise RankManifestError(f"manifest has no workers for {role} NODE{node_rank}")
+    return requested
+
+
+def selected_worker(manifest, role, node_rank):
+    rows = [row for row in manifest["workers"]
+            if row["role"] == role and int(row["node_rank"]) == int(node_rank)
+            and int(row["local_rank"]) == 0]
+    if len(rows) != 1:
+        raise RankManifestError(
+            f"expected one manifest selection for {role} NODE{node_rank}, found {len(rows)}"
+        )
+    return rows[0]
+
+
+class WindowMappingError(ValueError):
+    pass
+
+
+class ClockAlignmentError(ValueError):
+    pass
+
+
+def _append_jsonl(path, row):
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(row, sort_keys=True) + "\n")
+        f.flush()
+        os.fsync(f.fileno())
+
+
+def _clock_pair():
+    realtime_before_ns = time.time_ns()
+    monotonic_ns = time.monotonic_ns()
+    boottime_ns = (
+        time.clock_gettime_ns(time.CLOCK_BOOTTIME)
+        if hasattr(time, "CLOCK_BOOTTIME") else None
+    )
+    realtime_after_ns = time.time_ns()
+    pair = {
+        "realtime_before_ns": realtime_before_ns,
+        "realtime_after_ns": realtime_after_ns,
+        "realtime_mid_ns": (realtime_before_ns + realtime_after_ns) // 2,
+        "monotonic_ns": monotonic_ns,
+        "pair_uncertainty_ns": (realtime_after_ns - realtime_before_ns + 1) // 2,
+    }
+    if boottime_ns is not None:
+        pair["boottime_ns"] = boottime_ns
+    return pair
+
+
+def _clock_sync_snapshot():
+    commands = (["chronyc", "tracking", "-n"], ["timedatectl", "timesync-status"])
+    for cmd in commands:
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        except (OSError, subprocess.SubprocessError):
+            continue
+        text = (proc.stdout or "") + (proc.stderr or "")
+        if proc.returncode != 0:
+            continue
+        values = {}
+        for label in ("Last offset", "Root delay", "Root dispersion"):
+            match = re.search(rf"^{re.escape(label)}\s*:\s*([+-]?[0-9.eE+-]+)\s+seconds", text, re.MULTILINE)
+            if match:
+                values[label] = abs(float(match.group(1)))
+        leap_ok = bool(re.search(r"^Leap status\s*:\s*Normal\s*$", text, re.MULTILINE))
+        if leap_ok and "Root dispersion" in values:
+            uncertainty_s = values.get("Last offset", 0.0) + values["Root dispersion"] + values.get("Root delay", 0.0) / 2.0
+            return {
+                "available": True,
+                "command": cmd,
+                "uncertainty_ns": int(math.ceil(uncertainty_s * 1e9)),
+                "raw": text,
+            }
+        return {"available": False, "command": cmd, "uncertainty_ns": None, "raw": text}
+    return {"available": False, "command": None, "uncertainty_ns": None, "raw": "no clock-sync status command available"}
+
+
+def run_clock_sampler(out_path, node_rank, interval_s):
+    if interval_s <= 0:
+        raise ValueError(f"clock sample interval must be positive, got {interval_s}")
+    stop = False
+
+    def request_stop(_signum, _frame):
+        nonlocal stop
+        stop = True
+
+    signal.signal(signal.SIGTERM, request_stop)
+    signal.signal(signal.SIGINT, request_stop)
+    try:
+        boot_id = open("/proc/sys/kernel/random/boot_id", encoding="utf-8").read().strip()
+    except OSError:
+        boot_id = None
+    _append_jsonl(out_path, {
+        "kind": "clock_sampler_metadata",
+        "schema_version": 1,
+        "timestamp_unit": "ns",
+        "source_trace_clock": "CLOCK_BOOTTIME",
+        "node_rank": int(node_rank),
+        "hostname": socket.gethostname(),
+        "boot_id": boot_id,
+        "clock": time.get_clock_info("monotonic").__dict__,
+        "clock_sync": _clock_sync_snapshot(),
+    })
+    while not stop:
+        _append_jsonl(out_path, {
+            "kind": "clock_sample",
+            "node_rank": int(node_rank),
+            "hostname": socket.gethostname(),
+            **_clock_pair(),
+        })
+        deadline = time.monotonic() + interval_s
+        while not stop and time.monotonic() < deadline:
+            time.sleep(min(0.2, max(0.0, deadline - time.monotonic())))
+    _append_jsonl(out_path, {
+        "kind": "clock_sampler_stop",
+        "node_rank": int(node_rank),
+        "hostname": socket.gethostname(),
+        **_clock_pair(),
+    })
+
+
+def record_benchmark_marker(out_path, event, step_id, fields):
+    row = {
+        "kind": "benchmark_marker",
+        "event": event,
+        "step_id": step_id,
+        "hostname": socket.gethostname(),
+        **_clock_pair(),
+    }
+    row.update({key: value for key, value in fields.items() if value is not None})
+    _append_jsonl(out_path, row)
+    return row
+
+
+def _read_jsonl(path):
+    rows = []
+    with open(path, "r", encoding="utf-8") as f:
+        for lineno, line in enumerate(f, 1):
+            if not line.strip():
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise WindowMappingError(f"invalid JSON at {path}:{lineno}: {exc}") from exc
+    return rows
+
+
+def _map_wall_to_monotonic(samples, wall_ns, sync_uncertainty_ns, max_gap_ns):
+    samples = sorted(samples, key=lambda row: int(row["realtime_mid_ns"]))
+    before = None
+    after = None
+    for sample in samples:
+        sample_wall = int(sample["realtime_mid_ns"])
+        if sample_wall <= wall_ns:
+            before = sample
+        if sample_wall >= wall_ns:
+            after = sample
+            break
+    if before is None or after is None:
+        raise WindowMappingError(f"wall timestamp {wall_ns} is not bracketed by node clock samples")
+    r1 = int(before["realtime_mid_ns"])
+    r2 = int(after["realtime_mid_ns"])
+    if r2 - r1 > max_gap_ns:
+        raise WindowMappingError(f"clock-sample gap {r2-r1} ns exceeds {max_gap_ns} ns")
+    o1 = int(before["monotonic_ns"]) - r1
+    o2 = int(after["monotonic_ns"]) - r2
+    offset = o1 if r2 == r1 else o1 + ((o2 - o1) * (wall_ns - r1)) // (r2 - r1)
+    uncertainty = (
+        max(int(before.get("pair_uncertainty_ns", 0)), int(after.get("pair_uncertainty_ns", 0)))
+        + abs(o2 - o1) + int(sync_uncertainty_ns)
+    )
+    return wall_ns + offset, uncertainty, {
+        "formula": "trace_monotonic_ns = wall_realtime_ns + linearly_interpolated(monotonic_ns - realtime_mid_ns)",
+        "before_realtime_ns": r1,
+        "after_realtime_ns": r2,
+        "before_offset_ns": o1,
+        "after_offset_ns": o2,
+    }
+
+
+def build_window_manifest(jobdir, rank_manifest):
+    jobdir = os.path.abspath(jobdir)
+    timing_path = os.path.join(jobdir, "benchmark_timing.jsonl")
+    clock_paths = sorted(glob.glob(os.path.join(jobdir, "clock_NODE*.jsonl")))
+    historical_sources = []
+    for log_path in sorted(glob.glob(os.path.join(jobdir, "benchmark_*_CONCURRENCY.log"))):
+        initial_utc = None
+        with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+            for _ in range(10):
+                line = f.readline()
+                if not line:
+                    break
+                if line.startswith("UTC Time:"):
+                    initial_utc = line.strip()
+                    break
+        historical_sources.append({
+            "benchmark_log": os.path.relpath(log_path, jobdir),
+            "initial_log_timestamp": initial_utc,
+            "exact_measured_start_end_present": False,
+        })
+    unavailable = {
+        "schema_version": 1,
+        "job_dir": jobdir,
+        "available": False,
+        "analysis_scope": "whole_capture",
+        "reason": (
+            "historical job has no benchmark_timing.jsonl/per-node clock samples; "
+            "wall/log timestamps cannot be mapped reliably to trace monotonic time"
+        ),
+        "source_timestamps": historical_sources,
+        "node_windows": [],
+    }
+    if not os.path.isfile(timing_path) and not clock_paths:
+        return unavailable
+    if not os.path.isfile(timing_path):
+        raise WindowMappingError("clock samples exist but benchmark_timing.jsonl is missing")
+
+    markers = [row for row in _read_jsonl(timing_path) if row.get("kind") == "benchmark_marker"]
+    by_step = {}
+    for marker in markers:
+        key = (str(marker.get("step_id")), str(marker.get("event")))
+        if key in by_step:
+            raise WindowMappingError(f"duplicate benchmark marker {key} in {timing_path}")
+        by_step[key] = marker
+    step_ids = sorted({key[0] for key in by_step})
+    if not step_ids:
+        raise WindowMappingError(f"no benchmark markers in {timing_path}")
+    starts = []
+    ends = []
+    for step_id in step_ids:
+        start = by_step.get((step_id, "start"))
+        end = by_step.get((step_id, "end"))
+        if not start or not end:
+            raise WindowMappingError(f"unpaired benchmark markers for step {step_id}")
+        if int(end.get("return_code", 0)) != 0:
+            raise WindowMappingError(f"benchmark step {step_id} ended with status {end.get('return_code')}")
+        starts.append(start)
+        ends.append(end)
+    wall_start_ns = min(int(row["realtime_mid_ns"]) for row in starts)
+    wall_end_ns = max(int(row["realtime_mid_ns"]) for row in ends)
+    if wall_end_ns <= wall_start_ns:
+        raise WindowMappingError("benchmark end is not after benchmark start")
+
+    max_gap_ns = int(os.environ.get("CLOCK_SAMPLE_MAX_GAP_NS", "5000000000"))
+    max_uncertainty_ns = int(os.environ.get("WINDOW_MAX_UNCERTAINTY_NS", "20000000"))
+    node_windows = []
+    for selection in rank_manifest["selections"]:
+        role = selection["role"]
+        node_rank = int(selection["node_rank"])
+        clock_path = os.path.join(jobdir, f"clock_NODE{node_rank}.jsonl")
+        if not os.path.isfile(clock_path):
+            raise WindowMappingError(f"missing clock samples for NODE{node_rank}: {clock_path}")
+        rows = _read_jsonl(clock_path)
+        metadata = [row for row in rows if row.get("kind") == "clock_sampler_metadata"]
+        samples = [row for row in rows if row.get("kind") == "clock_sample"]
+        if len(metadata) != 1 or len(samples) < 2:
+            raise WindowMappingError(f"insufficient clock metadata/samples in {clock_path}")
+        sync = metadata[0].get("clock_sync") or {}
+        if not sync.get("available") or sync.get("uncertainty_ns") is None:
+            raise WindowMappingError(f"NODE{node_rank} lacks usable clock-sync uncertainty evidence")
+        start_ns, start_unc, start_formula = _map_wall_to_monotonic(
+            samples, wall_start_ns, int(sync["uncertainty_ns"]), max_gap_ns)
+        end_ns, end_unc, end_formula = _map_wall_to_monotonic(
+            samples, wall_end_ns, int(sync["uncertainty_ns"]), max_gap_ns)
+        uncertainty_ns = max(start_unc, end_unc)
+        if uncertainty_ns > max_uncertainty_ns:
+            raise WindowMappingError(
+                f"NODE{node_rank} clock uncertainty {uncertainty_ns} ns exceeds {max_uncertainty_ns} ns"
+            )
+        node_windows.append({
+            "role": role,
+            "node_rank": node_rank,
+            "hostname": selection["hostname"],
+            "start_monotonic_ns": start_ns,
+            "end_monotonic_ns": end_ns,
+            "uncertainty_ns": uncertainty_ns,
+            "clock_sync": sync,
+            "start_conversion": start_formula,
+            "end_conversion": end_formula,
+        })
+    return {
+        "schema_version": 1,
+        "job_dir": jobdir,
+        "available": True,
+        "analysis_scope": "benchmark_window",
+        "wall_start_realtime_ns": wall_start_ns,
+        "wall_end_realtime_ns": wall_end_ns,
+        "source_timestamps": markers,
+        "node_windows": node_windows,
+        "max_clock_uncertainty_ns": max_uncertainty_ns,
+    }
+
+
+def write_window_manifest(jobdir, rank_manifest, out_path):
+    manifest = build_window_manifest(jobdir, rank_manifest)
+    os.makedirs(os.path.dirname(os.path.abspath(out_path)), exist_ok=True)
+    tmp = f"{out_path}.tmp.{os.getpid()}"
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, indent=2, sort_keys=True)
+            f.write("\n")
+        os.replace(tmp, out_path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+    return manifest
+
+
+def load_window_manifest(path, role, node_rank):
+    with open(path, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+    if not manifest.get("available"):
+        return manifest, None
+    rows = [row for row in manifest.get("node_windows", [])
+            if row["role"] == role and int(row["node_rank"]) == int(node_rank)]
+    if len(rows) != 1:
+        raise WindowMappingError(f"expected one window for {role} NODE{node_rank}, found {len(rows)}")
+    return manifest, (int(rows[0]["start_monotonic_ns"]), int(rows[0]["end_monotonic_ns"]))
+
+
+def discover_ranks(dirpath):
+    'Discover trace artifacts; callers must join them to the rank manifest.'
+    ranks = []
+    for kcsv in glob.glob(os.path.join(dirpath, "*_kernel_trace.csv")):
+        m = _RANK_RE.match(os.path.basename(kcsv))
+        if not m:
+            continue
+        host, pid = m.group("host"), m.group("pid")
+        marker = os.path.join(dirpath, f"{host}_{pid}_marker_api_trace.csv")
+        pftrace = os.path.join(dirpath, f"{host}_{pid}_results.pftrace")
+        ranks.append((
+            int(pid), host, kcsv,
+            marker if os.path.exists(marker) else None,
+            pftrace if os.path.exists(pftrace) else None,
+        ))
+    ranks.sort(key=lambda x: x[0])
+    return ranks
+
+
+_NATIVE_CLOCK_CACHE = {}
+
+
+def _checked_ns(value, label):
+    if isinstance(value, bool):
+        raise ClockAlignmentError(f"{label} is not an integer nanosecond timestamp")
+    try:
+        result = int(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ClockAlignmentError(f"{label} is not an integer nanosecond timestamp: {value!r}") from exc
+    if isinstance(value, float) and not value.is_integer():
+        raise ClockAlignmentError(f"{label} is not an integer nanosecond timestamp: {value!r}")
+    if result < 0 or result > INT64_MAX:
+        raise ClockAlignmentError(f"{label} is outside signed-int64 nanoseconds: {result}")
+    return result
+
+
+def _wall_ns(source_ns, offset_ns, label):
+    wall_ns = source_ns + offset_ns
+    if wall_ns < 0 or wall_ns > INT64_MAX:
+        raise ClockAlignmentError(f"{label} wall-clock alignment overflows signed-int64: {wall_ns}")
+    return wall_ns
+
+
+def _load_explicit_clock_manifest(path, jobdir):
+    if not path:
+        return None
+    with open(path, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+    if manifest.get("schema_version") != 1 or manifest.get("timestamp_unit") != "ns":
+        raise ClockAlignmentError(
+            f"clock manifest {path} must have schema_version=1 and timestamp_unit='ns'"
+        )
+    manifest_jobdir = manifest.get("job_dir")
+    if manifest_jobdir and os.path.abspath(manifest_jobdir) != os.path.abspath(jobdir):
+        raise ClockAlignmentError(f"clock manifest {path} belongs to {manifest_jobdir}, not {jobdir}")
+    alignments = {}
+    for index, row in enumerate(manifest.get("nodes", [])):
+        try:
+            key = (str(row["role"]), int(row["node_rank"]))
+            hostname = str(row["hostname"])
+            source_clock = str(row["source_clock"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ClockAlignmentError(f"invalid node identity at {path}:nodes[{index}]") from exc
+        if key in alignments:
+            raise ClockAlignmentError(f"duplicate clock mapping for {key} in {path}")
+        if key[0] not in ("prefill", "decode") or key[1] < 0 or not hostname:
+            raise ClockAlignmentError(f"invalid role/node/hostname at {path}:nodes[{index}]")
+        if row.get("timestamp_unit", "ns") != "ns":
+            raise ClockAlignmentError(f"non-nanosecond clock mapping for {key} in {path}")
+        if source_clock not in ("CLOCK_BOOTTIME", "CLOCK_MONOTONIC", "CLOCK_MONOTONIC_RAW"):
+            raise ClockAlignmentError(f"unsupported source clock {source_clock} for {key} in {path}")
+        source_ns = _checked_ns(row.get("source_sample_ns"), f"{path}:{key} source_sample_ns")
+        monotonic_ns = _checked_ns(row.get("monotonic_sample_ns"), f"{path}:{key} monotonic_sample_ns")
+        realtime_ns = _checked_ns(row.get("realtime_sample_ns"), f"{path}:{key} realtime_sample_ns")
+        uncertainty_ns = _checked_ns(row.get("uncertainty_ns"), f"{path}:{key} uncertainty_ns")
+        if source_clock == "CLOCK_MONOTONIC" and source_ns != monotonic_ns:
+            raise ClockAlignmentError(f"{path}:{key} CLOCK_MONOTONIC sample does not match monotonic sample")
+        offset_ns = (monotonic_ns - source_ns) + (realtime_ns - monotonic_ns)
+        if row.get("offset_ns") is not None and int(row["offset_ns"]) != offset_ns:
+            raise ClockAlignmentError(f"{path}:{key} offset does not match its clock samples")
+        if (row.get("sample_start_source_ns") is None) != (row.get("sample_end_source_ns") is None):
+            raise ClockAlignmentError(f"{path}:{key} must provide both sample range endpoints or neither")
+        alignments[key] = {
+            "role": key[0],
+            "node_rank": key[1],
+            "hostname": hostname,
+            "source_clock": source_clock,
+            "offset_ns": offset_ns,
+            "uncertainty_ns": uncertainty_ns,
+            "sample_start_source_ns": (
+                _checked_ns(row["sample_start_source_ns"], f"{path}:{key} sample start")
+                if row.get("sample_start_source_ns") is not None else None
+            ),
+            "sample_end_source_ns": (
+                _checked_ns(row["sample_end_source_ns"], f"{path}:{key} sample end")
+                if row.get("sample_end_source_ns") is not None else None
+            ),
+            "correlation": {
+                "source_sample_ns": source_ns,
+                "monotonic_sample_ns": monotonic_ns,
+                "realtime_sample_ns": realtime_ns,
+            },
+            "provenance": {
+                "kind": "explicit_clock_manifest",
+                "path": os.path.abspath(path),
+                "detail": row.get("provenance"),
+            },
+        }
+    if not alignments:
+        raise ClockAlignmentError(f"clock manifest {path} has no node mappings")
+    return alignments
+
+
+def _parse_native_clock_snapshot(block, pftrace):
+    primary_match = re.search(r"primary_trace_clock:\s*(BUILTIN_CLOCK_[A-Z_]+)", block)
+    if not primary_match:
+        raise ClockAlignmentError(f"native clock snapshot in {pftrace} has no primary trace clock")
+    primary = primary_match.group(1)
+    primary_ids = {
+        "BUILTIN_CLOCK_REALTIME": (1, "CLOCK_REALTIME"),
+        "BUILTIN_CLOCK_MONOTONIC": (3, "CLOCK_MONOTONIC"),
+        "BUILTIN_CLOCK_MONOTONIC_RAW": (5, "CLOCK_MONOTONIC_RAW"),
+        "BUILTIN_CLOCK_BOOTTIME": (6, "CLOCK_BOOTTIME"),
+    }
+    if primary not in primary_ids:
+        raise ClockAlignmentError(f"unsupported primary trace clock {primary} in {pftrace}")
+    clocks = {}
+    for clock_block in re.findall(r"clocks\s*\{(.*?)\}", block, re.DOTALL):
+        id_match = re.search(r"clock_id:\s*(\d+)", clock_block)
+        ts_match = re.search(r"timestamp:\s*(\d+)", clock_block)
+        if not id_match or not ts_match:
+            continue
+        clock_id = int(id_match.group(1))
+        multiplier_match = re.search(r"unit_multiplier_ns:\s*(\d+)", clock_block)
+        multiplier = int(multiplier_match.group(1)) if multiplier_match else 1
+        if multiplier != 1:
+            raise ClockAlignmentError(
+                f"native clock {clock_id} in {pftrace} uses unsupported {multiplier} ns units"
+            )
+        timestamp = _checked_ns(ts_match.group(1), f"{pftrace} native clock {clock_id}")
+        if clock_id in clocks and clocks[clock_id] != timestamp:
+            raise ClockAlignmentError(f"duplicate conflicting native clock {clock_id} in {pftrace}")
+        clocks[clock_id] = timestamp
+    source_id, source_clock = primary_ids[primary]
+    for required_id, name in ((1, "REALTIME"), (3, "MONOTONIC"), (source_id, source_clock)):
+        if required_id not in clocks:
+            raise ClockAlignmentError(f"native {name} clock is missing from {pftrace}")
+    return {
+        "source_clock": source_clock,
+        "source_sample_ns": clocks[source_id],
+        "monotonic_sample_ns": clocks[3],
+        "realtime_sample_ns": clocks[1],
+    }
+
+
+def _extract_native_clock_alignment(pftrace, traceconv):
+    cache_key = (os.path.abspath(pftrace), os.path.abspath(traceconv))
+    if cache_key in _NATIVE_CLOCK_CACHE:
+        return _NATIVE_CLOCK_CACHE[cache_key]
+    try:
+        with open(traceconv, "rb") as f:
+            is_elf = f.read(4) == b"\x7fELF"
+    except OSError as exc:
+        raise ClockAlignmentError(f"cannot inspect native clock extractor {traceconv}: {exc}") from exc
+    cmd = ([traceconv] if is_elf else ["python3", traceconv]) + [
+        "text", "--skip-unknown", pftrace, "/dev/stdout",
+    ]
+    try:
+        proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            text=True, encoding="utf-8", errors="replace",
+        )
+    except OSError as exc:
+        raise ClockAlignmentError(f"cannot start native clock extraction for {pftrace}: {exc}") from exc
+    snapshots = []
+    block = []
+    depth = 0
+    try:
+        for line in proc.stdout:
+            if not block:
+                if "clock_snapshot {" not in line:
+                    continue
+                block = [line]
+                depth = line.count("{") - line.count("}")
+            else:
+                block.append(line)
+                depth += line.count("{") - line.count("}")
+            if block and depth == 0:
+                snapshots.append(_parse_native_clock_snapshot("".join(block), pftrace))
+                block = []
+                if len(snapshots) == 2:
+                    break
+    finally:
+        if proc.stdout:
+            proc.stdout.close()
+        if proc.poll() is None:
+            proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+    if len(snapshots) != 2:
+        raise ClockAlignmentError(
+            f"{pftrace} did not expose two native MONOTONIC/REALTIME clock snapshots"
+        )
+    if snapshots[0]["source_clock"] != snapshots[1]["source_clock"]:
+        raise ClockAlignmentError(f"native primary clock changes between snapshots in {pftrace}")
+    source_clock = snapshots[1]["source_clock"]
+    offsets = [
+        row["realtime_sample_ns"] - row["source_sample_ns"]
+        for row in snapshots
+    ]
+    sample_span_ns = max(
+        abs(snapshots[1][field] - snapshots[0][field])
+        for field in ("source_sample_ns", "monotonic_sample_ns", "realtime_sample_ns")
+    )
+    uncertainty_ns = max(sample_span_ns, abs(offsets[1] - offsets[0]))
+    selected = snapshots[1]
+    result = {
+        "source_clock": source_clock,
+        "offset_ns": offsets[1],
+        "uncertainty_ns": uncertainty_ns,
+        "sample_start_source_ns": None,
+        "sample_end_source_ns": None,
+        "correlation": selected,
+        "provenance": {
+            "kind": "native_perfetto_clock_snapshot",
+            "pftrace": os.path.abspath(pftrace),
+            "traceconv": os.path.abspath(traceconv),
+            "snapshot_count": 2,
+            "uncertainty_scope": "back-to-back native clock snapshot span",
+        },
+    }
+    _NATIVE_CLOCK_CACHE[cache_key] = result
+    return result
+
+
+def _load_host_clock_alignment(path, role, node_rank, hostname, native):
+    try:
+        rows = _read_jsonl(path)
+    except WindowMappingError as exc:
+        raise ClockAlignmentError(str(exc)) from exc
+    metadata = [row for row in rows if row.get("kind") == "clock_sampler_metadata"]
+    samples = [row for row in rows if row.get("kind") in ("clock_sample", "clock_sampler_stop")]
+    if len(metadata) != 1 or len(samples) < 2:
+        raise ClockAlignmentError(f"{path} must contain one metadata row and at least two clock samples")
+    meta = metadata[0]
+    if meta.get("timestamp_unit", "ns") != "ns":
+        raise ClockAlignmentError(f"{path} does not use nanosecond clock units")
+    if int(meta.get("node_rank", -1)) != node_rank or meta.get("hostname") != hostname:
+        raise ClockAlignmentError(
+            f"{path} identity does not match {role} NODE{node_rank} host {hostname}"
+        )
+    clock_info = meta.get("clock") or {}
+    if clock_info and (not clock_info.get("monotonic") or clock_info.get("adjustable")):
+        raise ClockAlignmentError(f"{path} does not describe a stable monotonic clock")
+    sync = meta.get("clock_sync") or {}
+    if not sync.get("available") or sync.get("uncertainty_ns") is None:
+        raise ClockAlignmentError(f"{path} lacks usable clock-sync uncertainty evidence")
+    sync_uncertainty_ns = _checked_ns(sync["uncertainty_ns"], f"{path} sync uncertainty")
+    source_clock = native["source_clock"] if native else meta.get("source_trace_clock")
+    if not source_clock:
+        raise ClockAlignmentError(
+            f"{path} does not identify the source trace clock and no native PFTrace snapshot is available"
+        )
+    if meta.get("source_trace_clock") and meta["source_trace_clock"] != source_clock:
+        raise ClockAlignmentError(f"{path} source clock conflicts with the native PFTrace clock")
+    source_to_monotonic = (
+        native["correlation"]["monotonic_sample_ns"] - native["correlation"]["source_sample_ns"]
+        if native else 0
+    )
+    normalized = []
+    previous_source = None
+    max_gap_ns = int(os.environ.get("CLOCK_SAMPLE_MAX_GAP_NS", "5000000000"))
+    for index, sample in enumerate(samples):
+        if int(sample.get("node_rank", -1)) != node_rank or sample.get("hostname") != hostname:
+            raise ClockAlignmentError(f"{path} sample {index} has the wrong node identity")
+        before_ns = _checked_ns(sample.get("realtime_before_ns"), f"{path} sample {index} realtime before")
+        realtime_ns = _checked_ns(sample.get("realtime_mid_ns"), f"{path} sample {index} realtime")
+        after_ns = _checked_ns(sample.get("realtime_after_ns"), f"{path} sample {index} realtime after")
+        monotonic_ns = _checked_ns(sample.get("monotonic_ns"), f"{path} sample {index} monotonic")
+        pair_uncertainty_ns = _checked_ns(
+            sample.get("pair_uncertainty_ns"), f"{path} sample {index} pair uncertainty")
+        if not before_ns <= realtime_ns <= after_ns:
+            raise ClockAlignmentError(f"{path} sample {index} has an invalid realtime bracket")
+        if pair_uncertainty_ns < (after_ns - before_ns + 1) // 2:
+            raise ClockAlignmentError(f"{path} sample {index} understates pair uncertainty")
+        if source_clock == "CLOCK_BOOTTIME" and sample.get("boottime_ns") is not None:
+            source_ns = _checked_ns(sample["boottime_ns"], f"{path} sample {index} boottime")
+        elif source_clock == "CLOCK_MONOTONIC":
+            source_ns = monotonic_ns
+        elif native:
+            source_ns = monotonic_ns - source_to_monotonic
+            if source_ns < 0:
+                raise ClockAlignmentError(f"{path} sample {index} source-clock conversion is negative")
+        else:
+            raise ClockAlignmentError(
+                f"{path} sample {index} cannot map {source_clock} to MONOTONIC"
+            )
+        if previous_source is not None:
+            gap_ns = source_ns - previous_source
+            if gap_ns <= 0 or gap_ns > max_gap_ns:
+                raise ClockAlignmentError(
+                    f"{path} source-clock sample gap {gap_ns} ns is invalid or exceeds {max_gap_ns} ns"
+                )
+        previous_source = source_ns
+        normalized.append({
+            "source_ns": source_ns,
+            "monotonic_ns": monotonic_ns,
+            "realtime_ns": realtime_ns,
+            "pair_uncertainty_ns": pair_uncertainty_ns,
+            "offset_ns": realtime_ns - source_ns,
+        })
+    selected = normalized[len(normalized) // 2]
+    uncertainty_ns = (
+        sync_uncertainty_ns
+        + max(row["pair_uncertainty_ns"] for row in normalized)
+        + max(abs(row["offset_ns"] - selected["offset_ns"]) for row in normalized)
+        + (native["uncertainty_ns"] if native and source_clock != "CLOCK_BOOTTIME" else 0)
+    )
+    native_delta_ns = None
+    if native:
+        native_delta_ns = selected["offset_ns"] - native["offset_ns"]
+        uncertainty_ns = max(uncertainty_ns, abs(native_delta_ns) + native["uncertainty_ns"])
+    return {
+        "role": role,
+        "node_rank": node_rank,
+        "hostname": hostname,
+        "source_clock": source_clock,
+        "offset_ns": selected["offset_ns"],
+        "uncertainty_ns": uncertainty_ns,
+        "sample_start_source_ns": normalized[0]["source_ns"],
+        "sample_end_source_ns": normalized[-1]["source_ns"],
+        "correlation": {
+            "source_sample_ns": selected["source_ns"],
+            "monotonic_sample_ns": selected["monotonic_ns"],
+            "realtime_sample_ns": selected["realtime_ns"],
+        },
+        "provenance": {
+            "kind": "host_clock_samples",
+            "path": os.path.abspath(path),
+            "sample_count": len(normalized),
+            "clock_sync_command": sync.get("command"),
+            "clock_sync_uncertainty_ns": sync_uncertainty_ns,
+            "native_crosscheck_delta_ns": native_delta_ns,
+            "native_pftrace": native["provenance"]["pftrace"] if native else None,
+        },
+    }
+
+
+def _resolve_clock_alignment(jobdir, role, node_rank, hostname, pftrace,
+                             explicit_alignments, traceconv):
+    key = (role, node_rank)
+    max_uncertainty_ns = int(os.environ.get(
+        "COMBINE_MAX_CLOCK_UNCERTAINTY_NS",
+        os.environ.get("WINDOW_MAX_UNCERTAINTY_NS", "20000000"),
+    ))
+    if max_uncertainty_ns < 0:
+        raise ClockAlignmentError("COMBINE_MAX_CLOCK_UNCERTAINTY_NS must be non-negative")
+    if explicit_alignments is not None:
+        if key not in explicit_alignments:
+            raise ClockAlignmentError(f"clock manifest has no mapping for {role} NODE{node_rank}")
+        alignment = dict(explicit_alignments[key])
+        if alignment["hostname"] != hostname:
+            raise ClockAlignmentError(
+                f"clock manifest host {alignment['hostname']} does not match {hostname} for {key}"
+            )
+    else:
+        native = None
+        native_available = bool(
+            pftrace and traceconv and os.path.isfile(pftrace)
+            and os.path.isfile(traceconv) and os.access(traceconv, os.X_OK)
+            and os.path.exists("/dev/stdout")
+        )
+        if native_available:
+            native = _extract_native_clock_alignment(pftrace, traceconv)
+        clock_path = os.path.join(jobdir, f"clock_NODE{node_rank}.jsonl")
+        if os.path.isfile(clock_path):
+            alignment = _load_host_clock_alignment(
+                clock_path, role, node_rank, hostname, native)
+        elif native:
+            alignment = {
+                **native,
+                "role": role,
+                "node_rank": node_rank,
+                "hostname": hostname,
+            }
+        else:
+            raise ClockAlignmentError(
+                f"no valid cross-node clock correlation for {role} NODE{node_rank}: "
+                f"missing {clock_path} and no extractable native PFTrace clock snapshot; "
+                "future captures must retain clock_NODE*.jsonl, or pass --clock-manifest"
+            )
+    if alignment["uncertainty_ns"] > max_uncertainty_ns:
+        raise ClockAlignmentError(
+            f"{role} NODE{node_rank} clock uncertainty {alignment['uncertainty_ns']} ns "
+            f"exceeds {max_uncertainty_ns} ns"
+        )
+    return alignment
+
+
+def _timestamp_range(path):
+    first_start_ns = last_end_ns = None
+    count = 0
+    with open(path, newline="", encoding="utf-8-sig") as f:
+        reader = csv.reader(f)
+        header = next(reader, None)
+        if not header:
+            return None, None, 0
+        if "Start_Timestamp" not in header or "End_Timestamp" not in header:
+            raise ClockAlignmentError(f"{path} has no Start_Timestamp/End_Timestamp columns")
+        start_index = header.index("Start_Timestamp")
+        end_index = header.index("End_Timestamp")
+        for lineno, row in enumerate(reader, 2):
+            if not row:
+                continue
+            try:
+                start_ns = _checked_ns(row[start_index], f"{path}:{lineno} Start_Timestamp")
+                end_ns = _checked_ns(row[end_index], f"{path}:{lineno} End_Timestamp")
+            except IndexError as exc:
+                raise ClockAlignmentError(f"{path}:{lineno} has an incomplete timestamp row") from exc
+            if end_ns < start_ns:
+                raise ClockAlignmentError(f"{path}:{lineno} has end before start")
+            first_start_ns = start_ns if first_start_ns is None else min(first_start_ns, start_ns)
+            last_end_ns = end_ns if last_end_ns is None else max(last_end_ns, end_ns)
+            count += 1
+    return first_start_ns, last_end_ns, count
+
+
+def _stream_csv_events(path, name_column, default_name, alignment, global_wall_min_ns,
+                       pid, tid, out_fh, first_written):
+    count = 0
+    first_source_ns = last_end_ns = None
+    with open(path, newline="", encoding="utf-8-sig") as f:
+        reader = csv.reader(f)
+        header = next(reader, None)
+        required = ("Start_Timestamp", "End_Timestamp", name_column)
+        if not header or any(column not in header for column in required):
+            raise ClockAlignmentError(f"{path} is missing required columns {required}")
+        start_index = header.index("Start_Timestamp")
+        end_index = header.index("End_Timestamp")
+        name_index = header.index(name_column)
+        for lineno, row in enumerate(reader, 2):
+            if not row:
+                continue
+            try:
+                start_ns = _checked_ns(row[start_index], f"{path}:{lineno} Start_Timestamp")
+                end_ns = _checked_ns(row[end_index], f"{path}:{lineno} End_Timestamp")
+            except IndexError as exc:
+                raise ClockAlignmentError(f"{path}:{lineno} has an incomplete event row") from exc
+            if end_ns < start_ns:
+                raise ClockAlignmentError(f"{path}:{lineno} has end before start")
+            if end_ns - start_ns > INT64_MAX:
+                raise ClockAlignmentError(f"{path}:{lineno} duration overflows signed-int64")
+            first_source_ns = start_ns if first_source_ns is None else min(first_source_ns, start_ns)
+            last_end_ns = max(last_end_ns or end_ns, end_ns)
+            wall_start_ns = _wall_ns(start_ns, alignment["offset_ns"], f"{path}:{lineno} start")
+            wall_end_ns = _wall_ns(end_ns, alignment["offset_ns"], f"{path}:{lineno} end")
+            display_start_ns = wall_start_ns - global_wall_min_ns
+            display_end_ns = wall_end_ns - global_wall_min_ns
+            if display_start_ns < 0 or display_end_ns < display_start_ns:
+                raise ClockAlignmentError(f"{path}:{lineno} produced invalid aligned coordinates")
+            name = row[name_index] if name_index < len(row) else default_name
+            event = {
+                "ph": "X", "name": name or default_name,
+                "ts": display_start_ns / 1000.0,
+                "dur": (end_ns - start_ns) / 1000.0,
+                "pid": pid, "tid": tid,
+            }
+            if first_written:
+                out_fh.write(",")
+            out_fh.write(json.dumps(event))
+            first_written = True
+            count += 1
+    return count, first_written, first_source_ns, last_end_ns
+
+
+def stream_kernel_events(kernel_csv, alignment, global_wall_min_ns,
+                         pid, tid, out_fh, first_written):
+    return _stream_csv_events(
+        kernel_csv, "Kernel_Name", "kernel", alignment, global_wall_min_ns,
+        pid, tid, out_fh, first_written,
+    )
+
+
+def stream_marker_events(marker_csv, alignment, global_wall_min_ns,
+                         pid, tid, out_fh, first_written):
+    return _stream_csv_events(
+        marker_csv, "Function", "marker", alignment, global_wall_min_ns,
+        pid, tid, out_fh, first_written,
+    )
+
+
+def build_combined(jobdir, out_path, rank0_only, rank_manifest, role_filter=None,
+                   clock_manifest_path=None, traceconv=None):
+    node_dirs = discover_node_dirs(jobdir)
+    if not node_dirs:
+        raise SystemExit(f"no rocprof_{{prefill,decode}}_NODE* dirs found under {jobdir}")
+    if role_filter:
+        node_dirs = [node_dir for node_dir in node_dirs if node_dir[0] == role_filter]
+        if not node_dirs:
+            raise RankManifestError(f"no {role_filter} rocprof dirs found under {jobdir}")
+
+    t_start = time.time()
+    pid_counter = 0
+    total_kernel_events = 0
+    total_marker_events = 0
+    summary = []
+    explicit_alignments = _load_explicit_clock_manifest(clock_manifest_path, jobdir)
+    nodes = []
+    for role, node_idx, dirpath in node_dirs:
+        ranks = discover_ranks(dirpath)
+        if not ranks:
+            raise RankManifestError(f"no ranks discovered in {dirpath}")
+        rows = [row for row in rank_manifest["workers"]
+                if row["role"] == role and int(row["node_rank"]) == node_idx]
+        by_pid = {int(row["pid"]): row for row in rows}
+        if len(by_pid) != len(rows):
+            raise RankManifestError(f"duplicate manifest PID for {role} NODE{node_idx}")
+        artifact_pids = {rank[0] for rank in ranks}
+        if set(by_pid) != artifact_pids:
+            raise RankManifestError(
+                f"manifest/artifact PID mismatch for {role} NODE{node_idx}: "
+                f"manifest={sorted(by_pid)}, artifacts={sorted(artifact_pids)}"
+            )
+        for pid_val, host, *_ in ranks:
+            if by_pid[pid_val]["hostname"] != host:
+                raise RankManifestError(
+                    f"manifest host {by_pid[pid_val]['hostname']} does not match artifact host "
+                    f"{host} for PID {pid_val}"
+                )
+        ranks.sort(key=lambda rank: int(by_pid[rank[0]]["local_rank"]))
+        selected = selected_worker(rank_manifest, role, node_idx)
+        selected_ranks = [rank for rank in ranks if rank[0] == int(selected["pid"])]
+        if len(selected_ranks) != 1:
+            raise RankManifestError(
+                f"selected PID {selected['pid']} missing/duplicate in {dirpath}"
+            )
+        if rank0_only:
+            ranks = selected_ranks
+        hostname = selected["hostname"]
+        alignment = _resolve_clock_alignment(
+            jobdir, role, node_idx, hostname, selected_ranks[0][4],
+            explicit_alignments, traceconv,
+        )
+        nodes.append({
+            "role": role, "node_rank": node_idx, "ranks": ranks,
+            "by_pid": by_pid, "alignment": alignment,
+        })
+
+    first_wall_timestamps = []
+    for node in nodes:
+        for _, _, kernel_csv, marker_csv, _ in node["ranks"]:
+            for source_path in (kernel_csv, marker_csv):
+                if not source_path:
+                    continue
+                first_source_ns, _, _ = _timestamp_range(source_path)
+                if first_source_ns is not None:
+                    first_wall_timestamps.append(_wall_ns(
+                        first_source_ns, node["alignment"]["offset_ns"],
+                        f"{source_path} first event",
+                    ))
+    if not first_wall_timestamps:
+        raise ClockAlignmentError("no timestamped events found in selected combined-trace inputs")
+    global_wall_min_ns = min(first_wall_timestamps)
+    tmp = f"{out_path}.tmp.{os.getpid()}"
+    node_ranges = {}
+    try:
+        with open(tmp, "w", encoding="utf-8", newline="\n") as out_fh:
+            out_fh.write('{"traceEvents":[')
+            first_written = False
+            for node in nodes:
+                role = node["role"]
+                node_idx = node["node_rank"]
+                alignment = node["alignment"]
+                range_key = (role, node_idx)
+                node_ranges[range_key] = [None, None]
+                for pid_val, host, kcsv, marker_csv, pftrace in node["ranks"]:
+                    mapping = node["by_pid"][pid_val]
+                    local_rank = int(mapping["local_rank"])
+                    global_rank = int(mapping["global_rank"])
+                    out_pid = 1000 + pid_counter
+                    pid_counter += 1
+                    proc_name = (
+                        f"{role.upper()} NODE{node_idx} LOCAL_RANK{local_rank} "
+                        f"GLOBAL_RANK{global_rank} ({host}:{pid_val})"
+                    )
+                    process_args = {
+                        "name": proc_name, "role": role, "node_rank": node_idx,
+                        "hostname": host, "source_pid": pid_val,
+                        **{key: mapping.get(key) for key in (
+                            "world_size", "global_rank", "local_rank", "dp_rank",
+                            "ep_rank", "pp_rank", "tp_rank",
+                        )},
+                    }
+                    meta = [
+                        {"ph": "M", "name": "process_name", "pid": out_pid, "tid": 0,
+                         "args": process_args},
+                        {"ph": "M", "name": "thread_name", "pid": out_pid, "tid": 1,
+                         "args": {"name": f"GPU kernels ({role} NODE{node_idx} local_rank{local_rank})"}},
+                    ]
+                    for meta_event in meta:
+                        if first_written:
+                            out_fh.write(",")
+                        out_fh.write(json.dumps(meta_event))
+                        first_written = True
+                    nk, first_written, kernel_first, kernel_last = stream_kernel_events(
+                        kcsv, alignment, global_wall_min_ns, out_pid, 1, out_fh, first_written)
+                    nmk = 0
+                    marker_first = marker_last = None
+                    if marker_csv:
+                        if first_written:
+                            out_fh.write(",")
+                        out_fh.write(json.dumps({
+                            "ph": "M", "name": "thread_name", "pid": out_pid, "tid": 2,
+                            "args": {"name": "Marker API (reqstats + MORI-IO)"},
+                        }))
+                        first_written = True
+                        nmk, first_written, marker_first, marker_last = stream_marker_events(
+                            marker_csv, alignment, global_wall_min_ns,
+                            out_pid, 2, out_fh, first_written,
+                        )
+                    starts = [value for value in (kernel_first, marker_first) if value is not None]
+                    ends = [value for value in (kernel_last, marker_last) if value is not None]
+                    if starts:
+                        old_start = node_ranges[range_key][0]
+                        node_ranges[range_key][0] = min(starts + ([old_start] if old_start is not None else []))
+                    if ends:
+                        old_end = node_ranges[range_key][1]
+                        node_ranges[range_key][1] = max(ends + ([old_end] if old_end is not None else []))
+                    total_kernel_events += nk
+                    total_marker_events += nmk
+                    has_native_pftrace = pftrace is not None
+                    summary.append((proc_name, nk, nmk, has_native_pftrace))
+                    log(f"{proc_name}: kernel_events={nk} marker_events={nmk} "
+                        f"native_pftrace={'yes' if has_native_pftrace else 'no'}")
+            for node in nodes:
+                key = (node["role"], node["node_rank"])
+                source_start, source_end = node_ranges[key]
+                sample_start = node["alignment"]["sample_start_source_ns"]
+                sample_end = node["alignment"]["sample_end_source_ns"]
+                if sample_start is not None and (
+                    source_start is None or source_start < sample_start or source_end > sample_end
+                ):
+                    raise ClockAlignmentError(
+                        f"{key} trace range {source_start}..{source_end} is not bracketed by "
+                        f"clock samples {sample_start}..{sample_end}"
+                    )
+            alignment_metadata = {
+                "schema_version": 1,
+                "coordinate_domain": "wall_realtime_ns_minus_one_global_minimum",
+                "formula": (
+                    "wall_ns = source_ns + (monotonic_sample_ns - source_sample_ns) "
+                    "+ (realtime_sample_ns - monotonic_sample_ns)"
+                ),
+                "source_timestamp_unit": "ns",
+                "event_coordinate_unit": "us",
+                "global_wall_origin_ns": global_wall_min_ns,
+                "nodes": [node["alignment"] for node in nodes],
+            }
+            out_fh.write('],"displayTimeUnit":"ns","clockAlignment":')
+            out_fh.write(json.dumps(alignment_metadata, sort_keys=True))
+            out_fh.write("}")
+            out_fh.flush()
+            os.fsync(out_fh.fileno())
+        os.replace(tmp, out_path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+    elapsed = time.time() - t_start
+    size = os.path.getsize(out_path)
+    log(f"wrote {out_path} ({size/1e6:.1f} MB, {pid_counter} lanes, "
+        f"{total_kernel_events} kernel events, {total_marker_events} marker events) "
+        f"in {elapsed:.1f}s")
+    return summary, size
+
+
+
+def categorize_kernel(name):
+    n = name.lower()
+
+    # Preserve classifier precedence for fused kernels.
+    if ('rmsnorm' in n or 'fused_rms' in n or 'rms_norm' in n or
+        ('rsqrt' in n and 'mean' in n and 'mul' in n)):
+        return 'RMSNorm'
+    # ROPE must precede other fused-kernel matches.
+    if 'rope' in n: return 'ROPE'
+
+    if 'reshape' in n and 'cache' in n:
+        return 'KVCacheReshape'
+
+    if 'kernel_unified_attention' in n: return 'Attention'
+    if '_fwd_kernel' in name: return 'TritonAttention'
+    if 'fmha' in n: return 'FMHA'
+    if 'mla' in n: return 'MLA'
+    if 'aiter::pa' in name: return 'PA'
+    if 'paged_attention' in n: return 'PagedAttn'
+
+    if 'routing' in n or 'route' in n: return 'MoE_Router'
+    if 'moesorting' in n or 'opus_moe_sorting_entry' in n: return 'MoE_Sort'
+    if 'epcombine' in n and 'syncbarrier' in n: return 'EP_Barrier'
+    # Only intra/inter-node payload kernels are MORI EP; support kernels are communication.
+    if any(x in n for x in ('epdispatchinternode', 'epcombineinternode', 'epdispatchintranode', 'epcombineintranode')): return 'MORI EP'
+    if 'epdispatch' in n or 'epcombine' in n: return 'Communication'
+    if 'fmoe' in n: return 'MoE_Fused'
+    if 'kernel_moe' in n: return 'MoE_Unfused'
+    if 'topk' in n: return 'MoE_TopK'
+
+    if 'gemm' in n or 'cijk' in n or 'wvsplit' in n or 'matmul' in n: return 'GEMM'
+    # Activation must precede quantization for fused kernels.
+    if 'act_and_mul' in n or 'silu' in n: return 'Activation'
+    if 'quant' in n: return 'Quant'
+
+    if 'allreduce' in n or 'cross_device' in n or 'nccl' in n: return 'Communication'
+
+    if 'poi' in n or 'elementwise' in n: return 'Elementwise'
+    return 'Other'
+
+
+def _find_column(headers, predicate, what):
+    for h in headers:
+        if predicate((h or '').lower()):
+            return h
+    sys.exit(
+        f"ERROR: could not find the {what} column.\n"
+        f"  Headers found: {headers}"
+    )
+
+
+def find_kernel_name_column(headers):
+    return _find_column(
+        headers,
+        lambda h: 'kernel' in h and 'name' in h,
+        "kernel name (a column containing both 'kernel' and 'name')",
+    )
+
+
+def find_duration_sum_column(headers):
+    return _find_column(
+        headers,
+        lambda h: 'duration' in h and '_sum' in h,
+        "duration sum (a column containing both 'duration' and '_sum')",
+    )
+
+
+def find_duration_count_column(headers):
+    for h in headers:
+        hl = (h or '').lower()
+        if 'duration' in hl and '_count' in hl:
+            return h
+    return None  # Count is optional; default to one launch per row.
+
+
+def _to_float(value):
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _to_int(value):
+    try:
+        return int(round(float(str(value).strip())))
+    except (TypeError, ValueError):
+        return 0
+
+
+def process(in_path, out_per_kernel, out_by_category, label):
+    # Accept producer BOMs and micro-sign headers.
+    with open(in_path, 'r', encoding='utf-8-sig', newline='') as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+
+    if not rows:
+        sys.exit(f"ERROR: input CSV '{in_path}' is empty.")
+
+    headers = rows[0]
+    data_rows = rows[1:]
+
+    name_col = find_kernel_name_column(headers)
+    dur_sum_col = find_duration_sum_column(headers)
+    count_col = find_duration_count_column(headers)
+
+    name_idx = headers.index(name_col)
+    dur_idx = headers.index(dur_sum_col)
+    count_idx = headers.index(count_col) if count_col else None
+
+
+    out_headers = ['Category'] + headers
+    agg = {}
+    grand_count = 0
+    grand_us = 0.0
+
+    with open(out_per_kernel, 'w', encoding='utf-8-sig', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow(out_headers)
+        for row in data_rows:
+            if not row or all((c or '').strip() == '' for c in row):
+                continue
+            kernel_name = row[name_idx] if name_idx < len(row) else ''
+            category = categorize_kernel(kernel_name)
+            writer.writerow([category] + row)
+
+            total_us = _to_float(row[dur_idx]) if dur_idx < len(row) else 0.0
+            n_kernels = (
+                _to_int(row[count_idx])
+                if count_idx is not None and count_idx < len(row)
+                else 1
+            )
+            bucket = agg.setdefault(category, [0, 0.0])
+            bucket[0] += n_kernels
+            bucket[1] += total_us
+            grand_count += n_kernels
+            grand_us += total_us
+
+
+    with open(out_by_category, 'w', encoding='utf-8-sig', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow(['Category', 'Num_Kernels', 'Total_us', 'Total_ms',
+                         'Pct_of_Kernel_Time'])
+        for category, (n_kernels, total_us) in sorted(
+                agg.items(), key=lambda kv: kv[1][1], reverse=True):
+            pct = (total_us / grand_us * 100) if grand_us > 0 else 0.0
+            writer.writerow([
+                category,
+                n_kernels,
+                f"{total_us:.2f}",
+                f"{total_us / 1000.0:.4f}",
+                f"{pct:.1f}%",
+            ])
+        writer.writerow([
+            'TOTAL',
+            grand_count,
+            f"{grand_us:.2f}",
+            f"{grand_us / 1000.0:.4f}",
+            "100.0%",
+        ])
+
+    _print_summary(label, in_path, headers, name_col, dur_sum_col, count_col,
+                   agg, grand_count, grand_us, out_per_kernel, out_by_category)
+
+
+def _print_summary(label, in_path, headers, name_col, dur_sum_col, count_col,
+                   agg, grand_count, grand_us, out_per_kernel, out_by_category):
+    print('==== %s ====' % label)
+    print('input: %s' % in_path)
+    print("kernel-name column:   %r" % name_col)
+    print("duration-sum column:  %r" % dur_sum_col)
+    print("duration-count column:%s" % (
+        (' %r' % count_col) if count_col else ' (not found; counted 1 row per kernel)'))
+    print('total kernel time: %.1f us  (%.3f ms)   total kernels: %d'
+          % (grand_us, grand_us / 1000.0, grand_count))
+    print()
+    print('%-15s %10s %15s %9s' % ('Category', '#kernels', 'total_us', '%time'))
+    for category, (n_kernels, total_us) in sorted(
+            agg.items(), key=lambda kv: kv[1][1], reverse=True):
+        pct = (total_us / grand_us * 100) if grand_us > 0 else 0.0
+        print('%-15s %10d %15.1f %8.2f%%' % (category, n_kernels, total_us, pct))
+    print('%-15s %10d %15.1f %8.2f%%' % ('TOTAL', grand_count, grand_us, 100.0))
+    print()
+    print('wrote:', out_per_kernel)
+    print('wrote:', out_by_category)
+
+
+
+OUTPUT_COLUMNS = [
+    "Time", "Total Time", "Instances", "Avg", "Med", "Min", "Max", "StdDev",
+    "GridXYZ", "BlockXYZ", "VGPR", "AccumVGPR", "SGPR", "LDS", "Scratch", "Name",
+    "Time %", "Total Time (ns)", "Avg (ns)", "Med (ns)", "Min (ns)", "Max (ns)",
+    "StdDev (ns)", "GridX", "GridY", "GridZ", "BlockX", "BlockY", "BlockZ",
+    "n_trimmed", "instances_before_trim",
+]
+
+
+def pretty_ns(ns):
+    if ns >= 1e6:
+        return f"{ns / 1e6:.3f} ms"
+    if ns >= 1e3:
+        return f"{ns / 1e3:.3f} \u00b5s"
+    return f"{ns:.3f} ns"
+
+
+def _n_to_trim(count, trim_pct):
+    'Return the ceiling-based trim count for eligible kernels.'
+    if trim_pct <= 0:
+        return 0
+    n = math.ceil(count * trim_pct / 100.0)
+    return max(n, 1)
+
+
+_KERNEL_RESOURCE_FIELDS = {
+    "GridX": "Grid_Size_X", "GridY": "Grid_Size_Y", "GridZ": "Grid_Size_Z",
+    "BlockX": "Workgroup_Size_X", "BlockY": "Workgroup_Size_Y", "BlockZ": "Workgroup_Size_Z",
+    "VGPR": "VGPR_Count", "AccumVGPR": "Accum_VGPR_Count", "SGPR": "SGPR_Count",
+    "LDS": "LDS_Block_Size", "Scratch": "Scratch_Size",
+}
+_NORMALIZED_HELP_COLUMNS = [
+    "Kernel name", "kernel_duration_us_sum", "kernel_duration_us_count",
+]
+
+
+def _scan_kernel_traces(kernel_trace_csvs, window=None):
+    """Stream raw worker CSVs and retain only durations plus one resource tuple per name."""
+    if isinstance(kernel_trace_csvs, (str, os.PathLike)):
+        paths = [os.path.abspath(os.fspath(kernel_trace_csvs))]
+    else:
+        paths = [os.path.abspath(os.fspath(path)) for path in kernel_trace_csvs]
+    if not paths:
+        raise SystemExit("ERROR: no kernel trace CSV inputs")
+    if len(paths) != len(set(paths)):
+        raise SystemExit(f"ERROR: duplicate kernel trace CSV inputs: {paths}")
+
+    groups = {}
+    raw_rows = invalid_count = total_dispatches = excluded_count = clipped_count = 0
+    invalid_correlation_ids = []
+    input_audits = []
+    for kernel_trace_csv in paths:
+        input_audit = {
+            "path": kernel_trace_csv,
+            "raw_row_count": 0,
+            "dispatch_row_count": 0,
+            "invalid_event_count": 0,
+            "window_excluded_events": 0,
+            "window_clipped_events": 0,
+            "included_event_count": 0,
+        }
+        with open(kernel_trace_csv, newline="", encoding="utf-8-sig") as f:
+            reader = csv.DictReader(f)
+            fieldnames = reader.fieldnames or []
+            name_col = "Kernel_Name" if "Kernel_Name" in fieldnames else None
+            start_col = "Start_Timestamp" if "Start_Timestamp" in fieldnames else None
+            end_col = "End_Timestamp" if "End_Timestamp" in fieldnames else None
+            if not (name_col and start_col and end_col):
+                raise SystemExit(
+                    f"ERROR: {kernel_trace_csv} does not look like a rocprofv3 "
+                    f"kernel_trace.csv (need Kernel_Name/Start_Timestamp/End_Timestamp, "
+                    f"got columns: {fieldnames})"
+                )
+            for row in reader:
+                raw_rows += 1
+                input_audit["raw_row_count"] += 1
+                if row.get("Kind") and row["Kind"] != "KERNEL_DISPATCH":
+                    continue
+                total_dispatches += 1
+                input_audit["dispatch_row_count"] += 1
+                correlation_id = (
+                    row.get("Correlation_Id") or row.get("Correlation_ID")
+                    or row.get("Dispatch_Id") or row.get("Dispatch_ID") or ""
+                )
+                try:
+                    start_ns = int(row[start_col])
+                    end_ns = int(row[end_col])
+                except (TypeError, ValueError):
+                    invalid_count += 1
+                    input_audit["invalid_event_count"] += 1
+                    invalid_correlation_ids.append(correlation_id)
+                    continue
+                dur_ns = end_ns - start_ns
+                if end_ns < start_ns or dur_ns > INT64_MAX:
+                    invalid_count += 1
+                    input_audit["invalid_event_count"] += 1
+                    invalid_correlation_ids.append(correlation_id)
+                    continue
+                if window is not None:
+                    clipped_start = max(start_ns, int(window[0]))
+                    clipped_end = min(end_ns, int(window[1]))
+                    if clipped_end <= clipped_start:
+                        excluded_count += 1
+                        input_audit["window_excluded_events"] += 1
+                        continue
+                    if clipped_start != start_ns or clipped_end != end_ns:
+                        clipped_count += 1
+                        input_audit["window_clipped_events"] += 1
+                    dur_ns = clipped_end - clipped_start
+                name = row[name_col] or ""
+                if name not in groups:
+                    groups[name] = {
+                        "durations": [],
+                        "resources": {
+                            output: row.get(source, "")
+                            for output, source in _KERNEL_RESOURCE_FIELDS.items()
+                        },
+                    }
+                groups[name]["durations"].append(dur_ns)
+                input_audit["included_event_count"] += 1
+        input_audits.append(input_audit)
+
+    max_count, max_fraction = _invalid_event_limits()
+    invalid_fraction = invalid_count / total_dispatches if total_dispatches else 0.0
+    if invalid_count > max_count or invalid_fraction > max_fraction:
+        raise TraceSanitizationError(
+            f"pooled-summary invalid-event guard rejected {invalid_count}/{total_dispatches} events"
+        )
+    return groups, {
+        "inputs": input_audits,
+        "pooled_raw_row_count": raw_rows,
+        "pooled_dispatch_row_count": total_dispatches,
+        "pooled_included_row_count": sum(
+            row["included_event_count"] for row in input_audits),
+        "dispatches_before": total_dispatches,
+        "invalid_event_count": invalid_count,
+        "invalid_event_fraction": invalid_fraction,
+        "invalid_correlation_ids": invalid_correlation_ids,
+        "window_excluded_events": excluded_count,
+        "window_clipped_events": clipped_count,
+    }
+
+
+def _build_summary_rows(groups, trim_pct):
+    summary_rows = []
+    grand_total_ns = 0
+    for name, g in groups.items():
+        durations = g["durations"]
+        count_before = len(durations)
+        if count_before >= 20 and trim_pct > 0:
+            n_trim = _n_to_trim(count_before, trim_pct)
+            n_trim = min(n_trim, count_before - 1)  # Never drop every call.
+            kept = sorted(durations)[: count_before - n_trim]
+        else:
+            n_trim = 0
+            kept = durations
+
+        total = sum(kept)
+        count = len(kept)
+        avg = total / count
+        med = statistics.median(kept)
+        mn = min(kept)
+        mx = max(kept)
+        stddev = statistics.pstdev(kept) if count > 1 else 0.0
+
+        grand_total_ns += total
+        summary_rows.append(g["resources"] | {
+            "Name": name,
+            "Instances": count,
+            "instances_before_trim": count_before,
+            "n_trimmed": n_trim,
+            "Total Time (ns)": total,
+            "Avg (ns)": avg,
+            "Med (ns)": med,
+            "Min (ns)": mn,
+            "Max (ns)": mx,
+            "StdDev (ns)": stddev,
+        })
+
+    summary_rows.sort(key=lambda x: x["Total Time (ns)"], reverse=True)
+    for r in summary_rows:
+        r["Time %"] = (100.0 * r["Total Time (ns)"] / grand_total_ns) if grand_total_ns else 0.0
+    return summary_rows, grand_total_ns
+
+
+def build_pooled_kernel_summaries(kernel_trace_csvs, trim_pct, window=None):
+    """Build canonical untrimmed and post-pooling-trimmed node summaries in one scan."""
+    groups, audit = _scan_kernel_traces(kernel_trace_csvs, window)
+    normalized_rows, normalized_total_ns = _build_summary_rows(groups, 0)
+    trimmed_rows, trimmed_total_ns = _build_summary_rows(groups, trim_pct)
+    return (
+        normalized_rows, normalized_total_ns,
+        trimmed_rows, trimmed_total_ns, audit,
+    )
+
+
+def build_trimmed_summary(kernel_trace_csv, trim_pct, window=None):
+    'Build trimmed rows and per-kernel trim metadata from one or more worker CSVs.'
+    groups, audit = _scan_kernel_traces(kernel_trace_csv, window)
+    rows, grand_total_ns = _build_summary_rows(groups, trim_pct)
+    return rows, grand_total_ns, audit
+
+
+def write_csv(rows, out_path, add_category, categorize_kernel, normalized=False):
+    columns = list(OUTPUT_COLUMNS[:-2] if normalized else OUTPUT_COLUMNS)
+    if normalized:
+        columns += _NORMALIZED_HELP_COLUMNS
+    if add_category and categorize_kernel is not None:
+        columns = ["Category"] + columns
+    with open(out_path, "w", newline="", encoding="utf-8-sig") as f:
+        w = csv.writer(f)
+        w.writerow(columns)
+        for r in rows:
+            grid_xyz = f"{r['GridX']} {r['GridY']} {r['GridZ']}"
+            block_xyz = f"{r['BlockX']} {r['BlockY']} {r['BlockZ']}"
+            out = [
+                f"{r['Time %']:.1f}%",
+                pretty_ns(r["Total Time (ns)"]),
+                r["Instances"],
+                pretty_ns(r["Avg (ns)"]),
+                pretty_ns(r["Med (ns)"]),
+                pretty_ns(r["Min (ns)"]),
+                pretty_ns(r["Max (ns)"]),
+                pretty_ns(r["StdDev (ns)"]),
+                grid_xyz,
+                block_xyz,
+                r["VGPR"], r["AccumVGPR"], r["SGPR"], r["LDS"], r["Scratch"],
+                r["Name"],
+                r["Time %"],
+                r["Total Time (ns)"], r["Avg (ns)"], r["Med (ns)"], r["Min (ns)"],
+                r["Max (ns)"], r["StdDev (ns)"],
+                r["GridX"], r["GridY"], r["GridZ"],
+                r["BlockX"], r["BlockY"], r["BlockZ"],
+                r["n_trimmed"], r["instances_before_trim"],
+            ]
+            if normalized:
+                out = out[:-2] + [
+                    r["Name"], f"{r['Total Time (ns)'] / 1000.0:.4f}", r["Instances"],
+                ]
+            if add_category and categorize_kernel is not None:
+                out = [categorize_kernel(r["Name"])] + out
+            w.writerow(out)
+
+
+def _add_combine_parser(subparsers):
+    p = subparsers.add_parser(
+        "combine",
+        help="stream rocprofv3 CSV shards into combined Chrome JSON traces",
+        description=(
+            "Stream rocprofv3 CSV shards into combined Chrome JSON traces; every node is "
+            "mapped to shared wall time before one global display origin is subtracted."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("jobdir", help="job output dir, e.g. /shared_inference/aarai/my_prof_run/<jobid>")
+    p.add_argument("--out-dir", default=None,
+                   help="where to write combined_all.pftrace / combined_rank0.pftrace / combined_prefill.chrome.json (default: <jobdir> itself)")
+    p.add_argument(
+        "--clock-manifest", default=None,
+        help=(
+            "validated schema-v1 cross-node clock manifest (default: auto-discover "
+            "clock_NODE*.jsonl or native PFTrace snapshots)"
+        ),
+    )
+    p.add_argument("--only", choices=["all", "rank0", "prefill", "both"], default="both",
+                   help="which trace(s) to build; both includes prefill-only (default: both)")
+    p.set_defaults(func=_run_combine)
+
+
+def _run_combine(a):
+    try:
+        return _run_combine_impl(a)
+    except (ClockAlignmentError, RankManifestError, OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"ERROR: {exc}") from exc
+
+
+def _run_combine_impl(a):
+    jobdir = os.path.abspath(a.jobdir)
+    out_dir = os.path.abspath(a.out_dir) if a.out_dir else jobdir
+    os.makedirs(out_dir, exist_ok=True)
+    manifest_path = os.path.join(out_dir, "rank_manifest.json")
+    manifest = write_rank_manifest(jobdir, manifest_path)
+    log(f"validated PID/rank manifest -> {manifest_path}")
+    clock_manifest = os.path.abspath(a.clock_manifest) if a.clock_manifest else None
+    here = os.path.dirname(os.path.abspath(__file__))
+    traceconv = os.environ.get(
+        "TRACECONV", os.path.join(here, "external_copies", "traceconv_bin", "traceconv"))
+
+    if a.only in ("all", "both"):
+        log(f"building combined_all.pftrace (ALL ranks, ALL nodes) from {jobdir}")
+        build_combined(
+            jobdir, os.path.join(out_dir, "combined_all.pftrace"), False, manifest,
+            clock_manifest_path=clock_manifest, traceconv=traceconv,
+        )
+    if a.only in ("rank0", "both"):
+        log(f"building combined_rank0.pftrace (local_rank=0 per node) from {jobdir}")
+        build_combined(
+            jobdir, os.path.join(out_dir, "combined_rank0.pftrace"), True, manifest,
+            clock_manifest_path=clock_manifest, traceconv=traceconv,
+        )
+    if a.only in ("prefill", "both"):
+        log(f"building combined_prefill.chrome.json (ALL prefill ranks, ALL prefill nodes) from {jobdir}")
+        build_combined(
+            jobdir, os.path.join(out_dir, "combined_prefill.chrome.json"),
+            False, manifest, role_filter="prefill",
+            clock_manifest_path=clock_manifest, traceconv=traceconv,
+        )
+
+
+def _add_extract_reqid_parser(subparsers):
+    p = subparsers.add_parser(
+        "extract-reqid",
+        help="extract request-to-MoRI write UID mappings from worker logs",
+        description="Extract request-to-MoRI write UID mappings from worker logs.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("logs", nargs="+", help="vLLM worker log file(s) to parse")
+    p.add_argument("-o", "--out", default=None,
+                   help="output CSV path (default: stdout)")
+    p.set_defaults(func=_run_extract_reqid)
+
+
+def _run_extract_reqid(args):
+    rows = parse_reqid_maps(args.logs)
+    fields = ["write_uid", "direction", "request_id", "transfer_id", "layer",
+              "role", "node_rank", "pid"]
+    out = (open(args.out, "w", newline="", encoding="utf-8")
+           if args.out else sys.stdout)
+    try:
+        writer = csv.DictWriter(out, fieldnames=fields)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: row[key] for key in fields})
+    finally:
+        if args.out:
+            out.close()
+
+    print(
+        f"[trace_tools extract-reqid] parsed {len(rows)} mapping line(s) "
+        f"from {len(args.logs)} file(s)"
+        + (f" -> {args.out}" if args.out else ""),
+        file=sys.stderr,
+    )
+
+
+def _add_buckets_parser(subparsers):
+    p = subparsers.add_parser(
+        "buckets",
+        help="apply first-party kernel categories to TraceLens summaries",
+        description="Add first-party kernel bucket categories to a TraceLens kernel-summary CSV.",
+    )
+    p.add_argument('--in', dest='in_path', required=True,
+                   help='Input TraceLens kernel_summary CSV.')
+    p.add_argument('--out-per-kernel', required=True,
+                   help='Output per-kernel CSV (Category + all original columns).')
+    p.add_argument('--out-by-category', required=True,
+                   help='Output by-category rollup CSV.')
+    p.add_argument('--label', default=None,
+                   help='Label for the stdout summary banner (default: input path).')
+    p.set_defaults(func=_run_buckets)
+
+
+def _run_buckets(args):
+    label = args.label if args.label is not None else args.in_path
+    process(args.in_path, args.out_per_kernel, args.out_by_category, label)
+
+
+def _add_trimmed_summary_parser(subparsers):
+    p = subparsers.add_parser(
+        "trimmed-summary",
+        help="build per-kernel summaries after dropping the slowest eligible calls",
+        description="Build per-kernel summaries after dropping the slowest eligible calls.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--kernel-trace", required=True, help="Raw rocprofv3 *_kernel_trace.csv (per-dispatch rows)")
+    p.add_argument("--out", default=None, help="Output CSV path (default: <stem>_summary_trimmed.csv next to input)")
+    p.add_argument("--trim-pct", type=float, default=5.0, help="Percent of each eligible kernel's slowest calls to drop (default: 5)")
+    p.add_argument("--add-category", action="store_true", help="Prepend a Category column via the shared first-party categorizer")
+    p.set_defaults(func=_run_trimmed_summary)
+    return p
+
+
+def run_trimmed_summary(kernel_trace, out_path, trim_pct, add_category, window=None):
+    'Shared trimmed-summary implementation used by both the CLI subcommand and `analyze`.'
+    if not os.path.isfile(kernel_trace):
+        raise SystemExit(f"ERROR: not found: {kernel_trace}")
+    if trim_pct < 0 or trim_pct >= 100:
+        raise SystemExit(f"ERROR: --trim-pct must be in [0, 100), got {trim_pct}")
+
+    classifier = categorize_kernel if add_category else None
+
+    rows, grand_total_ns, audit = build_trimmed_summary(kernel_trace, trim_pct, window)
+    write_csv(rows, out_path, add_category, classifier)
+
+    n_eligible = sum(1 for r in rows if r["instances_before_trim"] >= 20)
+    n_trimmed_kernels = sum(1 for r in rows if r["n_trimmed"] > 0)
+    total_calls_dropped = sum(r["n_trimmed"] for r in rows)
+    print(f"wrote {out_path}")
+    print(f"  {len(rows)} distinct kernels; {n_eligible} eligible (>=20 calls); "
+          f"{n_trimmed_kernels} trimmed at {trim_pct}%; {total_calls_dropped} total calls dropped")
+    print(f"  trimmed grand total: {pretty_ns(grand_total_ns)}")
+    print(
+        f"  malformed events discarded: {audit['invalid_event_count']} "
+        f"of {audit['dispatches_before']}; window excluded/clipped: "
+        f"{audit['window_excluded_events']}/{audit['window_clipped_events']}"
+    )
+
+
+def run_pooled_kernel_summaries(kernel_workers, normalized_path, trimmed_path,
+                                trim_pct, window=None):
+    """Write canonical all-local-worker summaries and return JSON-safe provenance."""
+    if trim_pct < 0 or trim_pct >= 100:
+        raise SystemExit(f"ERROR: --trim-pct must be in [0, 100), got {trim_pct}")
+    paths = [worker["kernel_csv"] for worker in kernel_workers]
+    normalized, normalized_total, trimmed, trimmed_total, audit = (
+        build_pooled_kernel_summaries(paths, trim_pct, window)
+    )
+    write_csv(normalized, normalized_path, False, None, normalized=True)
+    write_csv(trimmed, trimmed_path, True, categorize_kernel)
+
+    provenance = []
+    for worker, input_audit in zip(kernel_workers, audit["inputs"]):
+        if os.path.abspath(worker["kernel_csv"]) != input_audit["path"]:
+            raise RankManifestError("pooled kernel input order diverged from manifest local-rank order")
+        provenance.append({
+            key: worker[key] for key in (
+                "role", "node_rank", "hostname", "pid", "world_size",
+                "global_rank", "local_rank", "filename", "kernel_csv",
+            )
+        } | {
+            key: input_audit[key] for key in (
+                "raw_row_count", "dispatch_row_count", "invalid_event_count",
+                "window_excluded_events", "window_clipped_events", "included_event_count",
+            )
+        })
+    audit = dict(audit)
+    audit.update({
+        "analysis_scope": "all_local_workers_per_node",
+        "expected_local_world_size": len(kernel_workers),
+        "selected_local_ranks": [worker["local_rank"] for worker in kernel_workers],
+        "selected_pids": [worker["pid"] for worker in kernel_workers],
+        "workers": provenance,
+        "normalized_distinct_kernel_count": len(normalized),
+        "normalized_total_ns": normalized_total,
+        "trimmed_distinct_kernel_count": len(trimmed),
+        "trimmed_total_ns": trimmed_total,
+        "trimmed_calls_dropped": sum(row["n_trimmed"] for row in trimmed),
+    })
+
+    print("kernel_analysis_scope=all_local_workers_per_node")
+    print(f"expected_local_world_size={len(kernel_workers)}")
+    print("selected_local_ranks=" + ",".join(str(rank) for rank in audit["selected_local_ranks"]))
+    print("selected_pids=" + ",".join(str(pid) for pid in audit["selected_pids"]))
+    for worker in provenance:
+        print(
+            f"pooled_input local_rank={worker['local_rank']} pid={worker['pid']} "
+            f"file={worker['filename']} raw_rows={worker['raw_row_count']} "
+            f"dispatch_rows={worker['dispatch_row_count']} "
+            f"included_rows={worker['included_event_count']}"
+        )
+    print(
+        f"pooled_total raw_rows={audit['pooled_raw_row_count']} "
+        f"dispatch_rows={audit['pooled_dispatch_row_count']} "
+        f"included_rows={audit['pooled_included_row_count']}"
+    )
+    print(
+        f"normalized distinct_kernels={len(normalized)} total_ns={normalized_total} "
+        f"-> {normalized_path}"
+    )
+    print(
+        f"trimmed distinct_kernels={len(trimmed)} total_ns={trimmed_total} "
+        f"calls_dropped={audit['trimmed_calls_dropped']} -> {trimmed_path}"
+    )
+    print(
+        f"malformed events discarded: {audit['invalid_event_count']} "
+        f"of {audit['dispatches_before']}; window excluded/clipped: "
+        f"{audit['window_excluded_events']}/{audit['window_clipped_events']}"
+    )
+    return audit
+
+
+def _run_trimmed_summary(args):
+    out_path = args.out
+    if out_path is None:
+        base = os.path.basename(args.kernel_trace)
+        stem = base[: -len("_kernel_trace.csv")] if base.endswith("_kernel_trace.csv") else os.path.splitext(base)[0]
+        out_path = os.path.join(os.path.dirname(args.kernel_trace) or ".", f"{stem}_kernel_summary_trimmed.csv")
+    run_trimmed_summary(args.kernel_trace, out_path, args.trim_pct, args.add_category)
+
+
+def _date_u():
+    'Match the exact banner formatting of the shell `date -u` command.'
+    try:
+        return subprocess.run(["date", "-u"], capture_output=True, text=True, check=True).stdout.strip()
+    except Exception:
+        return time.strftime("%a %b %e %H:%M:%S UTC %Y", time.gmtime())
+
+
+def _tail_lines(text, n):
+    'Return the last n lines of text, mirroring the shell `tail -N` helper the old script relied on.'
+    if not text:
+        return ""
+    lines = text.splitlines()
+    return "\n".join(lines[-n:])
+
+
+def _print_tail(text, n):
+    tail = _tail_lines(text, n)
+    if tail:
+        print(tail)
+
+
+def _call_captured(func, *args, **kwargs):
+    '''Call func with stdout/stderr captured (like a subprocess with 2>&1), returning
+    (exit_code, captured_text). SystemExit / exceptions are converted to a nonzero
+    exit code instead of propagating, matching how the old script inspected $? after
+    shelling back out to trace_tools.py for buckets/trimmed-summary.'''
+    buf = io.StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    exit_code = 0
+    try:
+        sys.stdout = buf
+        sys.stderr = buf
+        func(*args, **kwargs)
+    except SystemExit as e:
+        code = e.code
+        if code is None:
+            exit_code = 0
+        elif isinstance(code, int):
+            exit_code = code
+        else:
+            print(str(code))
+            exit_code = 1
+    except Exception as e:
+        print(f"ERROR: {e}")
+        exit_code = 1
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+    return exit_code, buf.getvalue()
+
+
+def _find_first(dirpath, pattern):
+    'find "$dirpath" -maxdepth 1 -name pattern | head -1, deterministically sorted.'
+    matches = sorted(glob.glob(os.path.join(dirpath, pattern)))
+    return matches[0] if matches else None
+
+
+def _find_iname_first(dirpath, pattern):
+    'find "$dirpath" -maxdepth 1 -iname pattern | head -1, deterministically sorted.'
+    if not os.path.isdir(dirpath):
+        return None
+    rx = re.compile(fnmatch.translate(pattern), re.IGNORECASE)
+    matches = sorted(name for name in os.listdir(dirpath) if rx.match(name))
+    return os.path.join(dirpath, matches[0]) if matches else None
+
+
+def _ls_lh(path):
+    'Print `ls -lh path` output; return False (after printing path-appropriate stderr) if it fails.'
+    proc = subprocess.run(["ls", "-lh", path], capture_output=True, text=True)
+    if proc.stdout:
+        sys.stdout.write(proc.stdout)
+    if proc.returncode != 0:
+        if proc.stderr:
+            sys.stderr.write(proc.stderr)
+        return False
+    return True
+
+
+def _print_output_listing(dirs):
+    'Equivalent of `ls -la "$TL_DIR" "$TL_DIR/out_csvs" "$BK_DIR" 2>/dev/null`.'
+    proc = subprocess.run(["ls", "-la"] + list(dirs), capture_output=True, text=True)
+    if proc.stdout:
+        sys.stdout.write(proc.stdout)
+
+
+INT64_MAX = (1 << 63) - 1
+
+
+class TraceSanitizationError(ValueError):
+    pass
+
+
+def _invalid_event_limits():
+    # The known incident had 24 malformed dispatches in a multi-hundred-thousand
+    # event trace. Both guards must pass; overrides are explicit environment knobs.
+    max_count = int(os.environ.get("INVALID_EVENT_MAX_COUNT", "100"))
+    max_fraction = float(os.environ.get("INVALID_EVENT_MAX_FRACTION", "0.0001"))
+    if max_count < 0 or not 0 <= max_fraction <= 1:
+        raise TraceSanitizationError(
+            f"invalid sanitizer thresholds: count={max_count}, fraction={max_fraction}"
+        )
+    return max_count, max_fraction
+
+
+def _write_json_atomic(path, value):
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    tmp = f"{path}.tmp.{os.getpid()}"
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(value, f, indent=2, sort_keys=True)
+            f.write("\n")
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+def _pair_key(event):
+    return (
+        event.get("cat"), event.get("name"), event.get("pid"), event.get("tid"),
+        json.dumps(event.get("id2"), sort_keys=True),
+    )
+
+
+def _parse_trace_event_line(line, path, lineno):
+    stripped = line.strip()
+    if stripped.endswith(","):
+        stripped = stripped[:-1]
+    try:
+        event = json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        raise TraceSanitizationError(f"invalid event JSON at {path}:{lineno}: {exc}") from exc
+    if not isinstance(event, dict):
+        raise TraceSanitizationError(f"non-object trace event at {path}:{lineno}")
+    return event, stripped
+
+
+def _stream_traceconv_events(src, path):
+    """Yield (event, original_object_text), then (None, top-level trailer)."""
+    decoder = json.JSONDecoder()
+    buffer = ""
+    eof = False
+    max_record_bytes = 16 * 1024 * 1024
+    while True:
+        buffer = buffer.lstrip()
+        while buffer.startswith(","):
+            buffer = buffer[1:].lstrip()
+        if buffer.startswith("]"):
+            yield None, buffer + src.read()
+            return
+        if not buffer and eof:
+            raise TraceSanitizationError(f"unexpected EOF before traceEvents trailer in {path}")
+        try:
+            event, end = decoder.raw_decode(buffer)
+        except json.JSONDecodeError as exc:
+            if eof:
+                raise TraceSanitizationError(f"invalid traceconv JSON in {path}: {exc}") from exc
+            chunk = src.readline()
+            if chunk:
+                buffer += chunk
+                if len(buffer.encode("utf-8")) > max_record_bytes:
+                    raise TraceSanitizationError(
+                        f"trace record exceeds {max_record_bytes} bytes or is malformed in {path}"
+                    )
+            else:
+                eof = True
+            continue
+        if not isinstance(event, dict):
+            raise TraceSanitizationError(f"non-object trace event in {path}")
+        raw = buffer[:end]
+        buffer = buffer[end:]
+        yield event, raw
+
+
+def _invalid_record(domain, begin_ns, end_ns, correlation_id, event=None):
+    delta = end_ns - begin_ns
+    reasons = []
+    if end_ns < begin_ns:
+        reasons.append("end_before_begin")
+    if delta > INT64_MAX or delta < 0 and delta % (1 << 64) > INT64_MAX:
+        reasons.append("unsigned_duration_exceeds_int64")
+    return {
+        "domain": domain,
+        "correlation_id": correlation_id,
+        "begin_ns": begin_ns,
+        "end_ns": end_ns,
+        "signed_duration_ns": delta,
+        "unsigned_duration_ns": delta % (1 << 64),
+        "reasons": reasons,
+        "name": event.get("name") if event else None,
+        "pid": event.get("pid") if event else None,
+        "tid": event.get("tid") if event else None,
+    }
+
+
+def _guard_invalid(report, report_path):
+    count = report["invalid_event_count"]
+    denominator = report["duration_events_before"]
+    fraction = count / denominator if denominator else 0.0
+    max_count, max_fraction = _invalid_event_limits()
+    report["invalid_event_fraction"] = fraction
+    report["guard"] = {
+        "max_count": max_count,
+        "max_fraction": max_fraction,
+        "passed": count <= max_count and fraction <= max_fraction,
+        "override_environment": ["INVALID_EVENT_MAX_COUNT", "INVALID_EVENT_MAX_FRACTION"],
+    }
+    if not report["guard"]["passed"]:
+        report["status"] = "rejected_by_guard"
+        _write_json_atomic(report_path, report)
+        raise TraceSanitizationError(
+            f"invalid-event guard rejected {count}/{denominator} events "
+            f"({fraction:.6%}); limits are {max_count} and {max_fraction:.6%}"
+        )
+
+
+def sanitize_perfetto_json(in_path, out_path, report_path, window=None):
+    """Stream traceconv JSON, removing only malformed duration-bearing begin records.
+
+    traceconv globally sorts phase records and omits correlation IDs from ``ph=e``
+    records, so an end record cannot be uniquely paired after conversion. TraceLens
+    consumes only the duration-bearing ``ph=b`` record (the one with ``agent`` and
+    begin/end/delta fields); retaining phase-end records preserves every record that
+    cannot be proven malformed while removing exactly the bad TraceLens input.
+    """
+    if os.path.abspath(in_path) == os.path.abspath(out_path):
+        raise TraceSanitizationError("sanitizer input and output must differ")
+    os.makedirs(os.path.dirname(os.path.abspath(out_path)), exist_ok=True)
+    tmp = f"{out_path}.tmp.{os.getpid()}"
+    invalid = []
+    stats = {
+        "trace_records_before": 0,
+        "trace_records_after": 0,
+        "duration_events_before": 0,
+        "duration_events_after": 0,
+        "duration_ns_before": 0,
+        "duration_ns_after": 0,
+        "window_excluded_events": 0,
+        "window_clipped_events": 0,
+    }
+    try:
+        with open(in_path, "r", encoding="utf-8") as src, open(tmp, "w", encoding="utf-8") as dst:
+            header = src.readline()
+            if header.strip() != '{"traceEvents":[':
+                raise TraceSanitizationError(
+                    f"{in_path} is not line-oriented traceconv JSON (unexpected first line)"
+                )
+            dst.write(header)
+            previous = None
+
+            def emit(raw):
+                nonlocal previous
+                if previous is not None:
+                    dst.write(previous + ",\n")
+                previous = raw
+
+            trailer = None
+            for event, raw in _stream_traceconv_events(src, in_path):
+                if event is None:
+                    trailer = raw
+                    break
+                stats["trace_records_before"] += 1
+                args = event.get("args") or {}
+                is_duration = event.get("ph") == "b" and "begin_ns" in args and "end_ns" in args
+                if not is_duration:
+                    emit(raw)
+                    stats["trace_records_after"] += 1
+                    continue
+
+                begin_ns = int(args["begin_ns"])
+                end_ns = int(args["end_ns"])
+                delta_ns = end_ns - begin_ns
+                stats["duration_events_before"] += 1
+                if end_ns < begin_ns or delta_ns > INT64_MAX:
+                    invalid.append(_invalid_record(
+                        event.get("cat", "unknown"), begin_ns, end_ns,
+                        args.get("corr_id", (event.get("id2") or {}).get("local")), event,
+                    ))
+                    continue
+                stats["duration_ns_before"] += delta_ns
+
+                clipped_begin = begin_ns
+                clipped_end = end_ns
+                if window is not None:
+                    clipped_begin = max(begin_ns, int(window[0]))
+                    clipped_end = min(end_ns, int(window[1]))
+                    if clipped_end <= clipped_begin:
+                        stats["window_excluded_events"] += 1
+                        continue
+                    if clipped_begin != begin_ns or clipped_end != end_ns:
+                        stats["window_clipped_events"] += 1
+                        event_args = dict(args)
+                        event_args["begin_ns"] = clipped_begin
+                        event_args["end_ns"] = clipped_end
+                        event_args["delta_ns"] = clipped_end - clipped_begin
+                        event = dict(event)
+                        event["args"] = event_args
+                        event["ts"] = clipped_begin // 1000
+                        raw = json.dumps(event, separators=(",", ":"), sort_keys=True)
+                emit(raw)
+                stats["trace_records_after"] += 1
+                stats["duration_events_after"] += 1
+                stats["duration_ns_after"] += clipped_end - clipped_begin
+
+            if trailer is None:
+                raise TraceSanitizationError(f"traceEvents trailer missing in {in_path}")
+            if previous is not None:
+                dst.write(previous + "\n")
+            dst.write(trailer)
+            dst.flush()
+            os.fsync(dst.fileno())
+
+        report = {
+            "schema_version": 1,
+            "status": "sanitized",
+            "input": os.path.abspath(in_path),
+            "output": os.path.abspath(out_path),
+            "input_bytes": os.path.getsize(in_path),
+            "output_bytes": os.path.getsize(tmp),
+            "window_monotonic_ns": list(window) if window is not None else None,
+            "invalid_event_count": len(invalid),
+            "discarded_trace_records": len(invalid),
+            "phase_end_records_retained": True,
+            "phase_end_rationale": (
+                "traceconv end records have no correlation ID and are globally timestamp-sorted; "
+                "TraceLens consumes the duration-bearing begin record"
+            ),
+            "invalid_events": invalid,
+            **stats,
+        }
+        _guard_invalid(report, report_path)
+        os.replace(tmp, out_path)
+        report["status"] = "ok"
+        report["output_bytes"] = os.path.getsize(out_path)
+        _write_json_atomic(report_path, report)
+        return report
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+
+def sanitize_native_rocprof_data(data, source_path, report_path, window=None):
+    try:
+        tool_data = data["rocprofiler-sdk-tool"][0]
+        buffer_records = tool_data["buffer_records"]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise TraceSanitizationError(f"invalid rocprofv3 JSON structure in {source_path}") from exc
+    invalid = []
+    duration_before = duration_after = duration_ns_before = duration_ns_after = 0
+    excluded = clipped = 0
+    for domain, records in list(buffer_records.items()):
+        if not isinstance(records, list):
+            continue
+        kept = []
+        for record in records:
+            if not isinstance(record, dict) or "start_timestamp" not in record or "end_timestamp" not in record:
+                kept.append(record)
+                continue
+            begin_ns = int(record["start_timestamp"])
+            end_ns = int(record["end_timestamp"])
+            delta_ns = end_ns - begin_ns
+            duration_before += 1
+            correlation = record.get("correlation_id") or record.get("dispatch_info", {}).get("dispatch_id")
+            if end_ns < begin_ns or delta_ns > INT64_MAX:
+                invalid.append(_invalid_record(domain, begin_ns, end_ns, correlation))
+                continue
+            duration_ns_before += delta_ns
+            clipped_begin = begin_ns
+            clipped_end = end_ns
+            if window is not None:
+                clipped_begin = max(begin_ns, int(window[0]))
+                clipped_end = min(end_ns, int(window[1]))
+                if clipped_end <= clipped_begin:
+                    excluded += 1
+                    continue
+                if clipped_begin != begin_ns or clipped_end != end_ns:
+                    clipped += 1
+                    record = dict(record)
+                    record["start_timestamp"] = clipped_begin
+                    record["end_timestamp"] = clipped_end
+            kept.append(record)
+            duration_after += 1
+            duration_ns_after += clipped_end - clipped_begin
+        buffer_records[domain] = kept
+    report = {
+        "schema_version": 1,
+        "status": "sanitized_in_memory",
+        "input": os.path.abspath(source_path),
+        "output": "TraceLens in-memory rocprof data",
+        "input_bytes": os.path.getsize(source_path),
+        "window_monotonic_ns": list(window) if window is not None else None,
+        "invalid_event_count": len(invalid),
+        "discarded_trace_records": len(invalid),
+        "invalid_events": invalid,
+        "duration_events_before": duration_before,
+        "duration_events_after": duration_after,
+        "duration_ns_before": duration_ns_before,
+        "duration_ns_after": duration_ns_after,
+        "window_excluded_events": excluded,
+        "window_clipped_events": clipped,
+    }
+    _guard_invalid(report, report_path)
+    report["status"] = "ok"
+    _write_json_atomic(report_path, report)
+    return report
+
+
+def _json_trace_kind(path):
+    with open(path, "rb") as f:
+        prefix = f.read(4096).lstrip()
+    if prefix.startswith(b'{"traceEvents"'):
+        return "perfetto_json"
+    if prefix.startswith(b'{"rocprofiler-sdk-tool"'):
+        return "rocprof_json"
+    return None
+
+
+def _detect_trace(trace, rank_manifest_path=None):
+    """Resolve one exact analysis input without PID/filename-order fallback."""
+    trace = os.path.abspath(trace)
+    if os.path.isdir(trace):
+        match = _NODE_DIR_RE.fullmatch(os.path.basename(trace))
+        if not match:
+            print(f"ERROR: trace directory name must match rocprof_(prefill|decode)_NODE<N>: {trace}")
+            return None
+        if not rank_manifest_path:
+            print("ERROR: a rank manifest is required when analyzing a rocprof node directory")
+            return None
+        role, node_rank = match.group(1), int(match.group(2))
+        jobdir = os.path.dirname(trace)
+        manifest = load_rank_manifest(rank_manifest_path, jobdir)
+        workers = selected_workers(manifest, role, node_rank)
+        selected = workers[0]
+        kernel_workers = []
+        for worker in workers:
+            kernel_csv = os.path.join(jobdir, worker["artifacts"]["kernel_csv"])
+            if not os.path.isfile(kernel_csv):
+                print(
+                    f"ERROR: worker local_rank={worker['local_rank']} PID {worker['pid']} "
+                    f"has no kernel CSV: {kernel_csv}"
+                )
+                return None
+            kernel_workers.append({
+                key: worker[key] for key in (
+                    "role", "node_rank", "hostname", "pid", "world_size",
+                    "global_rank", "local_rank",
+                )
+            } | {
+                "kernel_csv": kernel_csv,
+                "filename": os.path.basename(kernel_csv),
+            })
+        artifacts = {
+            key: (os.path.join(jobdir, value) if value else None)
+            for key, value in selected["artifacts"].items()
+        }
+        kernel_csv = artifacts.get("kernel_csv")
+        if artifacts.get("pftrace") and os.path.isfile(artifacts["pftrace"]):
+            primary_kind = "pftrace"
+            primary = artifacts["pftrace"]
+        elif artifacts.get("rocprof_json") and os.path.isfile(artifacts["rocprof_json"]):
+            primary_kind = "rocprof_json"
+            primary = artifacts["rocprof_json"]
+        else:
+            print(
+                f"ERROR: selected PID {selected['pid']} has neither native PFTrace nor rocprof JSON; "
+                "raw CSV is not a TraceLens fallback"
+            )
+            return None
+        return {
+            "kind": primary_kind,
+            "path": primary,
+            "kernel_csv": kernel_csv,
+            "jobdir": jobdir,
+            "role": role,
+            "node_rank": node_rank,
+            "selection": selected,
+            "rank_manifest": os.path.abspath(rank_manifest_path),
+            "kernel_workers": kernel_workers,
+            "kernel_analysis_scope": "all_local_workers_per_node",
+        }
+
+    if not os.path.isfile(trace):
+        print(f"ERROR: trace not found: {trace}")
+        return None
+    if trace.endswith(".pftrace"):
+        kind = "pftrace"
+    elif trace.endswith(".json") or trace.endswith(".json.gz"):
+        if trace.endswith(".json.gz"):
+            print("ERROR: compressed JSON is not supported by the strict sanitizer")
+            return None
+        kind = _json_trace_kind(trace)
+        if not kind:
+            print(f"ERROR: unrecognized JSON trace schema: {trace}")
+            return None
+    elif trace.endswith("_kernel_trace.csv"):
+        print("ERROR: raw kernel CSV is not accepted as a TraceLens analysis input")
+        return None
+    else:
+        print(f"ERROR: '{trace}' is not a recognized trace file/dir")
+        return None
+    stem = trace[:-len("_results.pftrace")] if trace.endswith("_results.pftrace") else None
+    kernel_csv = stem + "_kernel_trace.csv" if stem and os.path.isfile(stem + "_kernel_trace.csv") else None
+    return {
+        "kind": kind,
+        "path": trace,
+        "kernel_csv": kernel_csv,
+        "jobdir": os.path.dirname(trace),
+        "role": None,
+        "node_rank": None,
+        "selection": None,
+        "rank_manifest": None,
+        "kernel_workers": None,
+        "kernel_analysis_scope": "single_trace",
+    }
+
+
+
+def _normalize_kernel_summary(src, out):
+    '''Reproduce the analyze_kernels.sh inline Python heredoc normalizer exactly. Prints its own
+    success/error message (matching the old unredirected heredoc) and returns an exit-code-like
+    int (0 success, 1 failure) instead of calling sys.exit, since a failure here must not abort
+    the rest of `analyze`.'''
+    if not src or not os.path.isfile(src):
+        print(f"ERROR: normalizer input CSV not found: {src}")
+        return 1
+    with open(src, newline='', encoding='utf-8-sig') as f:
+        rows = list(csv.reader(f))
+    if not rows:
+        print("ERROR: normalizer input CSV is empty: %s" % src)
+        return 1
+    hdr = rows[0]
+    low = [(h or '').strip().lower() for h in hdr]
+
+    def col(*cands):
+        for c in cands:
+            if c in low:
+                return low.index(c)
+        return None
+
+    name_i  = col('name', 'kernel name', 'kernel_name')
+    ns_i    = col('total time (ns)')
+    inst_i  = col('instances', 'total count')
+    start_i = col('start_timestamp')
+    end_i   = col('end_timestamp')
+    native_total_i = col('total kernel time (ms)')
+    native_count_i = col('count')
+
+    HELP = ['Kernel name', 'kernel_duration_us_sum', 'kernel_duration_us_count']
+
+    if start_i is not None and end_i is not None and name_i is not None:
+        agg = {}
+        for r in rows[1:]:
+            if not r or name_i >= len(r):
+                continue
+            nm = r[name_i]
+            try:
+                dur_us = (float(r[end_i]) - float(r[start_i])) / 1000.0
+            except (ValueError, IndexError):
+                continue
+            a = agg.setdefault(nm, [0.0, 0])
+            a[0] += dur_us
+            a[1] += 1
+        with open(out, 'w', newline='', encoding='utf-8-sig') as f:
+            w = csv.writer(f)
+            w.writerow(['Name', 'Total Time (ns)', 'Instances'] + HELP)
+            for nm, (us, cnt) in sorted(agg.items(), key=lambda kv: -kv[1][0]):
+                w.writerow([nm, us * 1000.0, cnt, nm, '%.4f' % us, cnt])
+        print("normalized rocprofv3 kernel_trace.csv: %d distinct kernels" % len(agg))
+        return 0
+    elif name_i is not None and native_total_i is not None and native_count_i is not None:
+        # TraceLens's rocprof analyzer currently labels this column as milliseconds,
+        # but its implementation stores total_ns / 1000 (microseconds). Normalize
+        # from that known producer behavior into the same ns/us columns as PFTrace.
+        n = 0
+        with open(out, 'w', newline='', encoding='utf-8-sig') as f:
+            w = csv.writer(f)
+            w.writerow(['Name', 'Total Time (ns)', 'Instances'] + HELP)
+            for r in rows[1:]:
+                if not r or name_i >= len(r):
+                    continue
+                try:
+                    total_us = float(r[native_total_i])
+                    count = int(float(r[native_count_i]))
+                except (ValueError, IndexError):
+                    continue
+                name = r[name_i]
+                w.writerow([name, total_us * 1000.0, count, name, total_us, count])
+                n += 1
+        print("normalized TraceLens rocprof JSON kernel_summary.csv: %d rows" % n)
+        return 0
+    elif name_i is not None:
+        n = 0
+        with open(out, 'w', newline='', encoding='utf-8-sig') as f:
+            w = csv.writer(f)
+            w.writerow(hdr + HELP)
+            for r in rows[1:]:
+                if not r or all((c or '').strip() == '' for c in r):
+                    continue
+                nm = r[name_i] if name_i < len(r) else ''
+                us = ''
+                if ns_i is not None and ns_i < len(r):
+                    try:
+                        us = '%.4f' % (float(r[ns_i]) / 1000.0)
+                    except ValueError:
+                        us = ''
+                cnt = ''
+                if inst_i is not None and inst_i < len(r):
+                    try:
+                        cnt = int(float(r[inst_i]))
+                    except ValueError:
+                        cnt = ''
+                w.writerow(r + [nm, us, cnt])
+                n += 1
+        print("normalized TraceLens kernel_summary.csv: %d rows" % n)
+        return 0
+    else:
+        print("ERROR: unrecognized kernel-summary schema; headers=%r" % hdr)
+        return 1
+
+
+def _run_native_tracelens(profile_json, out_csvs, sanitizer_report, window):
+    """Use TraceLens's official rocprof parser/analyzer on a narrowly filtered in-memory trace."""
+    from TraceLens.util import RocprofParser
+    from TraceLens.Reporting.rocprof_analysis import RocprofAnalyzer
+
+    data = RocprofParser.load_rocprof_data(profile_json)
+    report = sanitize_native_rocprof_data(data, profile_json, sanitizer_report, window)
+    kernel_events = RocprofParser.extract_kernel_events(data)
+    memory_events = RocprofParser.extract_memory_events(data)
+    api_events = RocprofParser.extract_api_events(data)
+    metadata = RocprofParser.get_metadata(data)
+    if window is not None:
+        metadata["init_time"], metadata["fini_time"] = int(window[0]), int(window[1])
+    analyzer = RocprofAnalyzer(kernel_events, memory_events, api_events, metadata)
+    frames = {
+        "gpu_timeline": analyzer.get_df_gpu_timeline(),
+        "kernel_summary": analyzer.get_df_kernel_summary(),
+        "kernel_summary_by_category": analyzer.get_df_kernel_summary_by_category(),
+    }
+    os.makedirs(out_csvs, exist_ok=True)
+    for name, frame in frames.items():
+        path = os.path.join(out_csvs, f"{name}.csv")
+        frame.to_csv(path, index=False)
+        print(f"TraceLens native rocprof: {path} ({len(frame)} rows)")
+    print(
+        f"TraceLens native rocprof sanitized {report['invalid_event_count']} malformed "
+        f"event(s); retained {len(kernel_events)} kernel event(s)"
+    )
+
+
+def run_analyze(trace, outdir, label, venv, traceconv, trim_pct,
+                rank_manifest_path=None, window_manifest_path=None):
+    """Strict single-trace analysis with manifest selection and no CSV fallback."""
+    print(f"############ [{label}] START {_date_u()} ############")
+    print(f"TRACE={trace}")
+
+    detected = _detect_trace(trace, rank_manifest_path)
+    if detected is None:
+        return 2
+    if os.path.isdir(outdir) and os.listdir(outdir):
+        print(f"ERROR: output directory is not empty (refusing stale-output success): {outdir}")
+        return 2
+
+    tl_dir = os.path.join(outdir, "tracelens")
+    out_csvs = os.path.join(tl_dir, "out_csvs")
+    bk_dir = os.path.join(outdir, "buckets")
+    os.makedirs(out_csvs, exist_ok=True)
+    os.makedirs(bk_dir, exist_ok=True)
+    metadata_path = os.path.join(outdir, "analysis_metadata.json")
+    kernel_workers = detected.get("kernel_workers")
+    node_aggregate = bool(kernel_workers)
+    tracelens_scope = "supplementary_local_rank_0" if node_aggregate else "primary_single_trace"
+    metadata = {
+        "schema_version": 1,
+        "status": "running",
+        "label": label,
+        "primary_input_kind": detected["kind"],
+        "primary_input": detected["path"],
+        "raw_csv_fallback": False,
+        "selection": detected["selection"],
+        "rank_manifest": detected["rank_manifest"],
+        "window_manifest": os.path.abspath(window_manifest_path) if window_manifest_path else None,
+        "tracelens": {
+            "scope": tracelens_scope,
+            "selection": detected["selection"],
+            "primary_input": detected["path"],
+        },
+        "kernel_analysis": {
+            "analysis_scope": detected["kernel_analysis_scope"],
+            "canonical_source": (
+                "pooled_raw_worker_kernel_csvs" if node_aggregate
+                else "tracelens_single_trace_summary"
+            ),
+            "expected_local_world_size": len(kernel_workers) if node_aggregate else None,
+            "selected_local_ranks": (
+                [worker["local_rank"] for worker in kernel_workers] if node_aggregate else None
+            ),
+            "workers": kernel_workers,
+        },
+    }
+    print(f"tracelens_scope={tracelens_scope}")
+    print(f"kernel_analysis_scope={detected['kernel_analysis_scope']}")
+
+    def fail(code, message):
+        print(f"ERROR: {message}")
+        metadata["status"] = "failed"
+        metadata["error"] = message
+        _write_json_atomic(metadata_path, metadata)
+        return code
+
+    if not os.path.isfile(os.path.join(venv, "bin", "activate")):
+        return fail(3, f"venv not found at '{venv}'")
+    env = os.environ.copy()
+    env["VIRTUAL_ENV"] = venv
+    env["PATH"] = os.path.join(venv, "bin") + os.pathsep + env.get("PATH", "")
+
+    window_manifest = {
+        "available": False,
+        "analysis_scope": "whole_capture",
+        "reason": "no window manifest supplied",
+    }
+    window = None
+    if window_manifest_path:
+        if detected["role"] is None:
+            return fail(2, "windowed analysis requires a manifest-selected role/node directory")
+        try:
+            window_manifest, window = load_window_manifest(
+                window_manifest_path, detected["role"], detected["node_rank"])
+        except (OSError, ValueError) as exc:
+            return fail(2, f"invalid window manifest: {exc}")
+    metadata["measurement_window"] = {
+        "available": bool(window_manifest.get("available")),
+        "analysis_scope": window_manifest.get("analysis_scope", "whole_capture"),
+        "reason": window_manifest.get("reason"),
+        "monotonic_ns": list(window) if window else None,
+    }
+    print(f"analysis_scope={metadata['measurement_window']['analysis_scope']}")
+    if not window:
+        print(f"measurement_window_unavailable={metadata['measurement_window']['reason']}")
+    _write_json_atomic(metadata_path, metadata)
+
+    sanitizer_report = os.path.join(tl_dir, "sanitizer_report.json")
+    kind = detected["kind"]
+    primary = detected["path"]
+    ks = None
+    catsum = None
+
+    if kind in ("pftrace", "perfetto_json"):
+        if kind == "pftrace":
+            print(
+                f"=== [{label}] (a0) {tracelens_scope} traceconv: "
+                "pftrace -> Perfetto JSON ==="
+            )
+            if not _ls_lh(primary):
+                return fail(2, "selected PFTrace is missing")
+            if not os.path.isfile(traceconv) or not os.access(traceconv, os.X_OK):
+                return fail(3, f"traceconv is not executable: {traceconv}")
+            base = os.path.basename(primary)
+            if base.endswith(".pftrace"):
+                base = base[:-len(".pftrace")]
+            converted = os.path.join(tl_dir, base + ".traceconv.tmp.json")
+            try:
+                with open(traceconv, "rb") as f:
+                    is_elf = f.read(4) == b"\x7fELF"
+            except OSError as exc:
+                return fail(3, f"cannot inspect traceconv: {exc}")
+            cmd = [traceconv, "json", primary, converted] if is_elf else ["python3", traceconv, "json", primary, converted]
+            try:
+                proc = subprocess.run(cmd, env=env, capture_output=True, text=True)
+            except OSError as exc:
+                return fail(3, f"traceconv invocation failed: {exc}")
+            traceconv_text = (proc.stdout or "") + (proc.stderr or "")
+            with open(os.path.join(tl_dir, "traceconv_stdout.txt"), "w", encoding="utf-8") as f:
+                f.write(traceconv_text)
+            print(f"traceconv_exit={proc.returncode} -> {converted}")
+            _print_tail(traceconv_text, 8)
+            if proc.returncode != 0 or not (os.path.isfile(converted) and os.path.getsize(converted) > 0):
+                return fail(3, f"traceconv failed with status {proc.returncode}")
+        else:
+            converted = primary
+
+        sanitized = os.path.join(tl_dir, os.path.basename(converted).replace(".traceconv.tmp", "") + ".sanitized.json")
+        try:
+            report = sanitize_perfetto_json(converted, sanitized, sanitizer_report, window)
+        except (OSError, ValueError) as exc:
+            return fail(4, f"trace sanitizer failed: {exc}")
+        print(
+            f"sanitizer_discarded={report['invalid_event_count']} "
+            f"window_before={report['duration_events_before']} window_after={report['duration_events_after']}"
+        )
+        if kind == "pftrace":
+            os.unlink(converted)
+
+        print(
+            f"=== [{label}] (a) {tracelens_scope} TraceLens Perfetto parsing "
+            "and kernel aggregation ==="
+        )
+        tl_cmd = [
+            "TraceLens_generate_perf_report_pftrace_hip_activity",
+            "--trace_path", sanitized,
+            "--output_xlsx_path", os.path.join(tl_dir, "report_TP0.xlsx"),
+            "--output_csvs_dir", out_csvs,
+            "--output_md_path", os.path.join(tl_dir, "report.md"),
+            "--traceconv", traceconv,
+            "--min_event_ns", "0",
+            "--write_md",
+        ]
+        try:
+            proc = subprocess.run(tl_cmd, env=env, capture_output=True, text=True)
+        except OSError as exc:
+            return fail(4, f"TraceLens invocation failed: {exc}")
+        tl_text = (proc.stdout or "") + (proc.stderr or "")
+        with open(os.path.join(tl_dir, "tracelens_stdout.txt"), "w", encoding="utf-8") as f:
+            f.write(tl_text)
+        print(f"tracelens_exit={proc.returncode}")
+        _print_tail(tl_text, 12)
+        if proc.returncode != 0 or "Traceback (most recent call last)" in tl_text or re.search(r"\bERROR\s+-", tl_text):
+            return fail(4, f"TraceLens Perfetto analysis failed with status {proc.returncode}")
+        ks = _find_iname_first(out_csvs, "kernel_summary*.csv")
+        catsum = _find_iname_first(out_csvs, "category_summary*.csv")
+        required = [ks, catsum, os.path.join(tl_dir, "report.md")]
+        if any(not path or not os.path.isfile(path) or os.path.getsize(path) == 0 for path in required):
+            return fail(4, "TraceLens exited without all required Perfetto outputs")
+    elif kind == "rocprof_json":
+        print(
+            f"=== [{label}] (a) {tracelens_scope} TraceLens native rocprof JSON "
+            "analysis (PFTrace unavailable) ==="
+        )
+        exit_code, tl_text = _call_captured(
+            _run_native_tracelens, primary, out_csvs, sanitizer_report, window)
+        with open(os.path.join(tl_dir, "tracelens_stdout.txt"), "w", encoding="utf-8") as f:
+            f.write(tl_text)
+        print(f"tracelens_exit={exit_code}")
+        _print_tail(tl_text, 12)
+        if exit_code != 0:
+            return fail(4, f"TraceLens native rocprof analysis failed with status {exit_code}")
+        ks = os.path.join(out_csvs, "kernel_summary.csv")
+        catsum = os.path.join(out_csvs, "kernel_summary_by_category.csv")
+        required = [ks, catsum, os.path.join(out_csvs, "gpu_timeline.csv")]
+        if any(not os.path.isfile(path) or os.path.getsize(path) == 0 for path in required):
+            return fail(4, "TraceLens native analysis did not produce all required outputs")
+    else:
+        return fail(2, f"unsupported strict analysis input kind: {kind}")
+
+    print(f"{tracelens_scope}_tracelens_kernel_summary_csv={ks}")
+    native_category_name = (
+        "supplementary_rank0_tracelens_native_category_summary.csv"
+        if node_aggregate else "tracelens_native_category_summary.csv"
+    )
+    native_category_copy = os.path.join(bk_dir, native_category_name)
+    shutil.copyfile(catsum, native_category_copy)
+    metadata["tracelens"].update({
+        "kernel_summary": ks,
+        "native_category_summary": native_category_copy,
+        "sanitizer_report": sanitizer_report,
+    })
+
+    norm = os.path.join(bk_dir, "kernel_summary_normalized.csv")
+    trimmed_path = os.path.join(bk_dir, "kernel_summary_trimmed.csv")
+    if node_aggregate:
+        print(
+            f"=== [{label}] (b) canonical pooled all-local-worker summaries "
+            f"(TRIM_PCT={trim_pct:g}%) ==="
+        )
+        pooled_result = {}
+
+        def build_pooled():
+            pooled_result["audit"] = run_pooled_kernel_summaries(
+                kernel_workers, norm, trimmed_path, trim_pct, window)
+
+        exit_code, pooled_text = _call_captured(build_pooled)
+        with open(os.path.join(bk_dir, "trimmed_summary_stdout.txt"), "w", encoding="utf-8") as f:
+            f.write(pooled_text)
+        print(f"pooled_summary_exit={exit_code}")
+        if pooled_text:
+            sys.stdout.write(pooled_text)
+        if (exit_code != 0 or "audit" not in pooled_result
+                or any(not os.path.isfile(path) or os.path.getsize(path) == 0
+                       for path in (norm, trimmed_path))):
+            return fail(5, "pooled all-local-worker summaries failed or produced missing outputs")
+        metadata["kernel_analysis"].update(pooled_result["audit"])
+        metadata["kernel_analysis"].update({
+            "normalized_output": norm,
+            "trimmed_output": trimmed_path,
+        })
+    else:
+        print(f"=== [{label}] (b) TraceLens kernel-summary normalization ===")
+        norm_exit = _normalize_kernel_summary(ks, norm)
+        print(f"normalize_exit={norm_exit} -> {norm}")
+        if norm_exit != 0 or not os.path.isfile(norm) or os.path.getsize(norm) == 0:
+            return fail(5, "kernel summary normalization failed")
+
+    print(f"=== [{label}] (c) first-party category buckets (name-based) ===")
+    exit_code, bucket_text = _call_captured(
+        process, norm,
+        os.path.join(bk_dir, "perkernel_buckets.csv"),
+        os.path.join(bk_dir, "bycat_buckets.csv"),
+        f"{label} ({'all local workers/node' if node_aggregate else 'TraceLens'})",
+    )
+    with open(os.path.join(bk_dir, "buckets_stdout.txt"), "w", encoding="utf-8") as f:
+        f.write(bucket_text)
+    print(f"buckets_exit={exit_code}")
+    _print_tail(bucket_text, 12)
+    bucket_outputs = [os.path.join(bk_dir, "perkernel_buckets.csv"), os.path.join(bk_dir, "bycat_buckets.csv")]
+    if exit_code != 0 or any(not os.path.isfile(path) or os.path.getsize(path) == 0 for path in bucket_outputs):
+        return fail(5, "first-party bucketing failed or produced missing outputs")
+
+    if not node_aggregate:
+        print(f"=== [{label}] (d) trimmed single-worker kernel summary (TRIM_PCT={trim_pct:g}%) ===")
+        trim_src = detected.get("kernel_csv")
+        if not trim_src or not os.path.isfile(trim_src):
+            return fail(5, "selected worker has no raw kernel CSV for the auxiliary trimmed summary")
+        print(f"trim_src={trim_src}")
+        exit_code, trim_text = _call_captured(
+            run_trimmed_summary, trim_src, trimmed_path, trim_pct, True, window)
+        with open(os.path.join(bk_dir, "trimmed_summary_stdout.txt"), "w", encoding="utf-8") as f:
+            f.write(trim_text)
+        print(f"trimmed_summary_exit={exit_code}")
+        _print_tail(trim_text, 8)
+        if exit_code != 0 or not os.path.isfile(trimmed_path) or os.path.getsize(trimmed_path) == 0:
+            return fail(5, "trimmed summary failed or produced no output")
+
+    expected_outputs = [metadata_path, sanitizer_report, ks, native_category_copy, norm, trimmed_path] + bucket_outputs
+    if any(not os.path.isfile(path) or os.path.getsize(path) == 0 for path in expected_outputs[1:]):
+        return fail(6, "final completeness check found a missing/empty output")
+    metadata["status"] = "success"
+    metadata["sanitizer_report"] = sanitizer_report
+    metadata["sanitizer_scope"] = tracelens_scope
+    metadata["outputs"] = expected_outputs[1:]
+    _write_json_atomic(metadata_path, metadata)
+    print(f"=== [{label}] OUTPUT LISTING ===")
+    _print_output_listing([tl_dir, out_csvs, bk_dir])
+    print(f"############ [{label}] DONE {_date_u()} ############")
+    return 0
+
+
+
+def _add_rank_manifest_parser(subparsers):
+    p = subparsers.add_parser("rank-manifest", help="reconstruct and validate PID/rank mappings from worker logs")
+    p.add_argument("jobdir")
+    p.add_argument("--out", required=True)
+    p.set_defaults(func=_run_rank_manifest)
+
+
+def _run_rank_manifest(args):
+    manifest = write_rank_manifest(args.jobdir, args.out)
+    for row in manifest["selections"]:
+        print(
+            f"selected role={row['role']} node_rank={row['node_rank']} pid={row['pid']} "
+            f"local_rank={row['local_rank']} global_rank={row['global_rank']} "
+            f"dp_rank={row['dp_rank']} ep_rank={row['ep_rank']} host={row['hostname']}"
+        )
+    print(f"wrote {args.out}")
+
+
+def _add_window_manifest_parser(subparsers):
+    p = subparsers.add_parser("window-manifest", help="map benchmark wall timestamps to each node trace clock")
+    p.add_argument("jobdir")
+    p.add_argument("--rank-manifest", required=True)
+    p.add_argument("--out", required=True)
+    p.set_defaults(func=_run_window_manifest)
+
+
+def _run_window_manifest(args):
+    ranks = load_rank_manifest(args.rank_manifest, args.jobdir)
+    manifest = write_window_manifest(args.jobdir, ranks, args.out)
+    print(f"measurement_window_available={str(manifest['available']).lower()}")
+    print(f"analysis_scope={manifest['analysis_scope']}")
+    if not manifest["available"]:
+        print(f"reason={manifest['reason']}")
+    print(f"wrote {args.out}")
+
+
+def _add_sanitize_parser(subparsers):
+    p = subparsers.add_parser("sanitize", help="discard only malformed traceconv duration pairs")
+    p.add_argument("--in", dest="in_path", required=True)
+    p.add_argument("--out", required=True)
+    p.add_argument("--report", required=True)
+    p.add_argument("--window-start-ns", type=int)
+    p.add_argument("--window-end-ns", type=int)
+    p.set_defaults(func=_run_sanitize)
+
+
+def _run_sanitize(args):
+    if (args.window_start_ns is None) != (args.window_end_ns is None):
+        raise SystemExit("ERROR: both --window-start-ns and --window-end-ns are required")
+    window = None if args.window_start_ns is None else (args.window_start_ns, args.window_end_ns)
+    report = sanitize_perfetto_json(args.in_path, args.out, args.report, window)
+    print(f"discarded_invalid_events={report['invalid_event_count']}")
+    print(f"wrote {args.out}")
+    print(f"wrote {args.report}")
+
+
+def _add_clock_sampler_parser(subparsers):
+    p = subparsers.add_parser("clock-sampler", help="record per-node realtime/monotonic clock correlations")
+    p.add_argument("--out", required=True)
+    p.add_argument("--node-rank", required=True, type=int)
+    p.add_argument("--interval", type=float, default=1.0)
+    p.set_defaults(func=lambda args: run_clock_sampler(args.out, args.node_rank, args.interval))
+
+
+def _add_benchmark_marker_parser(subparsers):
+    p = subparsers.add_parser("benchmark-marker", help="record an exact measured benchmark boundary")
+    p.add_argument("--out", required=True)
+    p.add_argument("--event", required=True, choices=("start", "end"))
+    p.add_argument("--step-id", required=True)
+    p.add_argument("--iteration", type=int)
+    p.add_argument("--isl", type=int)
+    p.add_argument("--osl", type=int)
+    p.add_argument("--concurrency", type=int)
+    p.add_argument("--num-prompts", type=int)
+    p.add_argument("--return-code", type=int)
+    p.set_defaults(func=_run_benchmark_marker)
+
+
+def _run_benchmark_marker(args):
+    fields = {key: getattr(args, key) for key in (
+        "iteration", "isl", "osl", "concurrency", "num_prompts", "return_code")}
+    row = record_benchmark_marker(args.out, args.event, args.step_id, fields)
+    print(json.dumps(row, sort_keys=True))
+
+
+def _add_analyze_parser(subparsers):
+    p = subparsers.add_parser(
+        "analyze",
+        help="run the single-trace analysis pipeline (traceconv + TraceLens + first-party buckets + trimmed summary)",
+        description=(
+            "Strict manifest-selected analysis: native PFTrace is converted and narrowly sanitized "
+            "before TraceLens; when a capture has no PFTrace, TraceLens's native rocprof JSON path "
+            "is used. Raw kernel CSV is never a TraceLens fallback."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("trace", help="*.pftrace / *.json file, or a rocprof_*_NODE* dir")
+    p.add_argument("outdir", help="new output directory (must be empty)")
+    p.add_argument("label", help="short label used in banners and stdout summaries")
+    p.add_argument("--rank-manifest", default=None)
+    p.add_argument("--window-manifest", default=None)
+    p.set_defaults(func=_run_analyze)
+    return p
+
+
+def _run_analyze(args):
+    here = os.path.dirname(os.path.abspath(__file__))
+    venv = os.environ.get("VENV", os.path.join(here, "external_copies", "venv"))
+    traceconv = os.environ.get("TRACECONV", os.path.join(here, "external_copies", "traceconv_bin", "traceconv"))
+    try:
+        trim_pct = float(os.environ.get("TRIM_PCT", "5"))
+    except ValueError:
+        trim_pct = 5.0
+    return run_analyze(
+        args.trace, args.outdir, args.label, venv, traceconv, trim_pct,
+        args.rank_manifest, args.window_manifest,
+    )
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__)
+    subparsers = p.add_subparsers(dest='command', required=True)
+    _add_combine_parser(subparsers)
+    _add_buckets_parser(subparsers)
+    _add_extract_reqid_parser(subparsers)
+    _add_rank_manifest_parser(subparsers)
+    _add_window_manifest_parser(subparsers)
+    _add_sanitize_parser(subparsers)
+    _add_clock_sampler_parser(subparsers)
+    _add_benchmark_marker_parser(subparsers)
+    _add_analyze_parser(subparsers)
+    trimmed_parser = _add_trimmed_summary_parser(subparsers)
+    effective_argv = sys.argv[1:] if argv is None else argv
+    if effective_argv and effective_argv[0] == 'trimmed-summary':
+        args = trimmed_parser.parse_args(effective_argv[1:])
+    else:
+        args = p.parse_args(effective_argv)
+    return args.func(args)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/vllm_dissag/parse_to_csv.py
+++ b/scripts/vllm_dissag/parse_to_csv.py
@@ -44,28 +44,27 @@ def parse_benchmark_log(log_file: str) -> Dict[Tuple[int, int, int], Dict]:
     current_concurrency = None
 
     for i, section in enumerate(sections[1:], 1):  # Skip first empty section
-        # Look for configuration in previous sections (from [RUNNING] line)
-        if i > 1:
-            prev_section = sections[i-1]
+        # The first result's configuration is in sections[0].
+        prev_section = sections[i - 1]
 
-            # vllm format: [RUNNING] prompts <N> isl <ISL> osl <OSL> con <CON>
-            config_match = re.search(
-                r'\[RUNNING\]\s+prompts\s+\d+\s+isl\s+(\d+)\s+osl\s+(\d+)\s+con\s+(\d+)',
-                prev_section
-            )
-            # Fallback: extract from Namespace(...) in vllm bench serve output
-            if not config_match:
-                isl_m = re.search(r'random_input_len=(\d+)', prev_section)
-                osl_m = re.search(r'random_output_len=(\d+)', prev_section)
-                con_m = re.search(r'max_concurrency=(\d+)', prev_section)
-                if isl_m and osl_m and con_m:
-                    config_match = type('Match', (), {
-                        'group': lambda self, n: [None, isl_m.group(1), osl_m.group(1), con_m.group(1)][n]
-                    })()
-            if config_match:
-                current_input_seq_len = int(config_match.group(1))
-                current_output_seq_len = int(config_match.group(2))
-                current_concurrency = int(config_match.group(3))
+        # vllm format: [RUNNING] prompts <N> isl <ISL> osl <OSL> con <CON>
+        config_match = re.search(
+            r'\[RUNNING\]\s+prompts\s+\d+\s+isl\s+(\d+)\s+osl\s+(\d+)\s+con\s+(\d+)',
+            prev_section
+        )
+        # Fallback: extract from Namespace(...) in vllm bench serve output
+        if not config_match:
+            isl_m = re.search(r'random_input_len=(\d+)', prev_section)
+            osl_m = re.search(r'random_output_len=(\d+)', prev_section)
+            con_m = re.search(r'max_concurrency=(\d+)', prev_section)
+            if isl_m and osl_m and con_m:
+                config_match = type('Match', (), {
+                    'group': lambda self, n: [None, isl_m.group(1), osl_m.group(1), con_m.group(1)][n]
+                })()
+        if config_match:
+            current_input_seq_len = int(config_match.group(1))
+            current_output_seq_len = int(config_match.group(2))
+            current_concurrency = int(config_match.group(3))
 
         # Extract Total token throughput (tok/s) from benchmark result section
         throughput_match = re.search(r'Total token throughput \(tok/s\):\s+([\d.]+)', section)

--- a/scripts/vllm_dissag/run_xPyD_models.slurm
+++ b/scripts/vllm_dissag/run_xPyD_models.slurm
@@ -175,6 +175,26 @@ if [[ -z "${CONNECTOR:-}" ]]; then
 fi
 WIDE_EP="${WIDE_EP:-0}"
 
+[[ "${RUN_PROFILE:-0}" != 1 || "${CONNECTOR:-rixl}" == "moriio" ]] || { echo "CONNECTOR=moriio is required when RUN_PROFILE=1" >&2; exit 1; }
+RUN_PROFILE="${RUN_PROFILE:-0}"
+case "$RUN_PROFILE" in
+  0) ;;
+  1)
+    for f in "moriio_profiling/hooks.sh" "moriio_profiling/process_kernels.sh"; do
+      if [[ ! -f "$f" ]]; then
+        echo "Error: Required profiling file '$f' not found in $(pwd)." >&2
+        exit 1
+      fi
+    done
+    source "${SCRIPT_DIR}/moriio_profiling/hooks.sh"
+    moriio_profiling_configure_run "$_run_deepep" || exit $?
+    SKIP_WARMUP="${SKIP_WARMUP:-1}"
+    export SKIP_WARMUP
+    ;;
+  *) echo "Error: RUN_PROFILE must be 0 or 1 (got '$RUN_PROFILE')." >&2; exit 1 ;;
+esac
+export RUN_PROFILE
+
 # Models that ONLY run wideEP (DP/EP), never TP: the DeepSeek family is served with
 # the MoRI-EP / DeepEP recipe (block=16, MLA off, per-role cudagraph). Running them
 # in TP mode is unsupported — the TP argv would double the model's own
@@ -220,13 +240,13 @@ echo "Launcher: $RUN_FILE  (CONNECTOR=${CONNECTOR} WIDE_EP=${WIDE_EP} EP_BACKEND
 # submit-time export of the same name still overrides. Forwarded in the docker run.
 # ---------------------------------------------------------------------------
 CONNECTOR_ENV_FILE="${SCRIPT_DIR}/connectors/${CONNECTOR}.env"
-CONNECTOR_ENV_ARGS=""
+CONNECTOR_ENV_ARGS=()
 if [[ -f "$CONNECTOR_ENV_FILE" ]]; then
   echo "Loading connector platform env: $CONNECTOR_ENV_FILE"
   while IFS= read -r _line; do
     [[ "$_line" =~ ^[[:space:]]*# || -z "${_line// }" ]] && continue
     _k="${_line%%=*}"; _v="${_line#*=}"
-    CONNECTOR_ENV_ARGS+=" -e ${_k}=${!_k:-$_v}"   # submit-time export of $_k wins
+    CONNECTOR_ENV_ARGS+=( -e "${_k}=${!_k:-$_v}" )   # submit-time export of $_k wins
   done < "$CONNECTOR_ENV_FILE"
 else
   echo "WARN: connector env file not found: $CONNECTOR_ENV_FILE" >&2
@@ -433,6 +453,9 @@ case "$BENCHMARK_SCRIPT" in
     long_context) BENCHMARK_SCRIPT_FILE="benchmark_long_context.sh" ;;
     *) echo "Error: invalid BENCHMARK_SCRIPT='$BENCHMARK_SCRIPT' (valid: sweep, long_context)" >&2; exit 1 ;;
 esac
+if [[ "${RUN_PROFILE:-0}" == "1" ]]; then
+    BENCHMARK_SCRIPT_FILE="benchmark_xPyD_profile.sh"
+fi
 if [[ ! -f "$BENCHMARK_SCRIPT_FILE" ]]; then
     echo "Error: selected benchmark script '$BENCHMARK_SCRIPT_FILE' not found in $(pwd)." >&2
     exit 1
@@ -454,7 +477,6 @@ else
     echo "Directory already exists: $LOG_PATH"
 fi
 
-export CONNECTOR_ENV_ARGS="$CONNECTOR_ENV_ARGS"
 export LOG_PATH=$LOG_PATH
 export NIXL_REPO_DIR=$NIXL_REPO_DIR
 export NIXL_COOKBOOK_PATH=$NIXL_COOKBOOK_PATH
@@ -477,9 +499,19 @@ export RUN_FILE_FULL="$NIXL_COOKBOOK_PATH/${RUN_FILE}"
 
 # Use only the selected nodes for srun execution
 SELECTED_NODELIST_SRUN=$(echo "$SELECTED_NODES" | paste -sd,)
+_PROFILE_RUN_RC=0
 
 srun --nodelist="$SELECTED_NODELIST_SRUN" bash -c '
+CONNECTOR_ENV_ARGS=("$@")
 echo "Rank $SLURM_PROCID on $(hostname)";
+_CLOCK_SAMPLER_PID="";
+clock_sampler_cleanup() {
+    if [ -n "${_CLOCK_SAMPLER_PID:-}" ]; then
+        kill "$_CLOCK_SAMPLER_PID" 2>/dev/null || true;
+        wait "$_CLOCK_SAMPLER_PID" 2>/dev/null || true;
+    fi
+}
+trap clock_sampler_cleanup EXIT;
 docker ps -q | xargs --no-run-if-empty docker stop;
 docker rm -f $DOCKER_CONT_NAME 2>/dev/null || true;
 fuser -k 5000/tcp 2>/dev/null || true;
@@ -533,6 +565,26 @@ done
 [ -d /etc/libibverbs.d ]     && _RDMA_MOUNTS="$_RDMA_MOUNTS -v /etc/libibverbs.d:/etc/libibverbs.d:ro"
 echo "[host-rdma] mounts: $_RDMA_MOUNTS"
 
+if [ "${RUN_PROFILE:-0}" = "1" ]; then
+    _CLOCK_DIR="$LOG_PATH/$SLURM_JOB_ID";
+    _CLOCK_FILE="$_CLOCK_DIR/clock_NODE${SLURM_PROCID}.jsonl";
+    mkdir -p "$_CLOCK_DIR";
+    if [ -e "$_CLOCK_FILE" ]; then
+        echo "[clock-sampler] ERROR: refusing to append to existing $_CLOCK_FILE" >&2;
+        exit 1;
+    fi
+    PYTHONDONTWRITEBYTECODE=1 python3 "$NIXL_REPO_DIR/moriio_profiling/trace_tools.py" \
+        clock-sampler --out "$_CLOCK_FILE" --node-rank "$SLURM_PROCID" --interval 1 &
+    _CLOCK_SAMPLER_PID=$!;
+    sleep 1;
+    if ! kill -0 "$_CLOCK_SAMPLER_PID" 2>/dev/null; then
+        wait "$_CLOCK_SAMPLER_PID" || true;
+        echo "[clock-sampler] ERROR: sampler failed to start on NODE${SLURM_PROCID}" >&2;
+        exit 1;
+    fi
+    echo "[clock-sampler] NODE${SLURM_PROCID} -> $_CLOCK_FILE";
+fi
+
 docker run --rm \
     --device /dev/dri \
     --device /dev/kfd \
@@ -572,6 +624,8 @@ docker run --rm \
     -e BENCHMARK_CON="${BENCHMARK_CON}" \
     -e BENCHMARK_COMBINATIONS="${BENCHMARK_COMBINATIONS}" \
     ${BENCHMARK_PORT:+-e BENCHMARK_PORT=$BENCHMARK_PORT} \
+    ${SKIP_WARMUP:+-e SKIP_WARMUP=$SKIP_WARMUP} \
+    ${BENCHMARK_NUM_PROMPTS:+-e BENCHMARK_NUM_PROMPTS=$BENCHMARK_NUM_PROMPTS} \
     ${PROXY_TYPE:+-e PROXY_TYPE=$PROXY_TYPE} \
     ${ROUTER_PORT:+-e ROUTER_PORT=$ROUTER_PORT} \
     -e IPADDRS=$IPADDRS \
@@ -613,6 +667,7 @@ docker run --rm \
     ${MORI_NUM_QP_PER_PE:+-e MORI_NUM_QP_PER_PE=$MORI_NUM_QP_PER_PE} \
     ${VLLM_MORIIO_QP_PER_TRANSFER:+-e VLLM_MORIIO_QP_PER_TRANSFER=$VLLM_MORIIO_QP_PER_TRANSFER} \
     ${VLLM_MORIIO_NUM_WORKERS:+-e VLLM_MORIIO_NUM_WORKERS=$VLLM_MORIIO_NUM_WORKERS} \
+    -e RUN_PROFILE=$RUN_PROFILE \
     -e GPU_MEMORY_UTILIZATION=${GPU_MEMORY_UTILIZATION:-0.8} \
     -e GPUS_PER_NODE=${GPUS_PER_NODE:-8} \
     ${GPU_MAX_HW_QUEUES:+-e GPU_MAX_HW_QUEUES=$GPU_MAX_HW_QUEUES} \
@@ -630,14 +685,25 @@ docker run --rm \
     -e DISTRIBUTED_TIMEOUT_SECONDS=${DISTRIBUTED_TIMEOUT_SECONDS:-7200} \
     -e VLLM_RPC_TIMEOUT=${VLLM_RPC_TIMEOUT:-300000} \
     -e VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-3600} \
-    ${CONNECTOR_ENV_ARGS} \
+    "${CONNECTOR_ENV_ARGS[@]}" \
     ${VLLM_CUDAGRAPH_MODE:+-e VLLM_CUDAGRAPH_MODE=$VLLM_CUDAGRAPH_MODE} \
     ${CUDAGRAPH_CAPTURE_SIZES:+-e CUDAGRAPH_CAPTURE_SIZES="$CUDAGRAPH_CAPTURE_SIZES"} \
     --name $DOCKER_CONT_NAME \
     $DOCKER_IMAGE_NAME -c "
         mkdir -p /run_logs/${SLURM_JOB_ID}
+        if [ "$RUN_PROFILE" = "1" ]; then set -o pipefail; fi
         $RUN_FILE_FULL 2>&1 | tee /run_logs/${SLURM_JOB_ID}/pd_vllm_bench_NODE${SLURM_PROCID}.log
     "
-'
+' bash "${CONNECTOR_ENV_ARGS[@]}" || _PROFILE_RUN_RC=$?
 srun --nodelist="$SELECTED_NODELIST_SRUN" bash -c 'docker stop $DOCKER_CONT_NAME 2>/dev/null || true; docker rm $DOCKER_CONT_NAME 2>/dev/null || true'
+
+# Profile post-processing combines traces and optionally extracts request mappings.
+# Propagate run/finalization failures first, then any post-processing failure.
+if [[ "$RUN_PROFILE" == "1" ]]; then
+    source "${SCRIPT_DIR}/moriio_profiling/process_kernels.sh"
+    _PROFILE_POSTHOC_RC=0
+    moriio_profiling_run_posthoc "$SLURM_JOB_ID" "$LOG_PATH" "$MASTER_NODE" "$NIXL_REPO_DIR" "$NIXL_COOKBOOK_PATH" "$DOCKER_IMAGE_NAME" \
+        || _PROFILE_POSTHOC_RC=$?
+    moriio_profiling_propagate_status "$_PROFILE_RUN_RC" "$_PROFILE_POSTHOC_RC" || exit $?
+fi
 

--- a/scripts/vllm_dissag/tests/argv_assert.sh
+++ b/scripts/vllm_dissag/tests/argv_assert.sh
@@ -53,7 +53,7 @@ echo "=== connector platform env files carry the RDMA-fix env ==="
 # sources connectors/<CONNECTOR>.env and forwards each var via docker -e.
 S="$(cat "$SLURM")"
 _has "$S" 'CONNECTOR_ENV_FILE="${SCRIPT_DIR}/connectors/${CONNECTOR}.env"' "slurm sources connector .env"
-_has "$S" '${CONNECTOR_ENV_ARGS}' "slurm forwards CONNECTOR_ENV_ARGS in docker run"
+_has "$S" '"${CONNECTOR_ENV_ARGS[@]}"' "slurm forwards CONNECTOR_ENV_ARGS in docker run"
 for cf in moriio rixl; do
   F="$DIR/connectors/${cf}.env"
   if [[ -f "$F" ]]; then

--- a/scripts/vllm_dissag/vllm_disagg.sh
+++ b/scripts/vllm_dissag/vllm_disagg.sh
@@ -47,8 +47,19 @@ if [[ -z "${CONNECTOR:-}" ]]; then
 fi
 WIDE_EP="${WIDE_EP:-0}"
 
+if [[ "${RUN_PROFILE:-0}" == "1" && "$CONNECTOR" != "moriio" ]]; then
+    echo "mori must be on for profiling" >&2
+    exit 1
+fi
+
 case "$CONNECTOR" in rixl|moriio) ;; *) echo "Error: invalid CONNECTOR='${CONNECTOR}' (expected rixl|moriio)." >&2; exit 1 ;; esac
 case "$WIDE_EP" in 0|1) ;; *) echo "Error: invalid WIDE_EP='${WIDE_EP}' (expected 0|1)." >&2; exit 1 ;; esac
+
+if [[ "${RUN_PROFILE:-0}" == "1" && "$CONNECTOR" == "moriio" ]]; then
+    _PROFILING_HOOKS="${SCRIPT_DIR}/moriio_profiling/hooks.sh"
+    [[ -f "$_PROFILING_HOOKS" ]] || { echo "Error: profiling hooks not found: ${_PROFILING_HOOKS}" >&2; exit 1; }
+    source "$_PROFILING_HOOKS"
+fi
 
 # EP backend defaults to the connector's partner; validate cross-pairings out.
 if [[ "$WIDE_EP" == "1" ]]; then
@@ -135,7 +146,14 @@ wait_for_proxy_and_cleanup() {
     echo "Waiting until proxy server closes..."
     python $NIXL_COOKBOOK_PATH/socket_wait.py --remote-ip ${MASTER_ADDR} --remote-port $PROXY_PORT
     echo "Killing the ${label} server"
-    pkill -P "$worker_pid" 2>/dev/null; kill "$worker_pid" 2>/dev/null || true
+    if [[ "${RUN_PROFILE:-0}" == "1" ]]; then
+        stop_worker "$worker_pid" || {
+            echo "[vllm_disagg] ERROR: profiling finalization failed for ${label}" >&2
+            exit 1
+        }
+    else
+        pkill -P "$worker_pid" 2>/dev/null; kill "$worker_pid" 2>/dev/null || true
+    fi
 }
 
 print_node_info() {
@@ -252,7 +270,14 @@ if [ "$NODE_RANK" -eq 0 ]; then
     echo "Killing the proxy server.."
     pkill -P $proxy_pid 2>/dev/null; kill $proxy_pid 2>/dev/null || true
     echo "Killing the prefill master server.."
-    pkill -P $local_worker_pid 2>/dev/null; kill $local_worker_pid 2>/dev/null || true
+    if [[ "${RUN_PROFILE:-0}" == "1" ]]; then
+        stop_worker "$local_worker_pid" || {
+            echo "[vllm_disagg] ERROR: profiling finalization failed for prefill master" >&2
+            exit 1
+        }
+    else
+        pkill -P "$local_worker_pid" 2>/dev/null; kill "$local_worker_pid" 2>/dev/null || true
+    fi
 
 elif [ "$NODE_RANK" -gt 0 ] && [ "$NODE_RANK" -lt "$xP" ]; then
     print_node_info "Prefill child node"


### PR DESCRIPTION
## Motivation

Add an opt-in profiling workflow for vLLM disaggregated serving using rocprofv3, ROCtx, and MoRIIO instrumentation while preserving the normal non-profiling workflow.

## Technical Details

- Added a dedicated ROCm 7.2.3 profiling Dockerfile with rocprofv3 and MoRIIO request-ID instrumentation.
- Added `benchmark_xPyD_profile.sh` for profiling-specific request IDs, timing manifests, warmup control, and bounded workloads.
- Added conditional kernel/marker capture and graceful worker finalization.
- Added composite request-ID correlation, combined traces, request statistics, and kernel categorization.
- Added true local-rank-0 selection and cross-node clock alignment for combined traces.
- Added validation for capture completeness, malformed durations, request identity, MoRI transfer attribution, and analysis failures.
- Profiling requires `RUN_PROFILE=1` with `CONNECTOR=moriio`; normal runs remain unchanged.

## Test Plan

- Build the dedicated profiling image using the `profiling` target.
- Run profiled 1P1D and 2P2D configurations across TP and EP models.
- Verify benchmark completion, capture finalization, request-ID consistency, ROCtx markers, MoRI attribution, combined traces, and kernel-analysis outputs.

## Test Result

All validation jobs below passed on their first submitted attempt:

- Llama 3.3 70B FP8-KV — 1P1D, TP8 (jobs 209995 and 210278)
- GPT-OSS 120B — 1P1D, TP8 (job 210279)
- DeepSeek-R1 — 1P1D, EP8 (job 210280)
- DeepSeek-V3 — 1P1D, EP8 (job 210281)
- DeepSeek-R1 — 2P2D, EP16/stage (job 210282)
- DeepSeek-V3 — 2P2D, EP16/stage (job 210283)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.