### PR TITLE
[vLLM]: drop tp8 from minimax m2.7

### DIFF
--- a/scripts/vllm/configs/extended.yaml
+++ b/scripts/vllm/configs/extended.yaml
@@ -65,7 +65,7 @@
   model:
     MiniMaxAI/MiniMax-M2.7
     amd/MiniMax-M2.7-MXFP4
-  tp: 4 8
+  tp: 4
   inp: 1024
   out: 1024
   dtype: auto


### PR DESCRIPTION
## Motivation
See https://github.com/vllm-project/vllm/pull/48173#issuecomment-5258960089; Minimax M2.7 is not designed for TP8, we should just keep it to TP4 for now and enable EP later instead of hacking a padding fix into vLLM.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
