### PR TITLE
Sync develop into mad-rccl (2026-08-07)

### DIFF
--- a/benchmark/vllm/README.md
+++ b/benchmark/vllm/README.md
@@ -14,8 +14,8 @@ This Docker image packages vLLM with PyTorch for AMD Instinct™ MI300X, MI325X,
 accelerators. It includes:
 
 -   ✅ ROCm™ 7.2.3
--   ✅ vLLM 0.23.0
--   ✅ PyTorch 2.10.0 (2.10.0+git8514f05)
+-   ✅ vLLM 0.26.0
+-   ✅ PyTorch 2.11.0 (2.11.0+gitd0c8b1f3)
 -   ✅ hipBLASLt 1.0
 
 With this Docker image, users can quickly validate the expected inference performance numbers on the Instinct accelerators listed above. 
@@ -58,7 +58,7 @@ To override the benchmark configs, specify a certain benchmark to use, or add yo
 The following command pulls the Docker image from Docker Hub.
 
 ```sh
-docker pull vllm/vllm-openai-rocm:v0.23.0
+docker pull vllm/vllm-openai-rocm:v0.26.0
 ```
 
 ### MAD-integrated benchmarking
@@ -157,9 +157,9 @@ Users also can run the benchmark tool after they launch a Docker container. For 
 
 #### Docker launch
 ```sh
-docker pull vllm/vllm-openai-rocm:v0.23.0
+docker pull vllm/vllm-openai-rocm:v0.26.0
 
-docker run -it --device=/dev/kfd --device=/dev/dri --group-add video --shm-size 16G --security-opt seccomp=unconfined --security-opt apparmor=unconfined --cap-add=SYS_PTRACE -v $(pwd):/workspace --env VLLM_ROCM_USE_AITER=1 --env HUGGINGFACE_HUB_CACHE=/workspace --name test vllm/vllm-openai-rocm:v0.23.0
+docker run -it --device=/dev/kfd --device=/dev/dri --group-add video --shm-size 16G --security-opt seccomp=unconfined --security-opt apparmor=unconfined --cap-add=SYS_PTRACE -v $(pwd):/workspace --env VLLM_ROCM_USE_AITER=1 --env HUGGINGFACE_HUB_CACHE=/workspace --name test vllm/vllm-openai-rocm:v0.26.0
 ```
 
 >[!NOTE]
@@ -374,6 +374,9 @@ owners and are only mentioned for informative purposes.   
 ## Changelog
 ----------
 This release note summarizes notable changes since the previous docker release.
+
+v0.26.0
+- Minimax gfx942 fix
 
 v0.23.0 release:
 - Merge accuracy benchmark into serving benchmark

