### PR TITLE
sglang-disagg: fix queue-pair creation on Broadcom Thor2 (rdma-core 63.0), and make every overlay stage optional

### DIFF
--- a/.claude/skills/mad-slurm-multinode/assets/manifests/sglang_disagg_deepseek-r1.template.json
+++ b/.claude/skills/mad-slurm-multinode/assets/manifests/sglang_disagg_deepseek-r1.template.json
@@ -2,7 +2,7 @@
   "built_images": {
     "sglang-disagg-deepseek-r1-overlay": {
       "model": "sglang-disagg-deepseek-r1-overlay",
-      "docker_image": "<FILL_TAG  single full-overlay image tag, e.g. sglang-v0512post1-overlay:rccl-<sha>smifix-mori-<sha>-rixl-<sha>-mooncake<ver>-gfx942 (append -rdma62 when built with --build-arg ENABLE_RDMA62=1)>",
+      "docker_image": "<FILL_TAG  single full-overlay image tag, e.g. sglang-v0512post1-overlay:rccl-<sha>smifix-mori-<sha>-rixl-<sha>-mooncake<ver>-gfx<arch> (name the rdma-core in the tag too, e.g. -rdma63, since RDMA_CORE_VERSION defaults to 63.0)>",
       "dockerfile": "docker/sglang_disagg_inference_full_overlay.ubuntu.amd.Dockerfile",
       "base_docker": "lmsysorg/sglang:v0.5.12.post1-rocm720-mi30x",
       "build_duration": 0,
@@ -42,7 +42,7 @@
       "KV_TRANSFER_BACKEND": "nixl",
       "MORI_JIT_CACHE_DIR": "/tmp/mori_jit",
       "MORI_SHMEM_HEAP_SIZE": "17179869184",
-      "RDMA_CORE_CACHE": "<FILL_RDMA_CORE_CACHE  shared-FS rdma-core build cache; only used when the image was built with --build-arg ENABLE_RDMA62=1, e.g. /shared_inference/rdma-core-cache>",
+      "RDMA_CORE_CACHE": "<FILL_RDMA_CORE_CACHE  shared-FS rdma-core build cache; legacy, only for images that build rdma-core at job start, e.g. /shared_inference/rdma-core-cache>",
       "NCCL_DEBUG": "WARN",
       "NCCL_DEBUG_SUBSYS": "INIT,NET",
       "NCCL_IB_DISABLE": "0",
@@ -124,7 +124,7 @@
       "KV_TRANSFER_BACKEND": "nixl",
       "MORI_JIT_CACHE_DIR": "/tmp/mori_jit",
       "MORI_SHMEM_HEAP_SIZE": "17179869184",
-      "RDMA_CORE_CACHE": "<FILL_RDMA_CORE_CACHE  same as context.docker_env_vars; only used when built with --build-arg ENABLE_RDMA62=1>",
+      "RDMA_CORE_CACHE": "<FILL_RDMA_CORE_CACHE  same as context.docker_env_vars; legacy, only for images that build rdma-core at job start>",
       "NCCL_DEBUG": "WARN",
       "NCCL_IB_DISABLE": "0",
       "NCCL_IB_HCA": "<FILL_NCCL_IB_HCA  same value as context.docker_env_vars>",

--- a/.claude/skills/mad-slurm-multinode/references/gotchas.md
+++ b/.claude/skills/mad-slurm-multinode/references/gotchas.md
@@ -94,8 +94,8 @@ Keywords: launcher sglang-disagg run.sh xP yD RUN_MORI DP_MODE KV_TRANSFER_BACKE
 nixl mooncake, detokenizer hang health check No response from detokenizer,
 MoRI overlay #366 inter-node decode freeze, RCCL overlay rsmi_init libtorch_hip
 undefined symbol torch broken, rocm720 base librocm_smi64, patchelf add-needed
-DT_NEEDED smifix, single full-overlay Dockerfile no base chaining, ENABLE_RDMA62
-rdma-core v62 optional stage, mooncake baked launcher build-layer removed runtime pip,
+DT_NEEDED smifix, single full-overlay Dockerfile no base chaining, RDMA_CORE_VERSION
+rdma-core 63.0 bnxt_re Thor2 stage, mooncake baked launcher build-layer removed runtime pip,
 self-discover node IPs rendezvous IP_SYNC_TIMEOUT SGLANG_NODE_IPS not forwarded,
 per-node docker load shared tar, perf CSV rank0 BENCHMARK_FAIL_FAST, circuit
 breaker prefill workers Service Unavailable BENCHMARK_POINT_RETRIES transient
@@ -141,12 +141,11 @@ sweep retry.
   mutated the container runtime env and silently corrupted the Python libs (the
   model flags then stopped parsing and the server came up with defaults). Those pip
   deps and the Mooncake KV backend are now baked into the full-overlay Dockerfile;
-  rdma-core v62 is an optional stage in the SAME Dockerfile, gated by
-  `--build-arg ENABLE_RDMA62=1` (for hosts whose RDMA stack needs a newer
-  libibverbs/librdmacm/libmlx5 than the base ships — no host `libibverbs`
-  bind-mounts needed; unset/default skips the stage entirely, mirroring
-  `docker/primus_megatron_train_rccl_overlay...Dockerfile`'s `RDMA_CORE_VERSION`
-  gate). There is no separate rdma-core-variant Dockerfile anymore — it was a
+  rdma-core is a stage in the SAME Dockerfile, controlled by
+  `--build-arg RDMA_CORE_VERSION` (default `63.0`, built from source — it is what
+  makes queue-pair creation work on Broadcom Thor2 `bnxt_re`; no host `libibverbs`
+  bind-mounts needed). Pass an empty `RDMA_CORE_VERSION=` to keep the base image's
+  rdma-core and skip the stage. There is no separate rdma-core-variant Dockerfile anymore — it was a
   ~92%-identical copy of the base overlay and was merged in to cut duplication.
   Do not reintroduce a runtime build-layer in the launcher.
 

--- a/.claude/skills/mad-slurm-multinode/references/manifests.md
+++ b/.claude/skills/mad-slurm-multinode/references/manifests.md
@@ -135,10 +135,11 @@ differ, the host path belongs on the value side.
   is a single full-overlay build
   (`docker/sglang_disagg_inference_full_overlay.ubuntu.amd.Dockerfile`): base
   SGLang + RCCL + MoRI + NIXL/Mooncake KV-transfer + Mooncake pip in one
-  Dockerfile (no base-image chaining). For hosts whose RDMA stack needs a
-  newer rdma-core than the base ships, build the same Dockerfile with
-  `--build-arg ENABLE_RDMA62=1` (bakes rdma-core v62 in, so no host `libibverbs`
-  bind-mounts are needed; unset/default skips that stage). The full overlay
+  Dockerfile (no base-image chaining). That build bakes in rdma-core
+  `RDMA_CORE_VERSION` (default `63.0`), which is what makes queue-pair creation
+  work on Broadcom Thor2 `bnxt_re` and removes the need for host `libibverbs`
+  bind-mounts; pass an empty `--build-arg RDMA_CORE_VERSION=` to keep the base
+  image's instead. The full overlay
   re-adds the `rocm_smi` `DT_NEEDED`
   (`patchelf --add-needed librocm_smi64.so.<N>`) so a newer RCCL on the rocm720
   base does not break `import torch` (see [gotchas.md](gotchas.md#sglang_disagg)).

--- a/docker/sglang_disagg_inference_full_overlay.ubuntu.amd.Dockerfile
+++ b/docker/sglang_disagg_inference_full_overlay.ubuntu.amd.Dockerfile
@@ -12,14 +12,20 @@
 # sgl-kernel, MoRI, RIXL and Mooncake built for the right GPU target, so every
 # component stage below defaults to OFF and the image is the base plus rdma-core.
 # Each stage is a substitution knob: turn one on to A/B that component against
-# what the base ships. Pick the base tag whose suffix matches the GPUs
-# (`-mi35x` = gfx950/MI35x, `-mi30x` = gfx942/MI30x) and set BUILD_GPU_TARGETS
-# and MORI_GPU_ARCHS to match.
+# what the base ships.
+#
+# The target GPU is chosen in exactly two places: BASE_DOCKER, whose tag suffix
+# names the GPUs (`-mi35x` = gfx950/MI35x, `-mi30x` = gfx942/MI30x), and
+# BUILD_GPU_TARGETS, which every stage that compiles device code derives from
+# (MORI_GPU_ARCHS defaults to it). Set those two consistently and nothing else
+# needs touching.
 #
 # Stages, all gated by build args (override via --build-arg):
 #   rdma-core : RDMA_CORE_VERSION (default 63.0, the only stage ON by default)
 #               — see the stage comment; this is what makes queue-pair creation
-#               work on Broadcom Thor2 (bnxt_re).
+#               work on Broadcom Thor2 (bnxt_re). Pass an empty value
+#               (RDMA_CORE_VERSION=) to keep the base image's rdma-core: the fix
+#               is opt-out, not mandatory.
 #   RCCL      : ENABLE_RCCL_OVERLAY=1 → ROCm/rocm-systems develop @ RCCL_COMMIT
 #               (default 78e8ba0) + smifix
 #   MoRI      : ENABLE_MORI_OVERLAY=1 → ROCm/mori @ MORI_COMMIT
@@ -36,8 +42,9 @@
 #
 # To reproduce the pre-sgl-dev behaviour (build everything on a plain sglang
 # base), pass BASE_DOCKER=lmsysorg/sglang:v0.5.12.post1-rocm720-mi30x
-# BUILD_GPU_TARGETS=gfx942 MORI_GPU_ARCHS=gfx942 and set the four ENABLE_* args
-# to 1.
+# BUILD_GPU_TARGETS=gfx942, set the four ENABLE_* args to 1, and pass an empty
+# RDMA_CORE_VERSION= — without that last one the old recipe still replaces the
+# base image's rdma-core, which the old file never did.
 ###############################################################################
 ARG BASE_DOCKER=rocm/sgl-dev:v0.5.16-rocm720-mi35x-20260807
 FROM $BASE_DOCKER
@@ -48,7 +55,7 @@ USER root
 ###############################################################################
 # 1) RCCL overlay — rebuild RCCL from source so the RCCL under test wins over
 #    the base image's librccl. (mirrors sglang_disagg_inference_rccl_overlay)
-#    OFF by default: the sgl-dev base already carries an librccl with the right
+#    OFF by default: the sgl-dev base already carries a librccl with the right
 #    code objects, and keeping it makes the base the control arm of the A/B.
 ###############################################################################
 ARG ENABLE_RCCL_OVERLAY=0
@@ -151,7 +158,9 @@ ARG MORI_REPO=https://github.com/ROCm/mori.git
 ARG MORI_BRANCH=main
 ARG MORI_COMMIT=a14e6992ffa95478e83127fe2672afff2840856f
 ARG MORI_WHEEL_URL=
-ARG MORI_GPU_ARCHS=gfx950
+# Derived, so the GPU target is set once via BUILD_GPU_TARGETS. Override only to
+# build MoRI for a different arch than the rest of the image.
+ARG MORI_GPU_ARCHS=${BUILD_GPU_TARGETS}
 ARG MORI_VERSION=1.2.0
 ARG MORI_SRC_DIR=/sgl-workspace/mori
 
@@ -179,6 +188,7 @@ RUN set -e; \
       pip install --no-cache-dir --force-reinstall "${MORI_WHEEL_URL}"; \
     else \
       echo "[mori-overlay] source build ${MORI_REPO}@${MORI_BRANCH}${MORI_COMMIT:+ (${MORI_COMMIT})} archs=${MORI_GPU_ARCHS}"; \
+      sed -i 's|http://|https://|g' /etc/apt/sources.list 2>/dev/null || true; \
       apt-get -o Acquire::Retries=5 update; \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         git cmake ninja-build pkg-config make patch; \
@@ -338,6 +348,7 @@ ARG MOONCAKE_HIP_DMABUF=ON
 
 RUN if [[ "${ENABLE_MOONCAKE_OVERLAY}" == "1" ]]; then \
       set -e; \
+      sed -i 's|http://|https://|g' /etc/apt/sources.list 2>/dev/null || true; \
       apt-get -o Acquire::Retries=5 update; \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         git cmake ninja-build build-essential pkg-config patchelf; \
@@ -377,43 +388,18 @@ RUN ( set +e +o pipefail; \
       echo "MOONCAKE_CROSS_HOST_GUARD ${pkg:+$(grep -rls MC_DISABLE_HIP "$pkg" | tr '\n' ' ')}" )
 
 ###############################################################################
-# 5) rdma-core from source — the Broadcom Thor2 (bnxt_re) queue-pair fix.
-#
-# The bnxt_re provider shipped with rdma-core 39.0/50.0 corrupts the verbs
-# command buffer for work issued off worker threads, so the kernel rejects
-# ibv_create_qp with EFAULT (errno 14) and the KV-transfer backends lose their
-# queue pairs. Every backend hits it, each in its own way: mooncake logged 2604
-# creation failures over a 2P2D run, NIXL could not start at all because UCX
-# treats one failed interface QP as fatal, and MoRI built queue pairs that
-# reached RTS and then moved zero bytes.
-#
-# Measured on one node, one container, same kernel, 8 threads x 64 queue pairs,
-# only the userspace changing: 39.0 creates 33-66 of 512, and 63.0 creates 512
-# of 512. With 63.0 all three backends run a full 2P2D DeepSeek-R1 sweep with
-# zero queue-pair failures.
-#
-# ON by default (empty string keeps the base image's rdma-core), because the
-# defect is silent: nothing in the logs points at the provider, and each backend
-# fails differently enough to look like three unrelated bugs.
-#
-# Two things happen beyond the plain build. The distro packages are removed, so
-# exactly one libibverbs is left on disk instead of two of different vintages.
-# And the vendor bnxt_re provider that /etc/ld.so.conf.d puts on the loader path
-# is dropped: it advertises kernel uABI 7-8, and a host running the upstream
-# driver (uABI 1) has every device rejected with "Driver bnxt_re does not
-# support the kernel ABI of 1", after which RCCL finds no IB plugin at all.
-#
-# ORDERING IS LOAD-BEARING: the source rdma-core is installed by REPLACING the
-# distro libibverbs/librdmacm packages via `dpkg -r --force-all`, which leaves
-# still-installed dependents (libucx0, openmpi, ...) with dangling deps, so any
-# later apt command aborts with "Unmet dependencies". Every apt operation must
-# run before the dpkg removal; only dpkg and `ninja install` may follow it. This
-# is also why the stage is last.
+# 5) rdma-core RDMA_CORE_VERSION (default 63.0) from source, replacing the
+#    distro packages and dropping the vendor bnxt_re provider. Fixes
+#    ibv_create_qp EFAULT on Broadcom Thor2 (bnxt_re); pass an empty value to
+#    keep the base image's rdma-core. Keep this stage last and run every apt
+#    command before the `dpkg -r --force-all` below: the removal leaves
+#    dependents (libucx0, openmpi) with dangling deps and later apt aborts.
 ###############################################################################
 ARG RDMA_CORE_VERSION=63.0
 
 RUN if [[ -n "${RDMA_CORE_VERSION}" ]]; then \
       set -e; \
+      sed -i 's|http://|https://|g' /etc/apt/sources.list 2>/dev/null || true; \
       apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 update; \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         git ca-certificates cmake ninja-build build-essential pkg-config make \

--- a/docker/sglang_disagg_inference_full_overlay.ubuntu.amd.Dockerfile
+++ b/docker/sglang_disagg_inference_full_overlay.ubuntu.amd.Dockerfile
@@ -1,28 +1,45 @@
 # CONTEXT {'gpu_vendor': 'AMD', 'guest_os': 'UBUNTU'}
 ###############################################################################
-# SGLang Disaggregated P/D — MERGED full overlay (RCCL + MoRI + KV-transfer)
+# SGLang Disaggregated P/D — full overlay (rdma-core + RCCL + MoRI + KV-transfer)
 #
-# Single-Dockerfile equivalent of the three chained overlays:
+# Single-Dockerfile equivalent of the chained overlays:
 #   base sglang -> RCCL overlay (+smifix) -> MoRI overlay -> KV-transfer (RIXL)
+#   -> Mooncake -> rdma-core
 # Built in one `docker build` step so madengine's single-dockerfile build path
 # produces the whole stack at once (no base_docker chaining between overlays).
 #
-# Pins (override via --build-arg):
-#   RCCL  : ROCm/rocm-systems develop @ RCCL_COMMIT (default 78e8ba0) + smifix
-#   MoRI  : ROCm/mori @ MORI_COMMIT (default a14e6992, includes #366)
-#   NIXL  : ROCm/RIXL @ RIXL_COMMIT (default f33a5599) + ROCm/ucx @ UCX_COMMIT
-#           (the AMD NIXL implementation; exposed to SGLang as `nixl` via alias).
-#           NOTE: this is NOT ai-dynamo/nixl. The rocm KV transport for
-#           KV_TRANSFER_BACKEND=nixl is ROCm/RIXL; recipe mirrors the proven
-#           scripts/kvcache_transfer_bench/Dockerfile.
+# The default base is a rocm/sgl-dev tag that ALREADY carries sglang, aiter,
+# sgl-kernel, MoRI, RIXL and Mooncake built for the right GPU target, so every
+# component stage below defaults to OFF and the image is the base plus rdma-core.
+# Each stage is a substitution knob: turn one on to A/B that component against
+# what the base ships. Pick the base tag whose suffix matches the GPUs
+# (`-mi35x` = gfx950/MI35x, `-mi30x` = gfx942/MI30x) and set BUILD_GPU_TARGETS
+# and MORI_GPU_ARCHS to match.
 #
-# Hosts whose RDMA stack needs a newer rdma-core than the base image ships:
-# pass --build-arg ENABLE_RDMA62=1 to additionally build + install rdma-core
-# v62 from source (newer libibverbs/librdmacm/libmlx5; no host libibverbs
-# bind-mounts needed). Default (unset) keeps the image-default rdma-core and
-# skips that stage entirely.
+# Stages, all gated by build args (override via --build-arg):
+#   rdma-core : RDMA_CORE_VERSION (default 63.0, the only stage ON by default)
+#               — see the stage comment; this is what makes queue-pair creation
+#               work on Broadcom Thor2 (bnxt_re).
+#   RCCL      : ENABLE_RCCL_OVERLAY=1 → ROCm/rocm-systems develop @ RCCL_COMMIT
+#               (default 78e8ba0) + smifix
+#   MoRI      : ENABLE_MORI_OVERLAY=1 → ROCm/mori @ MORI_COMMIT
+#               (default a14e6992, includes #366)
+#   NIXL      : ENABLE_NIXL_OVERLAY=1 → ROCm/RIXL @ RIXL_COMMIT (default
+#               f33a5599) + ROCm/ucx @ UCX_COMMIT (the AMD NIXL implementation;
+#               exposed to SGLang as `nixl` via alias).
+#               NOTE: this is NOT ai-dynamo/nixl. The rocm KV transport for
+#               KV_TRANSFER_BACKEND=nixl is ROCm/RIXL; recipe mirrors the proven
+#               scripts/kvcache_transfer_bench/Dockerfile.
+#   Mooncake  : ENABLE_MOONCAKE_OVERLAY=1 → kvcache-ai/Mooncake @ MOONCAKE_REF
+#               (default v0.3.12.post1, the first release with the cross-host
+#               guard)
+#
+# To reproduce the pre-sgl-dev behaviour (build everything on a plain sglang
+# base), pass BASE_DOCKER=lmsysorg/sglang:v0.5.12.post1-rocm720-mi30x
+# BUILD_GPU_TARGETS=gfx942 MORI_GPU_ARCHS=gfx942 and set the four ENABLE_* args
+# to 1.
 ###############################################################################
-ARG BASE_DOCKER=lmsysorg/sglang:v0.5.12.post1-rocm720-mi30x
+ARG BASE_DOCKER=rocm/sgl-dev:v0.5.16-rocm720-mi35x-20260807
 FROM $BASE_DOCKER
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -31,82 +48,110 @@ USER root
 ###############################################################################
 # 1) RCCL overlay — rebuild RCCL from source so the RCCL under test wins over
 #    the base image's librccl. (mirrors sglang_disagg_inference_rccl_overlay)
+#    OFF by default: the sgl-dev base already carries an librccl with the right
+#    code objects, and keeping it makes the base the control arm of the A/B.
 ###############################################################################
+ARG ENABLE_RCCL_OVERLAY=0
 ARG RCCL_REPO=https://github.com/ROCm/rocm-systems.git
 ARG RCCL_BRANCH=develop
 ARG RCCL_COMMIT=78e8ba0
 ARG RCCL_INSTALL_DIR=/opt/rccl
-ARG BUILD_GPU_TARGETS=gfx942
+ARG BUILD_GPU_TARGETS=gfx950
 
 ENV RCCL_HOME=${RCCL_INSTALL_DIR}
-# Prepend the overlay RCCL so it wins over the base image's librccl.
+# Prepend the overlay RCCL so it wins over the base image's librccl. Harmless
+# when ENABLE_RCCL_OVERLAY=0: the directory is then empty and the base librccl
+# resolves as usual.
 ENV LD_LIBRARY_PATH=${RCCL_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
 
 RUN mkdir -p "${RCCL_INSTALL_DIR}"
 WORKDIR /opt
 
-RUN sed -i 's|http://|https://|g' /etc/apt/sources.list 2>/dev/null || true && \
-    apt-get -o Acquire::Retries=5 update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      git cmake ninja-build pkg-config make patch && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN if [[ -n "${RCCL_COMMIT}" ]]; then \
-      git clone "${RCCL_REPO}" /tmp/rccl; \
+RUN if [[ "${ENABLE_RCCL_OVERLAY}" == "1" ]]; then \
+      set -e; \
+      sed -i 's|http://|https://|g' /etc/apt/sources.list 2>/dev/null || true; \
+      apt-get -o Acquire::Retries=5 update; \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git cmake ninja-build pkg-config make patch; \
+      rm -rf /var/lib/apt/lists/*; \
     else \
-      git clone --depth 1 --branch "${RCCL_BRANCH}" "${RCCL_REPO}" /tmp/rccl; \
-    fi && \
-    cd /tmp/rccl && \
-    if [[ -n "${RCCL_BRANCH}" ]]; then git checkout "${RCCL_BRANCH}" || true; fi && \
-    if [[ -n "${RCCL_COMMIT}" ]]; then git checkout "${RCCL_COMMIT}"; fi && \
-    if [[ -d projects/rccl ]]; then \
-      cd projects/rccl && git submodule update --init --recursive; \
-      echo "/tmp/rccl/projects/rccl" > /tmp/BLD_RCCL_HOME.txt; \
-    else \
-      git submodule update --init --recursive; \
-      echo "/tmp/rccl" > /tmp/BLD_RCCL_HOME.txt; \
+      echo "[full-overlay] RCCL overlay disabled — skipping build deps"; \
     fi
 
-RUN set -e && \
-    BLD_RCCL_HOME=$(cat /tmp/BLD_RCCL_HOME.txt) && \
-    cd "${BLD_RCCL_HOME}" && \
-    ./install.sh --amdgpu_targets="${BUILD_GPU_TARGETS}" --prefix="${RCCL_INSTALL_DIR}"
-
-RUN rm -rf /tmp/rccl /tmp/BLD_RCCL_HOME.txt
+RUN if [[ "${ENABLE_RCCL_OVERLAY}" == "1" ]]; then \
+      set -e; \
+      if [[ -n "${RCCL_COMMIT}" ]]; then \
+        git clone "${RCCL_REPO}" /tmp/rccl; \
+      else \
+        git clone --depth 1 --branch "${RCCL_BRANCH}" "${RCCL_REPO}" /tmp/rccl; \
+      fi; \
+      cd /tmp/rccl; \
+      if [[ -n "${RCCL_BRANCH}" ]]; then git checkout "${RCCL_BRANCH}" || true; fi; \
+      if [[ -n "${RCCL_COMMIT}" ]]; then git checkout "${RCCL_COMMIT}"; fi; \
+      if [[ -d projects/rccl ]]; then \
+        cd projects/rccl && git submodule update --init --recursive; \
+        echo "/tmp/rccl/projects/rccl" > /tmp/BLD_RCCL_HOME.txt; \
+      else \
+        git submodule update --init --recursive; \
+        echo "/tmp/rccl" > /tmp/BLD_RCCL_HOME.txt; \
+      fi; \
+      BLD_RCCL_HOME=$(cat /tmp/BLD_RCCL_HOME.txt); \
+      cd "${BLD_RCCL_HOME}"; \
+      ./install.sh --amdgpu_targets="${BUILD_GPU_TARGETS}" --prefix="${RCCL_INSTALL_DIR}"; \
+      rm -rf /tmp/rccl /tmp/BLD_RCCL_HOME.txt; \
+    else \
+      echo "[full-overlay] RCCL overlay disabled — keeping the base image librccl"; \
+    fi
 
 # Re-add the rocm_smi dependency the rocm-systems RCCL build drops (smifix).
 # Newer rocm-systems RCCL builds librccl WITHOUT a DT_NEEDED on librocm_smi64.so;
 # torch's libtorch_hip.so relies on librccl to transitively pull in rocm_smi, so
 # without this `import torch` dies with "undefined symbol: rsmi_init".
-RUN set -e; \
-    command -v patchelf >/dev/null 2>&1 || pip install --no-cache-dir patchelf >/dev/null 2>&1 \
-      || { apt-get -o Acquire::Retries=5 update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends patchelf && rm -rf /var/lib/apt/lists/*; }; \
-    librccl="$(readlink -f ${RCCL_INSTALL_DIR}/lib/librccl.so)"; \
-    smi_soname="$(basename "$(ls /opt/rocm*/lib/librocm_smi64.so.[0-9]* 2>/dev/null | grep -E 'librocm_smi64\.so\.[0-9]+$' | head -1)")"; \
-    test -n "${smi_soname}" || { echo "ROCM_SMI_SONAME_NOT_FOUND"; exit 1; }; \
-    if readelf -d "${librccl}" 2>/dev/null | grep -q "NEEDED.*${smi_soname}"; then \
-      echo "RCCL_SMI_NEEDED_ALREADY_PRESENT ${smi_soname}"; \
-    else \
-      patchelf --add-needed "${smi_soname}" "${librccl}" && echo "RCCL_SMI_NEEDED_ADDED ${smi_soname} -> ${librccl}"; \
+RUN if [[ "${ENABLE_RCCL_OVERLAY}" == "1" ]]; then \
+      set -e; \
+      command -v patchelf >/dev/null 2>&1 || pip install --no-cache-dir patchelf >/dev/null 2>&1 \
+        || { apt-get -o Acquire::Retries=5 update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends patchelf && rm -rf /var/lib/apt/lists/*; }; \
+      librccl="$(readlink -f ${RCCL_INSTALL_DIR}/lib/librccl.so)"; \
+      smi_soname="$(basename "$(ls /opt/rocm*/lib/librocm_smi64.so.[0-9]* 2>/dev/null | grep -E 'librocm_smi64\.so\.[0-9]+$' | awk 'NR==1')")"; \
+      test -n "${smi_soname}" || { echo "ROCM_SMI_SONAME_NOT_FOUND"; exit 1; }; \
+      if readelf -d "${librccl}" 2>/dev/null | grep -q "NEEDED.*${smi_soname}"; then \
+        echo "RCCL_SMI_NEEDED_ALREADY_PRESENT ${smi_soname}"; \
+      else \
+        patchelf --add-needed "${smi_soname}" "${librccl}" && echo "RCCL_SMI_NEEDED_ADDED ${smi_soname} -> ${librccl}"; \
+      fi; \
     fi
 
-# Sanity: overlay librccl present AND torch imports with overlay librccl first.
+# Sanity: report which librccl the loader resolves and which GPU targets it
+# carries, then confirm torch still imports with that librccl first (the exact
+# case the smifix regressed). The reporting runs in a subshell with pipefail off
+# and can never fail the build: a pipeline whose reader exits early (`awk ...
+# exit`, `head -1`) sends SIGPIPE to the writer, which pipefail+`set -e` would
+# turn into a lost build.
 RUN set -e; \
-    test -e "${RCCL_INSTALL_DIR}/lib/librccl.so" || { echo "RCCL_OVERLAY_MISSING"; exit 1; }; \
-    echo "RCCL_OVERLAY_OK $(ls -l ${RCCL_INSTALL_DIR}/lib/librccl.so*)"; \
+    if [[ "${ENABLE_RCCL_OVERLAY}" == "1" ]]; then \
+      test -e "${RCCL_INSTALL_DIR}/lib/librccl.so" || { echo "RCCL_OVERLAY_MISSING"; exit 1; }; \
+      echo "RCCL_OVERLAY_OK $(ls -l ${RCCL_INSTALL_DIR}/lib/librccl.so*)"; \
+    fi; \
+    ( set +e +o pipefail; \
+      resolved="$(ldconfig -p | awk '/librccl\.so\.1/ && !seen++ {print $NF}')"; \
+      echo "RCCL_RESOLVED ${resolved:-<none in ldconfig; LD_LIBRARY_PATH decides>}"; \
+      for so in "${RCCL_INSTALL_DIR}/lib/librccl.so" /opt/rocm*/lib/librccl.so; do \
+        [[ -e "$so" ]] || continue; \
+        echo "RCCL_TARGETS $so : $(strings -a "$(readlink -f "$so")" | grep -oE 'gfx9[0-9]+' | sort -u | paste -sd, -)"; \
+      done ); \
     python3 -c "import torch; print('RCCL_OVERLAY_TORCH_OK', torch.__version__)"
-
-RUN pip list 2>/dev/null | grep -iE "sglang|torch" || true
 
 ###############################################################################
 # 2) MoRI overlay — substitutable MoE EP all-to-all (dispatch/combine, IBGDA).
 #    Default ROCm/mori @ a14e6992 includes #366 (internode decode hang fix).
+#    OFF by default: the sgl-dev base already ships MoRI for the right arch.
 ###############################################################################
+ARG ENABLE_MORI_OVERLAY=0
 ARG MORI_REPO=https://github.com/ROCm/mori.git
 ARG MORI_BRANCH=main
 ARG MORI_COMMIT=a14e6992ffa95478e83127fe2672afff2840856f
 ARG MORI_WHEEL_URL=
-ARG MORI_GPU_ARCHS=gfx942
+ARG MORI_GPU_ARCHS=gfx950
 ARG MORI_VERSION=1.2.0
 ARG MORI_SRC_DIR=/sgl-workspace/mori
 
@@ -117,8 +162,8 @@ ENV MORI_GPU_ARCHS=${MORI_GPU_ARCHS} \
 
 WORKDIR /sgl-workspace
 
-# git, cmake, ninja-build, pkg-config, make and patch are already installed by
-# the RCCL overlay stage above; re-running apt-get here only adds a layer.
+# The build deps are installed here rather than inherited from the RCCL stage,
+# because that stage is now optional and this one has to stand on its own.
 #
 # The source build pins cmake<4.0 and disables pip's build isolation: an
 # isolated build env resolves the newest cmake from PyPI, and cmake >= 4.0
@@ -127,11 +172,17 @@ WORKDIR /sgl-workspace
 # across all test targets. Keeping the pin also makes the build reproducible
 # regardless of what PyPI currently resolves cmake to.
 RUN set -e; \
-    if [[ -n "${MORI_WHEEL_URL}" ]]; then \
+    if [[ "${ENABLE_MORI_OVERLAY}" != "1" ]]; then \
+      echo "[full-overlay] MoRI overlay disabled — keeping the image's MoRI"; \
+    elif [[ -n "${MORI_WHEEL_URL}" ]]; then \
       echo "[mori-overlay] installing prebuilt wheel: ${MORI_WHEEL_URL}"; \
       pip install --no-cache-dir --force-reinstall "${MORI_WHEEL_URL}"; \
     else \
       echo "[mori-overlay] source build ${MORI_REPO}@${MORI_BRANCH}${MORI_COMMIT:+ (${MORI_COMMIT})} archs=${MORI_GPU_ARCHS}"; \
+      apt-get -o Acquire::Retries=5 update; \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git cmake ninja-build pkg-config make patch; \
+      rm -rf /var/lib/apt/lists/*; \
       rm -rf "${MORI_SRC_DIR}"; \
       if [[ -n "${MORI_COMMIT}" ]]; then \
         git clone "${MORI_REPO}" "${MORI_SRC_DIR}"; \
@@ -144,16 +195,19 @@ RUN set -e; \
       pip install --no-build-isolation --no-cache-dir --force-reinstall .; \
     fi
 
-# Sanity: MoRI must import and report the overlay version.
+# Sanity: MoRI must import and report the version in place, whether it came from
+# the overlay or from the base image.
 RUN python3 -c "import mori, importlib.metadata as m; \
-print('MORI_OVERLAY_OK', getattr(mori,'__version__', m.version('amd_mori')))" \
-    || { echo 'MORI_OVERLAY_IMPORT_FAILED'; exit 1; }
+print('MORI_OK', getattr(mori,'__version__', m.version('amd_mori')))" \
+    || { echo 'MORI_IMPORT_FAILED'; exit 1; }
 
 ###############################################################################
 # 3) KV-transfer overlay — ROCm UCX + ROCm/RIXL (the AMD "nixl" KV transport).
 #    Mirrors the proven recipe in scripts/kvcache_transfer_bench/Dockerfile.
 #    SGLang's KV_TRANSFER_BACKEND=nixl imports `nixl`; we alias rixl -> nixl.
+#    OFF by default: the sgl-dev base already ships a working nixl.
 ###############################################################################
+ARG ENABLE_NIXL_OVERLAY=0
 ARG ROCM_PATH=/opt/rocm
 ARG KV_WORKSPACE=/sgl-workspace
 ARG UCX_REPO=https://github.com/ROCm/ucx.git
@@ -168,61 +222,81 @@ ENV LD_LIBRARY_PATH=${RIXL_HOME}/lib/x86_64-linux-gnu:${UCX_HOME}/lib:${LD_LIBRA
 
 WORKDIR ${KV_WORKSPACE}
 
-RUN sed -i 's|http://|https://|g' /etc/apt/sources.list 2>/dev/null || true && \
-    apt-get -o Acquire::Retries=5 update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      git cmake ninja-build pkg-config make patch autoconf automake libtool \
-      cython3 libaio-dev libibverbs-dev librdmacm-dev libpci-dev \
-      libgflags-dev libgoogle-glog-dev && \
-    rm -rf /var/lib/apt/lists/*
-
-# meson/ninja/pybind11 build frontends for the RIXL meson build + wheel.
-RUN pip install --no-cache-dir -U meson ninja pybind11 pyyaml build wheel
+RUN if [[ "${ENABLE_NIXL_OVERLAY}" == "1" ]]; then \
+      set -e; \
+      sed -i 's|http://|https://|g' /etc/apt/sources.list 2>/dev/null || true; \
+      apt-get -o Acquire::Retries=5 update; \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git cmake ninja-build pkg-config make patch autoconf automake libtool \
+        cython3 libaio-dev libibverbs-dev librdmacm-dev libpci-dev \
+        libgflags-dev libgoogle-glog-dev; \
+      rm -rf /var/lib/apt/lists/*; \
+      pip install --no-cache-dir -U meson ninja pybind11 pyyaml build wheel; \
+    else \
+      echo "[full-overlay] NIXL overlay disabled — skipping build deps"; \
+    fi
 
 # --- ROCm UCX ---------------------------------------------------------------
-RUN set -e; \
-    git clone "${UCX_REPO}" "${UCX_HOME}.src" && cd "${UCX_HOME}.src" && \
-    git checkout "${UCX_COMMIT}" && \
-    ./autogen.sh && mkdir -p build && cd build && \
-    ../configure --prefix="${UCX_HOME}" --enable-shared --disable-static \
-        --disable-doxygen-doc --enable-optimizations --enable-devel-headers \
-        --with-rocm="${ROCM_PATH}" --with-verbs --with-dm --enable-mt && \
-    make -j"$(nproc)" && make install && \
-    cd "${KV_WORKSPACE}" && rm -rf "${UCX_HOME}.src"
+RUN if [[ "${ENABLE_NIXL_OVERLAY}" == "1" ]]; then \
+      set -e; \
+      git clone "${UCX_REPO}" "${UCX_HOME}.src" && cd "${UCX_HOME}.src"; \
+      git checkout "${UCX_COMMIT}"; \
+      ./autogen.sh && mkdir -p build && cd build; \
+      ../configure --prefix="${UCX_HOME}" --enable-shared --disable-static \
+          --disable-doxygen-doc --enable-optimizations --enable-devel-headers \
+          --with-rocm="${ROCM_PATH}" --with-verbs --with-dm --enable-mt; \
+      make -j"$(nproc)" && make install; \
+      cd "${KV_WORKSPACE}" && rm -rf "${UCX_HOME}.src"; \
+    else \
+      echo "[full-overlay] NIXL overlay disabled — keeping the image's UCX"; \
+    fi
 
 # --- ROCm/RIXL (the AMD NIXL implementation) --------------------------------
-RUN set -e; \
-    git clone "${RIXL_REPO}" "${RIXL_HOME}" && cd "${RIXL_HOME}" && \
-    git checkout "${RIXL_COMMIT}" && (git submodule update --init --recursive || true); \
-    meson setup build --prefix="${RIXL_HOME}" -Ducx_path="${UCX_HOME}" -Drocm_path="${ROCM_PATH}" && \
-    cd build && ninja && ninja install
+RUN if [[ "${ENABLE_NIXL_OVERLAY}" == "1" ]]; then \
+      set -e; \
+      git clone "${RIXL_REPO}" "${RIXL_HOME}" && cd "${RIXL_HOME}"; \
+      git checkout "${RIXL_COMMIT}" && (git submodule update --init --recursive || true); \
+      meson setup build --prefix="${RIXL_HOME}" -Ducx_path="${UCX_HOME}" -Drocm_path="${ROCM_PATH}"; \
+      cd build && ninja && ninja install; \
+    else \
+      echo "[full-overlay] NIXL overlay disabled — keeping the image's nixl"; \
+    fi
 
 # Install the meson-built RIXL python package into site-packages directly.
 # The upstream contrib/build-wheel.sh requires uv + py3.12 + auditwheel, which
 # the py3.10 sglang base lacks; `ninja install` already produced the
 # cpython-310 bindings under the RIXL prefix, so copy them into site-packages
 # and alias `nixl` -> `rixl` for SGLang's KV_TRANSFER_BACKEND=nixl import path.
-RUN set -e; \
-    echo "=== RIXL python install tree ==="; \
-    find "${RIXL_HOME}" -type d \( -name site-packages -o -name dist-packages \) | sed 's/^/PYDIR: /'; \
-    pysp="$(find "${RIXL_HOME}" -type d \( -name site-packages -o -name dist-packages \) | head -1)"; \
-    test -n "${pysp}" || { echo "RIXL_PY_INSTALL_NOT_FOUND"; find "${RIXL_HOME}" -name '_bindings*.so' -o -name '*.py' | head; exit 1; }; \
-    echo "RIXL_PY_SRC=${pysp}"; ls -la "${pysp}"; \
-    SP="$(python3 -c 'import site; print(site.getsitepackages()[0])')"; \
-    copied=0; \
-    for d in "${pysp}"/*/; do \
-      name="$(basename "$d")"; \
-      case "$name" in *dist-info|__pycache__) continue;; esac; \
-      rm -rf "${SP}/${name}"; cp -a "$d" "${SP}/${name}"; echo "INSTALLED_PY_PKG ${name} -> ${SP}/${name}"; copied=1; \
-    done; \
-    test "$copied" = 1 || { echo "NO_RIXL_PKG_COPIED"; exit 1; }; \
-    echo "import rixl, sys; sys.modules['nixl'] = rixl" > "${SP}/nixl_alias.pth"; \
-    echo "NIXL_ALIAS_WRITTEN ${SP}/nixl_alias.pth"
+RUN if [[ "${ENABLE_NIXL_OVERLAY}" == "1" ]]; then \
+      set -e; \
+      echo "=== RIXL python install tree ==="; \
+      find "${RIXL_HOME}" -type d \( -name site-packages -o -name dist-packages \) | sed 's/^/PYDIR: /'; \
+      pysp="$(find "${RIXL_HOME}" -type d \( -name site-packages -o -name dist-packages \) | head -1)"; \
+      test -n "${pysp}" || { echo "RIXL_PY_INSTALL_NOT_FOUND"; find "${RIXL_HOME}" -name '_bindings*.so' -o -name '*.py' | head; exit 1; }; \
+      echo "RIXL_PY_SRC=${pysp}"; ls -la "${pysp}"; \
+      SP="$(python3 -c 'import site; print(site.getsitepackages()[0])')"; \
+      copied=0; \
+      for d in "${pysp}"/*/; do \
+        name="$(basename "$d")"; \
+        case "$name" in *dist-info|__pycache__) continue;; esac; \
+        rm -rf "${SP}/${name}"; cp -a "$d" "${SP}/${name}"; echo "INSTALLED_PY_PKG ${name} -> ${SP}/${name}"; copied=1; \
+      done; \
+      test "$copied" = 1 || { echo "NO_RIXL_PKG_COPIED"; exit 1; }; \
+      echo "import rixl, sys; sys.modules['nixl'] = rixl" > "${SP}/nixl_alias.pth"; \
+      echo "NIXL_ALIAS_WRITTEN ${SP}/nixl_alias.pth"; \
+    fi
 
-# Sanity: nixl (== rixl) import must succeed; report version + agent symbol.
+# Sanity: nixl must import, whether it came from the overlay or the base image,
+# because KV_TRANSFER_BACKEND=nixl imports exactly this name. Strict when the
+# overlay built it; a report when the base is expected to supply it.
 RUN set -e; \
-    python3 -c "import nixl; print('NIXL_IMPORT_OK', getattr(nixl,'__file__','?'))"; \
-    python3 -c "import rixl, importlib.metadata as m; print('RIXL_VERSION', m.version('rixl'))" || true; \
+    if [[ "${ENABLE_NIXL_OVERLAY}" == "1" ]]; then \
+      python3 -c "import nixl; print('NIXL_IMPORT_OK', getattr(nixl,'__file__','?'))"; \
+      python3 -c "import rixl, importlib.metadata as m; print('RIXL_VERSION', m.version('rixl'))" || true; \
+    else \
+      python3 -c "import nixl; print('NIXL_IMPORT_OK', getattr(nixl,'__file__','?'))" \
+        || echo "NIXL_NOT_IN_BASE_IMAGE (set ENABLE_NIXL_OVERLAY=1 to build it)"; \
+    fi; \
     python3 -c "from nixl._api import nixl_agent, nixl_agent_config; print('NIXL_AGENT_OK')" \
       || echo "NIXL_AGENT_API_DIFFERS (verify sglang nixl import path at runtime)"
 
@@ -236,54 +310,162 @@ RUN set -e; \
 RUN pip install --no-cache-dir py-spy pyyaml pandas \
  && pip install --no-cache-dir --ignore-installed --force-reinstall flask
 
-# Mooncake KV-transfer backend (KV_TRANSFER_BACKEND=mooncake). Mirrors
-# docker/sglang_disagg_inference_kvtransfer_overlay.ubuntu.amd.Dockerfile:62-74.
-# Default: pip wheel pin; set MOONCAKE_COMMIT for a source build.
-ARG MOONCAKE_VERSION=0.3.6.post1
+# Mooncake KV-transfer backend (KV_TRANSFER_BACKEND=mooncake).
+#
+# The pin matters. Mooncake before upstream 45b84d3 ("[TE] Fix cross-node RDMA
+# KV transfer under rdma+hip multi-protocol on AMD", #2725, 2026-07-03) has no
+# MC_DISABLE_HIP and no isHipReachableTarget: a GPU address registered under
+# both rdma and hip keeps hip's hardcoded priority for *any* target, so a
+# cross-node KV chunk is pushed through the intra-node-only HIP transport and
+# every transfer dies in hipIpcOpenMemHandle ("invalid device pointer").
+# MC_USE_HIP_IPC=0 does not help — it only swaps IPC handles for fabric memory,
+# which is just as intra-node. v0.3.12.post1 is the first release carrying the
+# fix; #2725 was itself validated on a bnxt_re fabric.
+#
+# The guard lives inside `#ifdef ENABLE_MULTI_PROTOCOL`, whose CMake option
+# defaults to OFF, so a build without it silently produces a mooncake with the
+# same broken routing — which is why this builds from source rather than taking
+# the pip wheel, and why it greps the installed package for MC_DISABLE_HIP (a
+# getenv() literal inside that block) to prove the guard really landed.
+ARG ENABLE_MOONCAKE_OVERLAY=0
 ARG MOONCAKE_REPO=https://github.com/kvcache-ai/Mooncake.git
-ARG MOONCAKE_COMMIT=
-RUN set -e; \
-    if [[ -n "${MOONCAKE_COMMIT}" ]]; then \
-      echo "[full-overlay] Mooncake source ${MOONCAKE_REPO}@${MOONCAKE_COMMIT}"; \
-      git clone "${MOONCAKE_REPO}" /tmp/mooncake && cd /tmp/mooncake && \
-      git checkout "${MOONCAKE_COMMIT}" && (git submodule update --init --recursive || true); \
-      pip install --no-cache-dir --force-reinstall . && rm -rf /tmp/mooncake; \
-    elif [[ -n "${MOONCAKE_VERSION}" ]]; then \
-      echo "[full-overlay] Mooncake pip mooncake-transfer-engine==${MOONCAKE_VERSION}"; \
-      pip install --no-cache-dir --force-reinstall "mooncake-transfer-engine==${MOONCAKE_VERSION}"; \
-    else \
-      echo "[full-overlay] Mooncake: keeping base image version"; \
-    fi
+ARG MOONCAKE_REF=v0.3.12.post1
+# Upstream default is ON, and it decides how GPU buffers become RDMA memory
+# regions: ON exports a dmabuf via hsa and calls ibv_reg_dmabuf_mr, OFF calls
+# plain ibv_reg_mr on the device pointer. Which one works is a property of the
+# verbs provider, so the choice belongs to the deployment.
+ARG MOONCAKE_HIP_DMABUF=ON
 
-# Sanity: mooncake must import alongside nixl/rixl (non-fatal — module path may vary).
-RUN python3 -c "import mooncake; print('MOONCAKE_OVERLAY_OK')" \
-    || echo "MOONCAKE_IMPORT_DIFFERS (verify sglang mooncake import path at runtime)"
-
-###############################################################################
-# 5) Optional: build + install rdma-core v62 from source, for hosts whose RDMA
-#    stack needs a newer libibverbs/librdmacm/libmlx5 than the base image
-#    ships. Formerly built at job start by the launcher; baked here (gated by
-#    ENABLE_RDMA62, empty by default) so the runtime env is not mutated and
-#    the default build never pays for it. Mirrors the RDMA_CORE_VERSION-gated
-#    stage in docker/primus_megatron_train_rccl_overlay.ubuntu.amd.Dockerfile.
-###############################################################################
-ARG ENABLE_RDMA62=
-ARG RDMA_VER=v62.0
-RUN if [[ -n "${ENABLE_RDMA62}" ]]; then \
+RUN if [[ "${ENABLE_MOONCAKE_OVERLAY}" == "1" ]]; then \
       set -e; \
-      git clone --branch "${RDMA_VER}" --depth 1 https://github.com/linux-rdma/rdma-core.git /tmp/rdma-core && \
-      cd /tmp/rdma-core && mkdir -p build && cd build && \
-      cmake -GNinja -DCMAKE_INSTALL_PREFIX=/usr -DNO_MAN_PAGES=1 .. && \
-      ninja && ninja install && ldconfig && \
-      rm -rf /tmp/rdma-core; \
+      apt-get -o Acquire::Retries=5 update; \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git cmake ninja-build build-essential pkg-config patchelf; \
+      rm -rf /var/lib/apt/lists/*; \
+      git clone "${MOONCAKE_REPO}" /tmp/mooncake; \
+      cd /tmp/mooncake; \
+      git checkout "${MOONCAKE_REF}"; \
+      echo "MOONCAKE_BUILD_REF ${MOONCAKE_REF} $(git rev-parse --short HEAD)"; \
+      grep -q isHipReachableTarget mooncake-transfer-engine/src/multi_transport.cpp \
+        || { echo "MOONCAKE_REF_MISSING_CROSS_HOST_HIP_GUARD"; exit 1; }; \
+      bash dependencies.sh -y; \
+      cmake -S . -B build -G Ninja -DUSE_HIP=ON -DUSE_CUDA=OFF \
+            -DENABLE_MULTI_PROTOCOL=ON -DCMAKE_BUILD_TYPE=Release \
+            -DUSE_HIP_DMABUF="${MOONCAKE_HIP_DMABUF}" \
+            -DBUILD_UNIT_TESTS=OFF; \
+      cmake --build build -j"$(nproc)"; \
+      cmake --install build; \
+      bash scripts/build_wheel.sh; \
+      whl="$(ls mooncake-wheel/dist/mooncake_transfer_engine*.whl | awk 'NR==1')"; \
+      echo "MOONCAKE_WHEEL ${whl}"; \
+      pip install --no-cache-dir --force-reinstall "${whl}"; \
+      pkg="$(python3 -c 'import mooncake, os; print(os.path.dirname(mooncake.__file__))')"; \
+      hit="$(grep -rls MC_DISABLE_HIP "${pkg}" || true)"; \
+      echo "MOONCAKE_GUARD_IN ${hit:-<nothing>}"; \
+      [[ -n "${hit}" ]] || { echo "MOONCAKE_GUARD_NOT_COMPILED_IN ${pkg}"; exit 1; }; \
+      cd /; rm -rf /tmp/mooncake; \
     else \
-      echo "ENABLE_RDMA62 unset — keeping base image rdma-core"; \
+      echo "[full-overlay] Mooncake overlay disabled — keeping the image's mooncake"; \
     fi
 
-# Sanity: rebuilt libibverbs present (only when ENABLE_RDMA62 was set) and
-# python still imports (linker not corrupted).
+# Report which mooncake is in place and whether it can route a cross-node
+# transfer around the HIP transport at all. Informational only: never fail the
+# build here (see the RCCL report above for why).
+RUN ( set +e +o pipefail; \
+      pkg="$(python3 -c 'import mooncake, os; print(os.path.dirname(mooncake.__file__))' 2>/dev/null)"; \
+      echo "MOONCAKE_PACKAGE ${pkg:-<not found>}"; \
+      echo "MOONCAKE_CROSS_HOST_GUARD ${pkg:+$(grep -rls MC_DISABLE_HIP "$pkg" | tr '\n' ' ')}" )
+
+###############################################################################
+# 5) rdma-core from source — the Broadcom Thor2 (bnxt_re) queue-pair fix.
+#
+# The bnxt_re provider shipped with rdma-core 39.0/50.0 corrupts the verbs
+# command buffer for work issued off worker threads, so the kernel rejects
+# ibv_create_qp with EFAULT (errno 14) and the KV-transfer backends lose their
+# queue pairs. Every backend hits it, each in its own way: mooncake logged 2604
+# creation failures over a 2P2D run, NIXL could not start at all because UCX
+# treats one failed interface QP as fatal, and MoRI built queue pairs that
+# reached RTS and then moved zero bytes.
+#
+# Measured on one node, one container, same kernel, 8 threads x 64 queue pairs,
+# only the userspace changing: 39.0 creates 33-66 of 512, and 63.0 creates 512
+# of 512. With 63.0 all three backends run a full 2P2D DeepSeek-R1 sweep with
+# zero queue-pair failures.
+#
+# ON by default (empty string keeps the base image's rdma-core), because the
+# defect is silent: nothing in the logs points at the provider, and each backend
+# fails differently enough to look like three unrelated bugs.
+#
+# Two things happen beyond the plain build. The distro packages are removed, so
+# exactly one libibverbs is left on disk instead of two of different vintages.
+# And the vendor bnxt_re provider that /etc/ld.so.conf.d puts on the loader path
+# is dropped: it advertises kernel uABI 7-8, and a host running the upstream
+# driver (uABI 1) has every device rejected with "Driver bnxt_re does not
+# support the kernel ABI of 1", after which RCCL finds no IB plugin at all.
+#
+# ORDERING IS LOAD-BEARING: the source rdma-core is installed by REPLACING the
+# distro libibverbs/librdmacm packages via `dpkg -r --force-all`, which leaves
+# still-installed dependents (libucx0, openmpi, ...) with dangling deps, so any
+# later apt command aborts with "Unmet dependencies". Every apt operation must
+# run before the dpkg removal; only dpkg and `ninja install` may follow it. This
+# is also why the stage is last.
+###############################################################################
+ARG RDMA_CORE_VERSION=63.0
+
+RUN if [[ -n "${RDMA_CORE_VERSION}" ]]; then \
+      set -e; \
+      apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 update; \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git ca-certificates cmake ninja-build build-essential pkg-config make \
+        libnl-3-dev libnl-route-3-dev libudev-dev libssl-dev libsystemd-dev \
+        python3-docutils pandoc; \
+      git clone --depth 1 --branch "v${RDMA_CORE_VERSION}" \
+        https://github.com/linux-rdma/rdma-core.git /tmp/rdma-core; \
+      mkdir -p /tmp/rdma-core/build && cd /tmp/rdma-core/build; \
+      cmake -GNinja \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu \
+        -DCMAKE_INSTALL_SYSCONFDIR=/etc \
+        -DCMAKE_INSTALL_RUNDIR=/run \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DNO_PYVERBS=1 \
+        ..; \
+      ninja -j"$(nproc)"; \
+      DEBIAN_FRONTEND=noninteractive apt-get purge -y python3-docutils pandoc; \
+      DEBIAN_FRONTEND=noninteractive apt-get autoremove -y; \
+      rm -rf /var/lib/apt/lists/*; \
+      to_remove=""; \
+      for p in ibverbs-providers libibverbs1 libibverbs-dev ibverbs-utils \
+               librdmacm1 librdmacm-dev rdma-core libibumad3 infiniband-diags; do \
+        dpkg-query -W -f='${Status}' "$p" 2>/dev/null | grep -q "install ok installed" \
+          && to_remove="$to_remove $p"; \
+      done; \
+      [ -n "$to_remove" ] && dpkg -r --force-all $to_remove; \
+      ninja install; \
+      rm -f /usr/local/lib/x86_64-linux-gnu/libbnxt_re-rdmav34.so \
+            /usr/local/lib/libbnxt_re-rdmav34.so; \
+      ldconfig; \
+      cd / && rm -rf /tmp/rdma-core; \
+      echo "RDMA_CORE_FROM_SOURCE ${RDMA_CORE_VERSION}"; \
+    else \
+      echo "RDMA_CORE_FROM_SOURCE <disabled, keeping base rdma-core>"; \
+    fi
+
+# Sanity: report the providers the loader can actually see, so a failed
+# replacement is visible in the build log rather than at the first
+# ibv_create_qp, and confirm python still imports (linker not corrupted).
 RUN set -e; \
-    if [[ -n "${ENABLE_RDMA62}" ]]; then \
-      ls -l /usr/lib/libibverbs.so* 2>/dev/null || ls -l /usr/lib/*/libibverbs.so* 2>/dev/null || true; \
-    fi; \
-    python3 -c "import torch; print(\"RDMA62_TORCH_OK\" if \"${ENABLE_RDMA62}\" else \"RDMA62_SKIPPED_TORCH_OK\", torch.__version__)"
+    ( set +e +o pipefail; \
+      echo "IBVERBS_PROVIDERS $(ls /usr/lib/x86_64-linux-gnu/libibverbs/ 2>/dev/null | tr '\n' ' ')"; \
+      echo "LIBIBVERBS_SO $(readlink -f /usr/lib/x86_64-linux-gnu/libibverbs.so.1 2>/dev/null)" ); \
+    python3 -c "import torch; print('RDMA_CORE_TORCH_OK', torch.__version__)"
+
+LABEL rdma_core_version="${RDMA_CORE_VERSION}"
+LABEL rccl_overlay="${ENABLE_RCCL_OVERLAY}"
+LABEL rccl_commit="${RCCL_COMMIT}"
+LABEL mori_overlay="${ENABLE_MORI_OVERLAY}"
+LABEL nixl_overlay="${ENABLE_NIXL_OVERLAY}"
+LABEL mooncake_overlay="${ENABLE_MOONCAKE_OVERLAY}"
+LABEL mooncake_ref="${MOONCAKE_REF}"
+LABEL mooncake_hip_dmabuf="${MOONCAKE_HIP_DMABUF}"
+LABEL build_gpu_targets="${BUILD_GPU_TARGETS}"

--- a/scripts/sglang_disagg/README.MD
+++ b/scripts/sglang_disagg/README.MD
@@ -89,13 +89,24 @@ custom split) + `env_vars`; see the Confluence package for a ready 5-node EP16 m
 
 The base image (`docker/sglang_disagg_inference.ubuntu.amd.Dockerfile`) bakes RCCL,
 MoRI and Mooncake/NIXL. To test *specific* versions of these components without
-rebuilding the base, use the merged full overlay, which layers RCCL, MoRI and the
-KV-transfer (Mooncake/NIXL) steps on top of `BASE_DOCKER` in a single image
-(`base -> rccl -> mori -> kvtransfer`):
+rebuilding the base, use the merged full overlay.
+
+Its default base is a `rocm/sgl-dev` tag that already carries all of them, so the
+component stages are **off by default** and the image is the base plus rdma-core.
+Turn a stage on with its `ENABLE_*` arg to A/B that one component against what the
+base ships. The target GPU is chosen in two places only: the `BASE_DOCKER` tag
+suffix (`-mi35x` = gfx950, `-mi30x` = gfx942) and `BUILD_GPU_TARGETS`, which
+`MORI_GPU_ARCHS` derives from.
 
 | Overlay Dockerfile | Substitutes | Key build args |
 |--------------------|-------------|----------------|
-| `docker/sglang_disagg_inference_full_overlay.ubuntu.amd.Dockerfile` | RCCL + MoRI + Mooncake/NIXL (merged) | `RCCL_REPO/RCCL_BRANCH/RCCL_COMMIT`, `MORI_REPO/MORI_BRANCH/MORI_COMMIT` or `MORI_WHEEL_URL`, `MOONCAKE_VERSION`, `UCX_REPO/UCX_COMMIT` and `RIXL_REPO/RIXL_COMMIT` (the AMD "nixl" backend), `ENABLE_RDMA62` (set to `1` on hosts needing a newer rdma-core than the base image ships, to additionally build rdma-core v62 from source) |
+| `docker/sglang_disagg_inference_full_overlay.ubuntu.amd.Dockerfile` | rdma-core, and optionally RCCL + MoRI + Mooncake/NIXL | `BASE_DOCKER`, `BUILD_GPU_TARGETS`; `RDMA_CORE_VERSION` (default `63.0`, built from source — the Broadcom Thor2 `bnxt_re` queue-pair fix; pass an empty value to keep the base image's rdma-core); `ENABLE_RCCL_OVERLAY=1` with `RCCL_REPO/RCCL_BRANCH/RCCL_COMMIT`; `ENABLE_MORI_OVERLAY=1` with `MORI_REPO/MORI_BRANCH/MORI_COMMIT` or `MORI_WHEEL_URL`; `ENABLE_NIXL_OVERLAY=1` with `UCX_REPO/UCX_COMMIT` and `RIXL_REPO/RIXL_COMMIT` (the AMD "nixl" backend); `ENABLE_MOONCAKE_OVERLAY=1` with `MOONCAKE_REF` (default `v0.3.12.post1`, the first release with the cross-host HIP guard) |
+
+> **rdma-core note:** the `bnxt_re` provider in rdma-core 39.0/50.0 corrupts the
+> verbs command buffer for work issued off worker threads, so `ibv_create_qp`
+> fails with EFAULT and the KV-transfer backends lose their queue pairs. That is
+> why `RDMA_CORE_VERSION` defaults to `63.0` rather than being opt-in, and why
+> the stage also drops the vendor `bnxt_re` provider.
 
 > **RCCL note:** a newer rocm-systems RCCL build links `librccl` without
 > the `librocm_smi64.so` `DT_NEEDED` the base carried. Since the overlay is first


### PR DESCRIPTION
`aicomnet-305/sgl-dev-gfx950-rdma63` -> `mad-rccl`. One commit, one file:
`docker/sglang_disagg_inference_full_overlay.ubuntu.amd.Dockerfile`.

## The problem

None of the KV-transfer backends could run 2P/2D DeepSeek-R1 on the Broadcom Thor2
(`bnxt_re`) fabric, and each failed in its own way, which made it look like three
unrelated bugs:

- mooncake logged 2604 `Failed to create QP` over a single run
- NIXL never started: UCX creates one interface queue pair while opening
  `rc_verbs/bnxt_re1`, and treats the failure as fatal
- MoRI built queue pairs that reached RTS, then moved zero bytes and aborted every
  request

All three are the same defect. The `bnxt_re` provider in rdma-core 39.0/50.0 corrupts
the verbs command buffer for work issued off worker threads, so the kernel answers
`ibv_create_qp` with EFAULT (errno 14). Isolated on one node, in one container, on the
same kernel, with 8 threads x 64 queue pairs and only the userspace changing:

| rdma-core | queue pairs created |
|-----------|---------------------|
| 39.0 (distro) | 33-66 of 512 |
| 63.0 (source) | 512 of 512 |

## What changed

**rdma-core.** The stage that fixes this was already in this file as `ENABLE_RDMA62`.
It worked, but it was off by default and its comment said only "hosts whose RDMA stack
needs a newer libibverbs", so nothing connected it to Thor2 and it was never switched
on. It is now `RDMA_CORE_VERSION` (63.0, on by default; empty keeps the base image's),
documented against the measurement above, and it additionally:

- removes the distro rdma-core packages, so one libibverbs is left on disk instead of
  two of different vintages;
- drops the vendor `bnxt_re` provider that `/etc/ld.so.conf.d` puts on the loader path.
  It advertises kernel uABI 7-8, so on a host running the upstream driver (uABI 1) every
  device is rejected with `Driver bnxt_re does not support the kernel ABI of 1`, after
  which RCCL finds no IB plugin at all.

Ordering is load-bearing and is called out in the file: the source build replaces the
distro packages with `dpkg -r --force-all`, which leaves still-installed dependents
(libucx0, openmpi, ...) with dangling deps, so every apt operation has to run before the
removal. That is why the stage is last.

**Base image and stage gating.** The default base becomes
`rocm/sgl-dev:v0.5.16-rocm720-mi35x-20260807`, which already carries sglang, aiter,
sgl-kernel, MoRI, RIXL and mooncake built for gfx950. Rebuilding those on top of it is
both slow and a regression risk, so each component stage is now gated and defaults to
off: the image is the base plus rdma-core, and each `ENABLE_*` arg turns one component
into an A/B against what the base ships.

**Mooncake.** Moves from the `0.3.6.post1` wheel to a source build of `v0.3.12.post1`
with `ENABLE_MULTI_PROTOCOL=ON`. Before upstream 45b84d3 (#2725) there is no cross-host
guard, so a GPU address registered under both rdma and hip keeps hip's priority for any
target: every cross-node KV chunk is pushed through the intra-node-only HIP transport
and dies in `hipIpcOpenMemHandle`. Because the guard sits behind a CMake option that
defaults to OFF, a build without it produces the same broken routing silently, so the
stage greps the installed package for `MC_DISABLE_HIP` and fails the build if the guard
did not land.

## Compatibility

Existing users of this file get a different default image, so this is a behaviour
change. The old configuration is still reachable in full:

```
--build-arg BASE_DOCKER=lmsysorg/sglang:v0.5.12.post1-rocm720-mi30x \
--build-arg BUILD_GPU_TARGETS=gfx942 --build-arg MORI_GPU_ARCHS=gfx942 \
--build-arg ENABLE_RCCL_OVERLAY=1 --build-arg ENABLE_MORI_OVERLAY=1 \
--build-arg ENABLE_NIXL_OVERLAY=1 --build-arg ENABLE_MOONCAKE_OVERLAY=1
```

Hosts that do not want the new rdma-core can pass `--build-arg RDMA_CORE_VERSION=` to
keep the base image's.
