### PR TITLE
MI300 Minimax TP constraint

### DIFF
--- a/scripts/vllm/configs/default.yaml
+++ b/scripts/vllm/configs/default.yaml
@@ -113,6 +113,10 @@
     --block-size: 128
     --kv-cache-dtype: fp8
     --attention-backend: TRITON_ATTN
+  arch_overrides:
+    # No native MXFP8 MOE for MI300, can't fit 
+    gfx942:
+      tp: 8
 
 ## gpt-oss w4a8 is gfx950 only
 - benchmark: serving


### PR DESCRIPTION
Override TP=4 for MiniMax-M3-MXFP4 on MI300. There is no native MXFP8 MOE kernel for gfx942; weights get switched to BF16 and does not fit on 4 GPUs. 