--- a/benchmark/xdit/README.md
+++ b/benchmark/xdit/README.md
@@ -41,7 +41,7 @@ latencies can be found from `results.csv` once the benchmark runs have finished.
 | pyt_xdit_flux_2_klein          | [Flux.2 Klein](https://huggingface.co/black-forest-labs/FLUX.2-klein-9B)              |
 | pyt_xdit_hunyuanvideo          | [HunyuanVideo](https://huggingface.co/tencent/HunyuanVideo)                           |
 | pyt_xdit_hunyuanvideo_1_5      | [HunyuanVideo 1.5](https://huggingface.co/tencent/HunyuanVideo-1.5)                   |
-| pyt_xdit_ltx_2                 | [LTX-2](https://huggingface.co/Lightricks/LTX-2)                                      |
+| pyt_xdit_ltx_2_3               | [LTX-2.3](https://huggingface.co/dg845/LTX-2.3-Diffusers)                             |
 | pyt_xdit_qwen_image            | [Qwen-Image](https://huggingface.co/Qwen/Qwen-Image-2512)                             |
 | pyt_xdit_qwen_image_edit       | [Qwen-Image-Edit](https://huggingface.co/Qwen/Qwen-Image-Edit)                        |
 | pyt_xdit_sd_3_5                | [Stable diffusion 3.5](https://huggingface.co/stabilityai/stable-diffusion-3.5-large) |

--- a/docker/pyt_xdit.ubuntu.amd.Dockerfile
+++ b/docker/pyt_xdit.ubuntu.amd.Dockerfile
@@ -24,7 +24,7 @@
 # SOFTWARE.
 #
 #################################################################################
-ARG BASE_DOCKER=rocm/pytorch-xdit:v26.6
+ARG BASE_DOCKER=rocm/pytorch-xdit:v26.7
 FROM ${BASE_DOCKER} AS base
 
 RUN apt-get update && apt install -y lshw && rm -rf /var/lib/apt/lists/*

--- a/models.json
+++ b/models.json
@@ -1739,7 +1739,7 @@
     "multiple_results": "results.csv"
   },
   {
-    "name": "pyt_xdit_ltx_2",
+    "name": "pyt_xdit_ltx_2_3",
     "dockerfile": "docker/pyt_xdit",
     "scripts": "scripts/pyt_xdit/run.sh",
     "n_gpus": "8",
@@ -1748,11 +1748,11 @@
     "tags": [
         "inference",
         "diffusion",
-        "t2v",
+        "t2av",
         "pyt",
         "xdit"
     ],
-    "args": "--workload ltx2",
+    "args": "--workload ltx2_3",
     "multiple_results": "results.csv"
   },
   {

--- a/scripts/vllm/configs/default.yaml
+++ b/scripts/vllm/configs/default.yaml
@@ -75,6 +75,7 @@
   extra_args:
     # GLM 5.2 has a context window of 1M tokens, which OOMs with bf16 KV cache
     --max-model-len: 101372
+    --kv-cache-dtype: fp8
   arch_overrides:
     # MI300 cannot fit FP8 TP4, override to TP8 only
     gfx942:
@@ -107,8 +108,7 @@
     VLLM_ROCM_USE_AITER: 1
   extra_args:
     --block-size: 128
-    --attention-backend: TRITON_ATTN
-    --moe-backend: aiter
+    --kv-cache-dtype: fp8
 
 ## gpt-oss w4a8 is gfx950 only
 - benchmark: serving

--- a/scripts/vllm/configs/default.yaml
+++ b/scripts/vllm/configs/default.yaml
@@ -113,6 +113,10 @@
     --block-size: 128
     --kv-cache-dtype: fp8
     --attention-backend: TRITON_ATTN
+  arch_overrides:
+    # No native MXFP8 MOE for MI300, can't fit 
+    gfx942:
+      tp: 8
 
 ## gpt-oss w4a8 is gfx950 only
 - benchmark: serving

--- a/scripts/vllm/configs/default.yaml
+++ b/scripts/vllm/configs/default.yaml
@@ -92,6 +92,7 @@
   max_concurrency: 1 8 32 128
   env:
     VLLM_ROCM_USE_AITER: 1
+    VLLM_USE_BREAKABLE_CUDAGRAPH: 0
   extra_args:
     --kv-cache-dtype: fp8
 
@@ -106,9 +107,12 @@
   max_concurrency: 1 8 32 128
   env:
     VLLM_ROCM_USE_AITER: 1
+    VLLM_USE_BREAKABLE_CUDAGRAPH: 0
+    VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT: 1
   extra_args:
     --block-size: 128
     --kv-cache-dtype: fp8
+    --attention-backend: TRITON_ATTN
 
 ## gpt-oss w4a8 is gfx950 only
 - benchmark: serving

--- a/scripts/vllm/configs/extended.yaml
+++ b/scripts/vllm/configs/extended.yaml
@@ -65,7 +65,7 @@
   model:
     MiniMaxAI/MiniMax-M2.7
     amd/MiniMax-M2.7-MXFP4
-  tp: 4 8
+  tp: 4
   inp: 1024
   out: 1024
   dtype: auto


### PR DESCRIPTION
Routine forward-merge of `develop` into `mad-rccl`. Merge commit only, no
functional changes authored here.

- Source: `develop` @ `34fbced` — 3 commits since merge base `f7e2560` (#198, #196, #195)
- Merge: clean, `models.json` auto-merged
- Checks: `models.json` parses, no deletions vs `mad-rccl`, RCCL multinode content untouched

This pull request updates several model and Docker configurations to incorporate newer versions and improve support for vLLM and XDiT workloads. The main changes include updating vLLM and PyTorch versions, switching to newer model variants, and adding configuration options for improved inference performance and compatibility.

**Updates to vLLM and PyTorch versions:**

- Updated the Docker image and documentation in `benchmark/vllm/README.md` to use vLLM 0.26.0 and PyTorch 2.11.0, replacing the previous v0.23.0 and PyTorch 2.10.0 versions. [[1]](diffhunk://#diff-16144d8589f3a5985c254b65e89cde356ad7ed92fe595432e674ebbbdac6e01fL17-R18) [[2]](diffhunk://#diff-16144d8589f3a5985c254b65e89cde356ad7ed92fe595432e674ebbbdac6e01fL61-R61) [[3]](diffhunk://#diff-16144d8589f3a5985c254b65e89cde356ad7ed92fe595432e674ebbbdac6e01fL160-R162)
- Added a release note for v0.26.0 highlighting a fix for Minimax gfx942.

**Model and configuration updates for XDiT:**

- Changed the supported LTX model from `LTX-2` to `LTX-2.3` in `benchmark/xdit/README.md`, `models.json`, and updated the relevant Hugging Face link. [[1]](diffhunk://#diff-d4bc4c29d1000ed5c839b6d61f809cba9058aea45b3d354dbe9dcb0a91e2a7ecL44-R44) [[2]](diffhunk://#diff-b546905e3eaa417cad3f64329ae02e69b2844d8551db177d092ef2d9a3a81276L1742-R1742)
- Updated model tags and workload arguments to reflect the new `LTX-2.3` model in `models.json`.

**Docker and config improvements:**

- Updated the XDiT Docker base image to `rocm/pytorch-xdit:v26.7` in `docker/pyt_xdit.ubuntu.amd.Dockerfile` for improved compatibility.
- Added new environment variables and arguments to `scripts/vllm/configs/default.yaml` to enable FP8 KV cache, disable breakable CUDA graphs, and shuffle KV cache layout for improved inference performance and stability. [[1]](diffhunk://#diff-8a6e2aa89be3779c861a52c10c7c90fa17273bb1872ed01fbbac270ecbda341aR78) [[2]](diffhunk://#diff-8a6e2aa89be3779c861a52c10c7c90fa17273bb1872ed01fbbac270ecbda341aR95) [[3]](diffhunk://#diff-8a6e2aa89be3779c861a52c10c7c90fa17273bb1872ed01fbbac270ecbda341aR110-L111)