### PR TITLE
sglang_disagg: document the config surface and extract it into config/ (stage 1, no behavior change)

### DIFF
--- a/scripts/sglang_disagg/CONFIG.md
+++ b/scripts/sglang_disagg/CONFIG.md
@@ -1,0 +1,364 @@
+# sglang_disagg Configuration Taxonomy
+
+> Config catalog as of commit `01b1650` (branch `pr171`, 2026-06-24). Line numbers below are pinned to this commit; prefer the named section when the file drifts.
+
+Documentation only. This file catalogs every environment variable, CLI parameter, and config value used by `scripts/sglang_disagg/`, grouped by functional responsibility. It changes no behavior.
+
+## How to read this document
+
+- **Primary bucket**: the section where a value is documented in full. Every value has exactly one.
+- **Overlaps**: other buckets where the value plays a secondary role (see [Cross-cutting Values](#cross-cutting-values)).
+- **Set by**: `user` (set explicitly), `computed` (derived from other values), `conditional` (only set in a particular mode).
+- **Required**: `yes`, `no` (has a default), or `conditional` (with the gating condition).
+- **Type**: `env-only` (read by a library at runtime), `flag-only` (a CLI argument), `env->flag` (a shell var passed into a CLI flag).
+- **Source** uses `file § section` plus the line at this commit.
+
+The seven buckets are: [Cluster](#1-cluster), [Framework](#2-framework), [Connectors](#3-connectors), [Parser](#4-parser), [Benchmarking](#5-benchmarking), [Launcher](#6-launcher), [Model](#7-model).
+
+> Note: the bucket **order in this document is optimized for review isolation** (each section is checkable against its source in isolation). It intentionally differs from the runtime **workflow order** shown in the diagram below.
+
+## Bucket overview and config flow
+
+```mermaid
+flowchart TD
+    subgraph stages [Launch stages]
+        direction LR
+        sbatch["sbatch<br/>run_xPyD_models.slurm"] --> dockerrun["docker run<br/>(per node)"] --> entry["entrypoint<br/>sglang_disagg_mori_io_ep.sh"] --> srv["sglang.launch_server<br/>+ launch_router"]
+    end
+
+    Cluster["Cluster<br/>SLURM, topology, IPs"]
+    Model["Model<br/>MODEL_NAME, models.yaml, sizes"]
+    Connectors["Connectors<br/>RUN_MORI, KV backend, RDMA"]
+    Launcher["Launcher<br/>roles, router, readiness"]
+    Framework["Framework<br/>NCCL/torch/aiter runtime"]
+    Benchmarking["Benchmarking<br/>bench_serving / GSM8K / GSP"]
+    Parser["Parser<br/>logs -> CSV / perf.csv"]
+
+    runmori{"RUN_MORI?"}
+    dpmode{"DP_MODE?"}
+
+    Cluster --> Launcher
+    Model --> Launcher
+    Connectors --> runmori
+    runmori -->|"1: mori"| Launcher
+    runmori -->|"0: mooncake"| Launcher
+    Model --> dpmode
+    dpmode -->|"1: dp/ep + dist-init"| Framework
+    dpmode -->|"0: tp only"| Framework
+    Launcher -->|"assembles PREFILL/DECODE_MODEL_CONFIG"| srv
+    Framework --> srv
+    srv --> Benchmarking
+    Benchmarking --> Parser
+```
+
+---
+
+## 1. Cluster
+
+SLURM allocation, physical topology, and host/fabric identity.
+
+### User-set
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| `xP` | `run_xPyD_models.slurm` (108) | `1` | user | no | env->flag | Number of prefill nodes. Drives node count, IP layout, and TP/EP scaling. | Model, Framework |
+| `yD` | `run_xPyD_models.slurm` (109) | `1` | user | no | env->flag | Number of decode nodes. | Model, Framework |
+| `GPUS_PER_NODE` | `sglang_disagg_mori_io_ep.sh § Parallelism Settings` (99) | `8` | user | no | env | GPUs per node; multiplies xP/yD for DP/EP/TP sizes. | Model |
+| `USE_CX7_NICS` | `mori_ep_env.sh § NIC mode selection` (10); passed at `run_xPyD_models.slurm` (400) | `1` in env file, `0` as passed by slurm | user | no | env | Selects the 8 CX7 rail NICs vs the mlx5_1 mgmt NIC. Note the default mismatch between the two files. | Connectors |
+| `MASTER_PORT` | `sglang_disagg_mori_io_ep.sh § Environment Configuration` (38); set to `39566` in `run_xPyD_models.slurm` (304) | `23731` | user | no | env | Rendezvous port advertised to workers. | Launcher |
+| sbatch directives (`-N`, `-n`, `--ntasks-per-node`, `--switches=2`, `--gres=gpu:8`, `--time`, `--output`/`--error`) | `run_xPyD_models.slurm § sbatch header` (2-15) | see file | user | yes | flag-only | SLURM allocation shape and IB-switch/rail policy. | - |
+
+### Computed
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| `NUM_NODES` / `NNODES` | `run_xPyD_models.slurm` (220, 320) | `xP + yD` | computed | - | env | Total nodes; validated against the allocation. | Launcher |
+| `MASTER_NODE` / `MASTER_ADDR` | `run_xPyD_models.slurm` (301-303) | first sorted node / its IP | computed | - | env | Master node hostname and IP used as the sync anchor (`:2322`). | Launcher |
+| `SELECTED_NODES` | `run_xPyD_models.slurm` (242) | first `NUM_NODES`, sorted | computed | - | - | Alphabetically sorted node subset; ordering must match IP layout. | - |
+| `IPS` / `IPADDRS` | `run_xPyD_models.slurm` (306-348) | discovered via `hostname -I` | computed | - | env | Comma-separated node IPs; `[0..xP-1]`=prefill, `[xP..]`=decode. | Launcher |
+| `IP_ARRAY`, `IP_FIRST_PREFILL`, `IP_FIRST_DECODE` | `sglang_disagg_mori_io_ep.sh § Cluster Topology` (205-208) | from `IPADDRS` | computed | - | - | Parsed IP list and per-role first IPs (router backends, dist-init). | Framework, Launcher |
+| `host_ip` / `host_name` | `sglang_disagg_mori_io_ep.sh` (84-85) | `ip route` / `hostname` | computed | - | - | This node's bind IP and name. | - |
+| `SLURM_*` overrides (`SLURM_NNODES`, `SLURM_NTASKS`, `SLURM_JOB_NODELIST`, `SLURM_JOB_NAME`, ...) | `run_xPyD_models.slurm § SLURM env overrides` (250-270) | derived | computed | - | env | Rewrites the SLURM env to the selected node subset before `srun`. | - |
+| `USER_NAME` | `run_xPyD_models.slurm` (300, 347) | `whoami` | computed | - | env | Used in log paths / perf metadata. | Parser |
+| `SLURM_JOB_ID` / `SLURM_JOBID` | `run_xPyD_models.slurm § SLURM env overrides` (263-274), passthrough at (379) | from SLURM allocation, `0` in-container fallback | computed | - | env | Job id used to namespace all log dirs (`/run_logs/${SLURM_JOB_ID}/`). | Launcher, Parser, Benchmarking |
+
+---
+
+## 2. Framework
+
+SGLang / torch / NCCL / aiter runtime tuning that is not tied to the KV transport. Most values live in `mori_ep_env.sh` and are `env-only` with `${VAR:-default}` overrides.
+
+### User-set (NCCL fabric tuning, `mori_ep_env.sh § NCCL configuration`)
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| `NCCL_IB_HCA` | `mori_ep_env.sh` (28) | `${_DEFAULT_IB}` | user | no | env-only | NICs NCCL uses for the collective (TP/all-reduce) fabric. | Cluster, Connectors |
+| `NCCL_IB_GID_INDEX` | `mori_ep_env.sh` (31) | `3` | user | no | env-only | RoCE v2 GID index. | - |
+| `NCCL_CROSS_NIC` | `mori_ep_env.sh` (34) | `1` | user | no | env-only | Allow multiple NICs per GPU. | - |
+| `NCCL_NET_GDR_LEVEL` | `mori_ep_env.sh` (37) | `3` | user | no | env-only | GPUDirect RDMA level (PXB crossing). | - |
+| `NCCL_IB_DISABLE` | `mori_ep_env.sh` (40) | `0` | user | no | env-only | Force IB transport over sockets. | - |
+| `NCCL_IB_QPS_PER_CONNECTION` | `mori_ep_env.sh` (44) | `4` | user | no | env-only | QPs per connection (CX7 parallelism). | - |
+| `NCCL_IB_SPLIT_DATA_ON_QPS` | `mori_ep_env.sh` (47) | `1` | user | no | env-only | Split data across QPs. | - |
+| `NCCL_BUFFSIZE` | `mori_ep_env.sh` (51) | `8388608` | user | no | env-only | 8MB NCCL buffer for NDR 400G. | - |
+| `NCCL_IB_TIMEOUT` / `NCCL_IB_RETRY_CNT` | `mori_ep_env.sh` (54-55) | `22` / `7` | user | no | env-only | IB op timeout and retry count. | - |
+| `NCCL_IB_SL` / `NCCL_IB_TC` | `mori_ep_env.sh` (58, 61) | `0` / `106` | user | no | env-only | Service level and traffic class (RoCE QoS). | - |
+| `NCCL_IB_PCI_RELAXED_ORDERING` | `mori_ep_env.sh` (64) | `1` | user | no | env-only | PCIe relaxed ordering. | - |
+| `NCCL_IB_ADAPTIVE_ROUTING` | `mori_ep_env.sh` (67) | `1` | user | no | env-only | Adaptive routing if fabric supports it. | - |
+| `NCCL_TOPO_DUMP_FILE` | `mori_ep_env.sh` (70) | `/tmp/nccl_topo.xml` | user | no | env-only | Topology auto-detection dump path. | - |
+| `NCCL_DEBUG` / `NCCL_DEBUG_SUBSYS` | `mori_ep_env.sh` (72-73) | `INFO` / `INIT,NET,GRAPH` | user | no | env-only | NCCL logging verbosity. | - |
+| `GLOO_SOCKET_IFNAME` | `mori_ep_env.sh` (91), `sglang_disagg_mori_io_ep.sh § setup_sglang_worker_env` (291) | default-route iface / `eth0` | user | no | env-only | Control-plane socket interface for Gloo. Primary=Framework (consuming library). | Cluster |
+| `NCCL_SOCKET_IFNAME` | `mori_ep_env.sh` (92), `sglang_disagg_mori_io_ep.sh` (292) | `${GLOO_SOCKET_IFNAME}` / `eth0` | user | no | env-only | Control-plane socket interface for NCCL. | Cluster |
+| `GLOO_TIMEOUT_MS` | `mori_ep_env.sh § Timeouts` (98) | `300000` | user | no | env-only | Gloo collective timeout. | - |
+| `TORCH_DIST_INIT_BARRIER_TIMEOUT` | `mori_ep_env.sh` (99) | `300` | user | no | env-only | torch dist init barrier timeout. | - |
+| `SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT` | `mori_ep_env.sh` (100) | `1200` | user | no | env-only | Disagg bootstrap timeout. | Connectors |
+| `SGLANG_DISAGGREGATION_WAITING_TIMEOUT` | `mori_ep_env.sh` (101), `sglang_disagg_mori_io_ep.sh` (295) | `1200` | user | no | env-only | Disagg waiting timeout. | Connectors |
+| `PYTHONDONTWRITEBYTECODE` | `mori_ep_env.sh § Runtime optimizations` (106) | `1` | user | no | env-only | Skip `.pyc` writes. | - |
+| `SGLANG_USE_AITER` | `mori_ep_env.sh` (107), `sglang_disagg_mori_io_ep.sh` (293) | `1` | user | no | env-only | Enable AITER kernels. | - |
+| `SGLANG_ROUTER_STDOUT_LOGS` | `mori_ep_env.sh` (108) | `0` | user | no | env-only | Router stdout logging toggle. | Launcher |
+| `PYTHONPATH` | `mori_ep_env.sh` (111) | prepends `/sgl-workspace/aiter` | user | no | env-only | Adds aiter to import path when present. | - |
+| generic `launch_server` flags (`--attention-backend aiter`, `--watchdog-timeout`, `--mem-fraction-static`, `--cuda-graph-bs`, `--disable-cuda-graph`, `--disable-radix-cache`) | `models.yaml` (base/prefill/decode) | per model | user | yes | flag-only | Runtime/engine tuning applied per role. Values live in Model config; the knobs themselves are framework runtime. | Model |
+| `--trust-remote-code`, `--decode-log-interval 1`, `--log-level-http warning` | `sglang_disagg_mori_io_ep.sh § launch blocks` (354, 367, 369) | constants | user | yes | flag-only | Always-applied engine flags. | Launcher |
+
+### Computed / conditional (distributed process-group rendezvous)
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| `DIST_INIT_PORT` | `sglang_disagg_mori_io_ep.sh § Cluster Topology` (210) | `5757` | conditional | conditional (DP_MODE=1) | env->flag | Port for the torch/sglang process-group rendezvous (TP/DP/EP group), not KV transport. | Cluster |
+| `PREFILL_DIST_INIT_ADDR` / `DECODE_DIST_INIT_ADDR` | `sglang_disagg_mori_io_ep.sh` (213-214) | `IP_FIRST_*:DIST_INIT_PORT` | computed | conditional (DP_MODE=1) | env->flag | `--dist-init-addr` for prefill/decode groups (used at 361/583/670). | Cluster |
+| `PREFILL_NNODES` / `DECODE_NNODES` | `sglang_disagg_mori_io_ep.sh` (211-212) | `xP` / `yD` | computed | conditional (DP_MODE=1) | env->flag | `--nnodes` per role for the process group. | Cluster, Model |
+
+---
+
+## 3. Connectors
+
+KV-cache transport and disaggregation transport selection. Split by backend mode.
+
+### Backend selection (always)
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| `RUN_MORI` | `run_xPyD_models.slurm § Backend selection` (87) | `0` | user | no | env | Selects transport: `1`=MoRI IO, `0`=Mooncake. | Parser (perf tag) |
+| `KV_TRANSFER_BACKEND` | set `mooncake` at `run_xPyD_models.slurm` (91); default `mori` at `sglang_disagg_mori_io_ep.sh` (189) | `mori` | conditional | no | env->flag | Value passed to `--disaggregation-transfer-backend` (190-191). | - |
+| `--disaggregation-transfer-backend` | `sglang_disagg_mori_io_ep.sh` (190-191) | `${KV_TRANSFER_BACKEND}` | computed | yes | flag-only | Per-role transport backend flag. | - |
+| `--disaggregation-mode` | `sglang_disagg_mori_io_ep.sh § launch blocks` (348, 657) | `prefill` / `decode` | user | yes | flag-only | Marks the server as a prefill or decode endpoint. | Launcher |
+| `IB_DEVICES` | `mori_ep_env.sh § CORE DEVICE LIST` (23) | `${_DEFAULT_IB}` (CX7 rails or mlx5_1) | user | yes | env->flag | RDMA NICs for KV transfer; passed to `--disaggregation-ib-device` (351/573/660). | Cluster |
+
+### MoRI-specific (`RUN_MORI=1`; the `SGLANG_MORI_*`/dispatch knobs require `DP_MODE=1`)
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| `MORI_RDMA_DEVICES` | `mori_ep_env.sh § MORI configuration` (79) | `${_DEFAULT_IB}` | user | conditional (RUN_MORI=1) | env-only | NIC set MoRI uses for EP. | Cluster |
+| `MORI_IB_GID_INDEX` | `mori_ep_env.sh` (82) | `3` | user | conditional (RUN_MORI=1) | env-only | MoRI GID index (matches NCCL). | - |
+| `MORI_QPS_PER_CONNECTION` | `mori_ep_env.sh` (85) | `4` | user | conditional (RUN_MORI=1) | env-only | MoRI QPs per connection. | - |
+| `MORI_SOCKET_IFNAME` | `mori_ep_env.sh § Socket interface` (93) | `${GLOO_SOCKET_IFNAME}` | user | conditional (RUN_MORI=1) | env-only | MoRI control-plane socket interface. Primary=Connectors (consuming library). | Cluster |
+| `SGLANG_MORI_FP8_DISP` | `mori_ep_env.sh § MoRI EP tuning` (116), `sglang_disagg_mori_io_ep.sh` (294) | `True` (`False` if model name has `mxfp4`) | user | conditional (DP_MODE=1) | env-only | FP8 dispatch for MoRI EP. | Model |
+| `SGLANG_MORI_FP4_DISP` | `mori_ep_env.sh` (118) | `False` | user | conditional (DP_MODE=1) | env-only | FP4 dispatch toggle. | - |
+| `SGLANG_MORI_FP8_COMB` | `mori_ep_env.sh` (119) | `False` | user | conditional (DP_MODE=1) | env-only | FP8 combine toggle. | - |
+| `MORI_MAX_DISPATCH_TOKENS_DECODE` | `mori_ep_env.sh` (120) | `160` | user | conditional (DP_MODE=1) | env-only | Max dispatch tokens per rank (decode). | - |
+| `SGLANG_MORI_DISPATCH_INTER_KERNEL_SWITCH_THRESHOLD` | `mori_ep_env.sh` (121), `sglang_disagg_mori_io_ep.sh` (639) | `2 * MORI_MAX_DISPATCH_TOKENS_DECODE` | computed | conditional (DP_MODE=1) | env-only | Inter-kernel switch threshold. | - |
+| `SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK` | `sglang_disagg_mori_io_ep.sh` (640) | `${MORI_MAX_DISPATCH_TOKENS_DECODE}` | computed | conditional (DP_MODE=1) | env-only | Per-rank max dispatch tokens (decode). | - |
+| `MORI_SHMEM_HEAP_SIZE` | `mori_ep_env.sh` (123) | `17179869184` (16 GiB) | user | conditional (DP_MODE=1) | env-only | MoRI shared-memory heap (4 GiB default too small for EP>=32). | - |
+| `--moe-a2a-backend mori` | `models.yaml` (`dp_flags`, DeepSeek-V3/R1) | - | user | conditional (DP_MODE=1) | flag-only | Routes MoE all-to-all through MoRI EP. | Model |
+
+### Mooncake-specific (`RUN_MORI=0`)
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| `KV_TRANSFER_BACKEND=mooncake` | `run_xPyD_models.slurm § Backend selection` (91) | set when `RUN_MORI=0` | conditional | conditional (RUN_MORI=0) | env->flag | Forces the Mooncake transport; MoRI env is unused. | - |
+
+---
+
+## 4. Parser
+
+Log-to-CSV conversion and perf metadata. See [`parse_to_csv.py`](parse_to_csv.py) (production, wired into `benchmark_xPyD.sh`) and [`benchmark_parser.py`](benchmark_parser.py) (standalone diagnostic).
+
+### CLI arguments
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| `log_file` | `parse_to_csv.py § main` (176) | - | user | yes | flag-only | Benchmark log to parse. | - |
+| `-o` / `--output` | `parse_to_csv.py` (177) | `<log>_results.csv` | user | no | flag-only | Results CSV path (max throughput per config). | - |
+| `--perf-csv` | `parse_to_csv.py` (178) | - | user | no | flag-only | Also emit madengine `perf.csv`. | - |
+| `--model-name` | `parse_to_csv.py` (179) | `""` | user | no | flag-only | Model name recorded in `perf.csv`. | Model |
+| `logfile` / `--csv` / `--compact` / `--no-screen` | `benchmark_parser.py § main` (138-162) | - / auto / off / off | user | varies | flag-only | Standalone parser inputs (pandas table + optional CSV). | - |
+
+### Env consumed for `perf.csv` tagging (`parse_to_csv.py § _get_run_metadata`, 101-129)
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| `xP`, `yD` | env (104-105) | `1`, `1` | user | no | env | Deployment shape tag `disagg_xPyD`. | Cluster |
+| `DP_MODE` | env (106) | `0` | user | no | env | Selects backend tag `mori_dp`. | Model |
+| `RUN_MORI` | env (107) | `0` | user | no | env | Selects backend tag `mori_io` vs `mooncake`. | Connectors |
+| `GPUS_PER_NODE` | env (108) | `8` | user | no | env | Used to compute `n_gpus`. | Cluster |
+| `DOCKER_IMAGE_NAME` | env (125) | `""` | user | no | env | Recorded in `perf.csv`. | Launcher |
+| `SLURM_JOB_NODELIST` | env (126) | `""` | user | no | env | Recorded as `machine_name`. | Cluster |
+
+---
+
+## 5. Benchmarking
+
+Benchmark drivers that hit the router. This is the intended extension point for multiple benchmark types (throughput / accuracy / GSP, and future agentx). Two drivers exist today.
+
+### Throughput sweep (`benchmark_xPyD.sh`, production; wired into the launcher)
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| `BENCHMARK_ITR` | `run_xPyD_models.slurm` (349); `benchmark_xPyD.sh` (29) | `2` | user | no | env | Number of sweep iterations (iter 1+ parsed). | - |
+| `BENCHMARK_COMBINATIONS` | `run_xPyD_models.slurm` (398); `benchmark_xPyD.sh` (27) | `1024/1024 8192/1024` | user | no | env | ISL/OSL combinations to sweep. | - |
+| `CON` | `benchmark_xPyD.sh` (25) | `8 16 32 64 128 256 512` | user | yes | (in-script) | Concurrency levels swept per combination. | - |
+| `p_con` | `benchmark_xPyD.sh` (35-37) | `max(2 * con, 16)` | computed | - | (in-script) | Prompt count per sweep step (`--num-prompt`), floored at 16. | - |
+| `bench_serving` flags (`--backend sglang`, `--model $MODEL_PATH`, `--host 127.0.0.1`, `--port 2322`, `--dataset-name random`, `--random-input`, `--random-output`, `--random-range-ratio 1.0`, `--max-concurrency`, `--num-prompt`, `--pd-separated`) | `benchmark_xPyD.sh` (11-23, 40-52) | see file | user | yes | flag-only | Drives the sweep against the router on `:2322`. | Launcher, Model |
+| `BENCHMARK_FILE` | `run_xPyD_models.slurm` (317) | cookbook path | user | no | env | Informational path recorded for the run. | Launcher |
+
+### Accuracy + GSP sweep (`benchmark_xPyD_GSP.sh`, alternate driver)
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| GSM8K accuracy (`benchmark/gsm8k/bench_sglang.py --parallel 1400 --num-questions 1400`) | `benchmark_xPyD_GSP.sh` (17) | constants | user | yes | flag-only | Accuracy benchmark against the running server. | - |
+| GSP sweep flags (`--dataset-name generated-shared-prefix`, `--gsp-system-prompt-len`, `--gsp-question-len`, `--gsp-output-len`, `--gsp-num-groups`, `--gsp-prompts-per-group`, `--port 30000`) | `benchmark_xPyD_GSP.sh` (43-54) | see file | user | yes | flag-only | Shared-prefix throughput sweep. Note: targets `--port 30000`, not the router `:2322` used by `benchmark_xPyD.sh`. | Launcher |
+| `CON` / `COMBINATIONS` | `benchmark_xPyD_GSP.sh` (30-31) | `32 64 128 256 512 1024` / `4096/100 2048/100 1024/1024 512/1500` | user | yes | (in-script) | GSP concurrency and ISL/OSL grid. | - |
+
+### Smoke test
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| `CURL_TEST_MODEL` | `sglang_disagg_mori_io_ep.sh § NODE_RANK 0` (520) | `${MODEL_PATH}` | user | no | env | Model field for the pre-benchmark `/v1/completions` smoke test. | Launcher, Model |
+
+---
+
+## 6. Launcher
+
+Orchestration and control flow: role dispatch, router, readiness gating, and validation.
+
+### User-set
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| `DOCKER_IMAGE_NAME` | `run_xPyD_models.slurm` (99, 399) | none (hard error if unset) | user | yes | env | Container image run on every node. | Parser |
+| `SKIP_BENCHMARK` | `run_xPyD_models.slurm` (114) | `0` | user | no | env | Skip the benchmark phase on NODE 0. | Benchmarking |
+| `SKIP_CURL_TEST` | `run_xPyD_models.slurm` (115) | `0` | user | no | env | Skip the smoke test. | Benchmarking |
+| `LOG_PATH` | `run_xPyD_models.slurm` (106) | `/shared_inference/$USER/model_blog_logs` | user | no | env | Host log directory (mounted as `/run_logs`). | - |
+| `MODEL_DIR` | `run_xPyD_models.slurm` (118) | `/shared_inference/models_blog/` | user | no | env | Fallback model search root. | Model |
+| `BARRIER_PORT` | `sglang_disagg_mori_io_ep.sh § Environment Configuration` (70) | `4342` | user | no | env | Container-creation barrier port. | - |
+| readiness knobs (`SEARCH_SIGNAL`, `ROUTER_READY_TIMEOUT_SECONDS`, `ROUTER_POLL_SLEEP_SECONDS`) | `sglang_disagg_mori_io_ep.sh § NODE_RANK 0` (389-391) | `The server is fired up...` / `4000` / `10` | user | no | env | Log-grep readiness signal and poll timing before starting the router. | Parser |
+
+### Computed / constants
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| `RUN_FILE` / `RUN_FILE_FULL` | `run_xPyD_models.slurm` (86, 354) | `sglang_disagg_mori_io_ep.sh` | computed | - | env | The unified entrypoint always used. | - |
+| `MOONCAKE_REPO_DIR` / `MOONCAKE_COOKBOOK_PATH` | `run_xPyD_models.slurm` (105, 316) | `$(pwd)` / `/opt/mooncake-cookbook` | computed | - | env | Host repo dir and its in-container mount. | - |
+| `DOCKER_CONT_NAME` | `run_xPyD_models.slurm` (353) | `container_${MODEL_NAME}_${JOB_ID}` | computed | - | env | Per-job container name. | - |
+| `NODE_RANK` | `sglang_disagg_mori_io_ep.sh` (39), from `SLURM_PROCID` | `0` | computed | yes | env | Selects the role branch (0=prefill+router, `1..xP-1`=prefill, `xP..`=decode). | - |
+| `PREFILL_NODE_RANK` / `DECODE_NODE_RANK` | `sglang_disagg_mori_io_ep.sh` (338/558, 631) | derived from `NODE_RANK` | computed | - | env->flag | Per-role `--node-rank` (DP_MODE=1). | Framework |
+| `PREFILL_ARGS` / `DECODE_ARGS` | `sglang_disagg_mori_io_ep.sh § Router backend URLs` (236-253) | from `IP_ARRAY` | computed | - | flag-only | Router `--prefill`/`--decode` backend URLs (`:3000`). | Cluster |
+| router config (`--pd-disaggregation`, `--host 0.0.0.0`, `--port 2322`) | `sglang_disagg_mori_io_ep.sh § NODE_RANK 0` (448-453) | constants | computed | yes | flag-only | sglang_router (proxy) launch. | - |
+| server bind (`--host ${host_ip}`, `--port 3000`) | `sglang_disagg_mori_io_ep.sh § launch blocks` (352-353) | constants | computed | yes | flag-only | Per-worker HTTP bind. | Cluster |
+| load-balance method (`--load-balance-method`, `--prefill-round-robin-balance`) | `sglang_disagg_mori_io_ep.sh` (343-350) | `round_robin` (`follow_bootstrap_room` if DP_MODE=1) | computed | yes | flag-only | Router LB; DP_MODE=1 pins requests to the DP rank owning the bootstrap slot. | Model |
+| proxy PD-readiness probe (`ROUTER_HTTP_BASE`, wait/interval) | `sglang_disagg_mori_io_ep.sh` (495-515) | `http://127.0.0.1:2322` / 300s / 10s | computed | - | env | Polls `/v1/completions` until the full PD path is live. | Benchmarking |
+| allowlists (`VALID_MODELS`, `MORI_EP_VALID_MODELS`, `MORI_DP_MODE1_ALLOWED_MODELS`) | `run_xPyD_models.slurm` (30-71); `sglang_disagg_mori_io_ep.sh` (12-15) | fixed arrays | computed | yes | (in-script) | Model validation gates (DP_MODE=1 restricted to DeepSeek-V3/R1). | Model |
+| `PREFILL_LOG` / `DECODE_LOG` | `sglang_disagg_mori_io_ep.sh § launch blocks` (373, 601 / 682) | `/run_logs/${SLURM_JOB_ID:-0}/{prefill,decode}_NODE${NODE_RANK}.log` | computed | - | env | Per-role server log paths (`tee`'d); consumed by the parser. | Cluster, Parser |
+
+### Docker runtime (reference only)
+
+Container-runtime flags are not sglang-disagg config per se and are intentionally not catalogued individually. See `run_xPyD_models.slurm § srun docker run` (359-404): `--device /dev/dri|/dev/kfd|/dev/infiniband`, `--network host`, `--ipc host`, `--group-add video`, `--cap-add SYS_PTRACE`, `--security-opt seccomp=unconfined`, `--privileged`, volume mounts (`$HOME`, `/shared_inference`, `/mnt/m2m_nobackup`, `${LOG_PATH}`, repo), `--shm-size 64G`, `--ulimit nofile=1048576:1048576`, and the `-e` env passthrough.
+
+---
+
+## 7. Model
+
+Model selection and per-model engine configuration. `models.yaml` is the active config source consumed by `sglang_disagg_mori_io_ep.sh` (not legacy).
+
+### User-set
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| `MODEL_NAME` | `run_xPyD_models.slurm` (117) | `None` (validated) | user | yes | env | Selects the model and its `models.yaml` entry. | Launcher, Parser |
+| `DP_MODE` | `run_xPyD_models.slurm` (110) | `0` | user | no | env | `0`=TP (all models), `1`=DP+EP (DeepSeek-V3/R1 only). Selects the YAML flag set. | Parser, Launcher, Connectors |
+| `MODELS_YAML` | `sglang_disagg_mori_io_ep.sh` (126) | `${SCRIPT_DIR}/models.yaml` | user | no | env | Override path to the model-flags YAML consumed by the reader. | Launcher |
+| `models.yaml` keys (`base_flags`, `tp_flags`, `dp_flags`, `prefill.tp`, `prefill.dp`, `decode.tp`, `decode.dp`, `experimental_flags`) | [`models.yaml`](models.yaml) | per model | user | yes | flag-only | Per-model, per-role engine flags loaded by the YAML reader (134-176). | Framework, Connectors |
+| `GENERIC_TP_SIZE` | `sglang_disagg_mori_io_ep.sh § Parallelism Settings` (100) | `8` | user | no | env->flag | Per-worker TP size when `DP_MODE=0`. | Cluster |
+
+### Computed
+
+| Name | Source | Default | Set by | Required | Type | Meaning | Overlaps |
+|------|--------|---------|--------|----------|------|---------|----------|
+| `MODEL_PATH` | `run_xPyD_models.slurm § Model path selection` (189-214) | first existing of 3 roots | computed | yes | env->flag | Resolved model directory (validated on all nodes); `--model-path`. | - |
+| `PARALLEL_MODE` | `sglang_disagg_mori_io_ep.sh` (50-54) | `tp` (or `dp` if DP_MODE=1) | computed | - | env | Chooses which YAML flag set to load. | - |
+| `PREFILL_TP_SIZE` / `DECODE_TP_SIZE` | `sglang_disagg_mori_io_ep.sh` (103-107) | `GENERIC_TP_SIZE`, or `xP/yD * GPUS_PER_NODE` if DP_MODE=1 | computed | yes | env->flag | `--tp-size` per role. | Cluster |
+| `PREFILL_DP_SIZE` / `DECODE_DP_SIZE` | `sglang_disagg_mori_io_ep.sh` (114-115) | `xP/yD * GPUS_PER_NODE` | computed | conditional (DP_MODE=1) | env->flag | `--dp-size` per role. | Cluster |
+| `PREFILL_EP_SIZE` / `DECODE_EP_SIZE` | `sglang_disagg_mori_io_ep.sh` (112-113) | `xP/yD * GPUS_PER_NODE` | computed | conditional (DP_MODE=1) | env->flag | `--ep-size` per role. | Cluster |
+| `MODEL_BASE_FLAGS`, `MODEL_MODE_FLAGS`, `MODEL_PREFILL_FLAGS`, `MODEL_DECODE_FLAGS`, `MODEL_EXPERIMENTAL_FLAGS` | `sglang_disagg_mori_io_ep.sh § Model-Specific Configuration from YAML` (165-171) | from YAML | computed | - | env->flag | Individual flag groups extracted from `models.yaml`. | - |
+| `PREFILL_MODEL_CONFIG` / `DECODE_MODEL_CONFIG` | `sglang_disagg_mori_io_ep.sh` (178-179), +transfer backend (190-191) | assembled | computed | yes | env->flag | Final per-role flag string passed to `launch_server`. | Connectors, Framework |
+
+---
+
+## Cross-cutting Values
+
+When a value serves multiple roles, the Primary bucket is chosen by these rules, in priority order:
+
+1. **Control flow wins** — if it gates which code path runs, it is Launcher.
+2. **Transport identity wins** — if it selects RDMA devices or the backend for KV transfer, it is Connectors.
+3. **Tuning wins** — if it only affects performance, not correctness, it is Framework.
+4. **Source of truth wins** — if it is the user-facing model knob, it is Model.
+
+| Value | Primary | Secondary | Rationale |
+|-------|---------|-----------|-----------|
+| `NCCL_IB_*` | Framework | Cluster (fabric identity), Connectors (if MoRI reuses NICs) | Tunes the NCCL collective fabric, not the KV transport. |
+| `GLOO_SOCKET_IFNAME`, `NCCL_SOCKET_IFNAME` | Framework | Cluster | Assigned by consuming library (Gloo/NCCL); value is the physical iface. |
+| `MORI_SOCKET_IFNAME` | Connectors | Cluster | Consumed by the MoRI transport. |
+| `IB_DEVICES` | Connectors | Cluster | Selects KV-transfer RDMA NICs (`--disaggregation-ib-device`); `NCCL_IB_HCA` consumes the same list for Framework. |
+| `DIST_INIT_PORT`, `PREFILL_/DECODE_DIST_INIT_ADDR` | Framework | Cluster | torch/sglang process-group rendezvous (DP_MODE=1), not KV transport; endpoint IPs come from topology. |
+| `TP` / `DP` / `EP` sizes | Model | Cluster | Model parallelism degrees that scale with `xP*GPUS_PER_NODE`. |
+| `RUN_MORI` | Connectors | Parser | Selects the KV backend; also read for the perf.csv tag. |
+| `DP_MODE` | Model | Parser, Launcher, Connectors | Selects the YAML flag set; also a perf tag, an allowlist gate, and a MoRI-EP switch. |
+| `SKIP_BENCHMARK`, `SEARCH_SIGNAL` | Launcher | Benchmarking, Parser | Control flow / readiness signal grepped from logs. |
+| `CURL_TEST_MODEL` | Benchmarking | Launcher, Model | Smoke-test payload model, defaults to `MODEL_PATH`. |
+
+---
+
+## Legacy Configuration (appendix)
+
+Do NOT use in new deployments. The active launcher is `sglang_disagg_mori_io_ep.sh` with `mori_ep_env.sh` and `models.yaml`.
+
+### `set_env_vars.sh` (superseded by `mori_ep_env.sh`)
+
+| Name | Superseded by | Notes |
+|------|---------------|-------|
+| `IBDEVICES` | `IB_DEVICES` (`mori_ep_env.sh`) | Hardcoded `mlx5_0,mlx5_2,...`; consumed only by `sglang_disagg_server.sh`. |
+| `NCCL_SOCKET_IFNAME` (with appended `mlx5_*`) | `NCCL_SOCKET_IFNAME` (`mori_ep_env.sh`) | Legacy appends NIC names to the socket iface. |
+| `GLOO_SOCKET_IFNAME` | `GLOO_SOCKET_IFNAME` (`mori_ep_env.sh`) | - |
+| `NCCL_IB_DISABLE=1` | `NCCL_IB_DISABLE` (`mori_ep_env.sh`, default `0`) | Legacy disables IB; active path enables it. |
+| `NCCL_IGNORE_CPU_AFFINITY=1` | (not carried forward) | Legacy-only. |
+| `HSA_NO_SCRATCH_RECLAIM=1` | (not carried forward) | Legacy-only; not present in the active path. |
+
+### `sglang_disagg_server.sh` (superseded by `sglang_disagg_mori_io_ep.sh`)
+
+| Name | Superseded by | Notes |
+|------|---------------|-------|
+| `declare -A MODEL_PREFILL_CONFIGS` / `MODEL_DECODE_CONFIGS` | `models.yaml` (`prefill.*` / `decode.*`) | Bash associative arrays of `--tp-size` per model -> YAML config. |
+| `--disaggregation-transfer-backend mooncake` (hardcoded) | `--disaggregation-transfer-backend ${KV_TRANSFER_BACKEND}` | Modern path selects MoRI or Mooncake. |
+| `--stream-output`, `MC_TE_METRIC=true` | (not carried forward) | Legacy prefill/decode launch options. |
+| server `--port 2322` | server `--port 3000` (router on `2322`) | Modern path separates server and router ports. |
+
+---
+
+## Verification
+
+- **Forward** (source -> tables): every `export`/assignment/CLI flag found by grepping the active files (`run_xPyD_models.slurm`, `sglang_disagg_mori_io_ep.sh`, `mori_ep_env.sh`, `models.yaml`, `benchmark_xPyD.sh`, `benchmark_xPyD_GSP.sh`, `parse_to_csv.py`, `benchmark_parser.py`) appears in exactly one Primary bucket.
+- **Inverse** (tables -> source): every value named above exists in at least one source file at commit `01b1650`.
+- **Orphans**: an automated flag sweep of the active files found no undocumented engine/router/benchmark config. Flags that appear in source but are intentionally NOT catalogued as sglang-disagg config fall into three invocation-plumbing categories:
+  - Socket-sync utility args wired from Launcher/Cluster values: `--local-ip`, `--local-port`, `--node-ips`, `--node-ports`, `--enable-port` (`socket_barrier.py`), `--remote-ip`, `--remote-port` (`socket_wait.py`).
+  - Container/tooling invocation flags: `--entrypoint`, `--name`, `--rm`, `--no-run-if-empty` (docker/xargs), `--ignore-installed`, `--force-reinstall` (pip), `--max-time` (curl probe).
+  - SLURM allocation flags: `--job-name`, `--switches`, `--gres`, `--time`, `--nodelist`, `--nodes`, `--spread-job` (the last is in a comment, intentionally removed) — covered collectively under Cluster sbatch directives.
+  - Legacy-only values (`set_env_vars.sh`, `sglang_disagg_server.sh`) live in the appendix, not the main buckets.
+
+### Counts
+
+| Metric | Count |
+|--------|-------|
+| Primary buckets | 7 |
+| Cataloged values (main buckets) | ~100 across Cluster/Framework/Connectors/Parser/Benchmarking/Launcher/Model |
+| Cross-cutting straddlers | 10 |
+| Legacy values (appendix) | 10 |
+| Orphans (undocumented, active path) | 0 |

--- a/scripts/sglang_disagg/DESIGN.md
+++ b/scripts/sglang_disagg/DESIGN.md
@@ -1,0 +1,188 @@
+# sglang_disagg — Design & Responsibility Overview
+
+## What this module is
+
+`scripts/sglang_disagg/` is a **benchmarking harness for SGLang Prefill/Decode (PD)
+disaggregated inference on AMD (ROCm) GPUs**, orchestrated over a **SLURM** cluster.
+It launches separate prefill and decode SGLang servers across nodes, fronts them with
+a router/proxy, runs a concurrency-sweep benchmark, and parses the results into CSV.
+
+The code here is almost entirely **bash orchestration + small Python utilities** — it
+wraps SGLang (`sglang.launch_server`, `sglang_router`, `sglang.bench_serving`) rather
+than implementing the inference itself.
+
+> For a full breakdown of every environment variable, CLI parameter, and config value
+> grouped by responsibility (cluster / framework / connectors / parser / benchmarking /
+> launcher / model), see [CONFIG.md](CONFIG.md).
+
+## Layered structure
+
+```
+Build layer      docker/sglang_disagg_inference.ubuntu.amd.Dockerfile   (SGLang + MoRI image)
+                             │
+Cluster layer    run_xPyD_models.slurm     (sbatch: node selection, IP discovery, docker run per node)
+                             │
+Entrypoint       sglang_disagg_mori_io_ep.sh   (per-node role dispatch: prefill / decode / router)
+   layer                     │
+Config layer     models.yaml   mori_ep_env.sh   (model flags; RDMA/NCCL/MoRI env)
+                             │
+Sync layer       socket_barrier.py   socket_wait.py   (cross-node rendezvous / shutdown wait)
+                             │
+Benchmark        benchmark_xPyD.sh   (bench_serving concurrency sweep)
+   layer                     │
+Parse layer      parse_to_csv.py   benchmark_parser.py   (logs → CSV / perf.csv)
+```
+
+## File responsibilities
+
+| File | Responsibility |
+|------|----------------|
+| `docker/sglang_disagg_inference.ubuntu.amd.Dockerfile` | Build the runtime image: SGLang ROCm base + optional MoRI (pinned commit) + `sglang-router`. |
+| `run_xPyD_models.slurm` | Cluster orchestration: validate `MODEL_NAME`/`DP_MODE`, choose KV backend (`RUN_MORI`), select `xP+yD` nodes, discover IPs, `docker run` the entrypoint on every node. |
+| `sglang_disagg_mori_io_ep.sh` | Per-node container entrypoint. Derives `PARALLEL_MODE` (tp/dp), computes TP/DP/EP sizes, loads model flags from YAML, and dispatches by `NODE_RANK` into prefill / decode / router roles. |
+| `models.yaml` | Per-model CLI flags: `base_flags`, `tp_flags`/`dp_flags`, and role-specific `prefill`/`decode` flags. Backend-agnostic. |
+| `mori_ep_env.sh` | NCCL / RDMA / MoRI environment variables, `IB_DEVICES` (NIC selection). |
+| `set_env_vars.sh` | Legacy NCCL/IB env (used only by the legacy `sglang_disagg_server.sh`). |
+| `socket_barrier.py` | Startup rendezvous — opens a local port and waits until all nodes have opened theirs. |
+| `socket_wait.py` | Lifecycle wait — blocks while a remote port (router :2322) stays open; returns when it closes. |
+| `benchmark_xPyD.sh` | Concurrency-sweep benchmark driven through the router via `sglang.bench_serving`. |
+| `parse_to_csv.py` | Production parser: benchmark log → results CSV + madengine `perf.csv`. |
+| `benchmark_parser.py` | Standalone richer diagnostic parser (pandas; latency + throughput metrics). Not wired into the pipeline. |
+| `sglang_disagg_server.sh` | Legacy Mooncake-only launcher (bash assoc-array configs, port 2322 servers, no MoRI/DP). Superseded by `sglang_disagg_mori_io_ep.sh`. |
+| `salloc_launch.sh` | Example `salloc`/`sbatch` invocation commands. |
+
+## Responsibility diagram
+
+```mermaid
+graph TD
+    subgraph User["User / Operator"]
+        SL[salloc_launch.sh<br/>example invocations]
+    end
+
+    subgraph Build["Build-time"]
+        DF["Dockerfile<br/>base SGLang ROCm image<br/>+ optional MoRI + sglang-router"]
+    end
+
+    subgraph Cluster["Cluster orchestration (runs on login node)"]
+        SLURM["run_xPyD_models.slurm<br/>• validate MODEL_NAME / DP_MODE allowlist<br/>• pick RUN_FILE + KV backend (mori/mooncake)<br/>• select xP+yD nodes, discover IPs<br/>• export env, docker run on every node"]
+    end
+
+    subgraph Node["Per-node container entrypoint"]
+        ENTRY["sglang_disagg_mori_io_ep.sh<br/>• derive PARALLEL_MODE (tp/dp) from DP_MODE<br/>• compute TP/DP/EP sizes<br/>• load model flags from YAML<br/>• dispatch by NODE_RANK"]
+        R0["NODE_RANK 0<br/>Prefill#0 + Router/proxy<br/>(co-located)"]
+        RP["NODE_RANK 1..xP-1<br/>Prefill workers"]
+        RD["NODE_RANK xP..xP+yD-1<br/>Decode workers"]
+    end
+
+    subgraph Config["Configuration"]
+        YAML["models.yaml<br/>base/tp/dp + prefill/decode flags"]
+        ENV["mori_ep_env.sh<br/>NCCL/RDMA/MoRI env, IB_DEVICES"]
+    end
+
+    subgraph Sync["Cross-node synchronization"]
+        BAR["socket_barrier.py<br/>wait until all nodes open a port"]
+        WAIT["socket_wait.py<br/>block until proxy port closes"]
+    end
+
+    subgraph SGLang["SGLang processes (external)"]
+        PSRV["sglang.launch_server<br/>--disaggregation-mode prefill"]
+        DSRV["sglang.launch_server<br/>--disaggregation-mode decode"]
+        ROUTER["sglang_router.launch_router<br/>--pd-disaggregation :2322"]
+    end
+
+    subgraph Bench["Benchmark + parsing"]
+        BENCH["benchmark_xPyD.sh<br/>concurrency sweep via bench_serving"]
+        P2C["parse_to_csv.py<br/>→ results.csv + madengine perf.csv"]
+        BP["benchmark_parser.py<br/>→ rich metrics table/CSV"]
+    end
+
+    SL --> SLURM
+    DF -.provides image.-> SLURM
+    SLURM -->|docker run + env per node| ENTRY
+    ENTRY --> R0 & RP & RD
+    ENTRY -.reads.-> YAML
+    ENTRY -.sources.-> ENV
+
+    R0 --> PSRV
+    R0 --> ROUTER
+    RP --> PSRV
+    RD --> DSRV
+
+    ENTRY --> BAR
+    RP --> WAIT
+    RD --> WAIT
+
+    ROUTER -->|routes /generate, /v1/completions| PSRV
+    ROUTER --> DSRV
+    PSRV -.KV cache transfer RDMA.-> DSRV
+
+    R0 --> BENCH
+    BENCH -->|HTTP :2322| ROUTER
+    BENCH --> P2C
+    BENCH -. optional .-> BP
+```
+
+## Runtime sequence (one job)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as run_xPyD_models.slurm
+    participant N0 as NODE 0 (Prefill+Router)
+    participant NP as Prefill workers
+    participant ND as Decode workers
+    participant B as benchmark_xPyD.sh
+
+    U->>S: sbatch (xP, yD, MODEL_NAME, RUN_MORI)
+    S->>S: validate model, select nodes, discover IPs
+    S->>N0: docker run entrypoint (NODE_RANK=0)
+    S->>NP: docker run entrypoint (NODE_RANK 1..xP-1)
+    S->>ND: docker run entrypoint (NODE_RANK xP..)
+    Note over N0,ND: socket_barrier.py — all containers rendezvous
+    N0->>N0: launch prefill server
+    NP->>NP: launch prefill servers
+    ND->>ND: launch decode servers
+    N0->>N0: poll logs for "server is fired up and ready"
+    N0->>N0: launch sglang_router (:2322)
+    N0->>N0: probe /v1/completions until PD path ready
+    N0->>B: run benchmark (concurrency sweep)
+    B->>N0: bench_serving → router → prefill+decode
+    B->>B: parse_to_csv.py → CSV + perf.csv
+    N0->>N0: kill router + prefill
+    NP-->>NP: socket_wait detects router closed → exit
+    ND-->>ND: socket_wait detects router closed → exit
+```
+
+## Port reference
+
+| Purpose | Modern launcher (`sglang_disagg_mori_io_ep.sh`) | Legacy launcher (`sglang_disagg_server.sh`) |
+|---------|--------------------------------------------------|----------------------------------------------|
+| Prefill / decode server | `3000` | `2322` |
+| Router / proxy | `2322` | `2322` |
+| `dist-init` (DP_MODE=1 rendezvous) | `5757` (`DIST_INIT_PORT`) | n/a |
+| Startup barrier | `BARRIER_PORT` (default `4342`) | hardcoded `4342` |
+
+## Key design decisions
+
+- **Single unified launcher, two KV backends.** `run_xPyD_models.slurm` always uses
+  `sglang_disagg_mori_io_ep.sh`; `RUN_MORI` toggles `--disaggregation-transfer-backend`
+  between `mori` (RDMA-based MoRI IO) and `mooncake`. The backend is deliberately kept
+  out of `models.yaml` so model configs stay backend-agnostic.
+- **Two parallelism modes via `DP_MODE`.** `DP_MODE=0` → TP-only (all models);
+  `DP_MODE=1` → DP-attention + MoRI expert parallelism, restricted by an allowlist to
+  DeepSeek-V3/R1 (enforced redundantly in both the slurm script and the entrypoint).
+- **Router co-located on prefill NODE 0** — no dedicated proxy node. IP layout
+  convention: `IP[0..xP-1]` = prefill, `IP[xP..]` = decode. Nodes are alphabetically
+  sorted so `srun` PROCID ordering matches the IP array.
+- **File-based + socket-based synchronization.** Readiness is detected by grepping
+  worker logs on a shared `/run_logs` mount for
+  `"The server is fired up and ready to roll!"`; lifecycle coordination uses
+  `socket_barrier.py` (startup rendezvous) and `socket_wait.py` (workers block until the
+  router's port 2322 closes, then self-terminate). DP ranks are intentionally *not*
+  gated on the dist-init port because torch rendezvous would otherwise deadlock.
+- **Two parsers with different scopes.** `parse_to_csv.py` is the production one wired
+  into `benchmark_xPyD.sh` (max-throughput CSV + madengine `perf.csv`).
+  `benchmark_parser.py` is a richer standalone diagnostic (pandas, latency percentiles)
+  not called by the pipeline.
+- **`sglang_disagg_server.sh` is legacy** (Mooncake-only, superseded by the YAML-driven
+  MoRI/EP launcher).

--- a/scripts/sglang_disagg/ROADMAP.md
+++ b/scripts/sglang_disagg/ROADMAP.md
@@ -1,0 +1,109 @@
+# sglang_disagg config refactor - staged roadmap
+
+This refactor is delivered in three independently reviewable stages. Each stage is
+behavior-preserving and builds on the previous one. See [CONFIG.md](CONFIG.md) for the
+configuration taxonomy and [DESIGN.md](DESIGN.md) for the high-level design.
+
+## Overview
+
+```mermaid
+flowchart LR
+    baseline["Baseline<br/>config hard-wired inside scripts"]
+    s1["Stage 1<br/>EXTRACT<br/>pull variables out of scripts"]
+    s2["Stage 2<br/>CATEGORIZE + VALIDATE<br/>group into the 7 buckets, prove no run regressions"]
+    s3["Stage 3<br/>GENERALIZE<br/>folder-per-category, drop-in configs"]
+
+    baseline --> s1 --> s2 --> s3
+```
+
+Status: this PR lands Stage 1 + Stage 2 together (the extraction is already bucket-aligned).
+Stage 3 is a follow-on this work unblocks.
+
+## Stage 1 - Extract variables out of the scripts
+
+Goal: decouple *values* from *control flow*. Scripts stop hard-coding env/defaults and
+instead source external config. Runtime behavior is identical.
+
+```mermaid
+flowchart TB
+    subgraph before [Before]
+        direction TB
+        b_slurm["run_xPyD_models.slurm<br/>(-e passthrough + defaults)"]
+        b_entry["sglang_disagg_mori_io_ep.sh<br/>(inline VAR:-default)"]
+        b_env["mori_ep_env.sh<br/>(all NCCL/MORI env inline)"]
+    end
+
+    subgraph after [After Stage 1]
+        direction TB
+        a_entry["entrypoint (control flow only)"]
+        a_env["mori_ep_env.sh (aggregator)"]
+        a_cfg["extracted config values<br/>(external, sourced)"]
+        a_entry -->|"source"| a_cfg
+        a_env -->|"source"| a_cfg
+    end
+
+    before ==>|"lift values out"| after
+```
+
+Verify: resolved `env` is byte-identical before/after.
+
+## Stage 2 - Categorize into the 7 buckets + validate
+
+Goal: give the extracted values a home aligned to the CONFIG.md taxonomy, and gate on
+"no run issues."
+
+```mermaid
+flowchart TB
+    flat["Extracted config (flat)"]
+
+    subgraph buckets [Bucket-aligned files]
+        direction TB
+        nic["nic-selection.env.sh<br/>(shared prelude)"]
+        fw["framework.env.sh"]
+        conn["connectors.env.sh"]
+        defs["runtime.defaults.sh<br/>(Cluster/Launcher/Model)"]
+    end
+
+    gate{"Validation gate<br/>env-diff across DP_MODE x USE_CX7_NICS<br/>bash -n, standalone sourcing"}
+
+    flat --> nic & fw & conn & defs
+    nic --> gate
+    fw --> gate
+    conn --> gate
+    defs --> gate
+    gate -->|"identical + clean"| ok["Stage 2 accepted"]
+    gate -->|"any diff"| fix["fix + re-verify"]
+    fix --> gate
+```
+
+## Stage 3 - Generalize into a folder-per-category, drop-in structure
+
+Goal: make it trivial to add a new config - drop a file into the right category folder;
+it is auto-discovered and sourced. No script edits needed to add config.
+
+```mermaid
+flowchart TB
+    subgraph tree [config/ folder-per-bucket]
+        direction TB
+        cl["cluster/*.env.sh"]
+        fw2["framework/*.env.sh"]
+        cn["connectors/*.env.sh"]
+        md["model/*.env.sh"]
+        bn["benchmarking/*.env.sh"]
+    end
+
+    loader["loader: source category/*.env.sh in dependency order"]
+    newcfg["new requirement"]
+
+    cl --> loader
+    fw2 --> loader
+    cn --> loader
+    md --> loader
+    bn --> loader
+    loader --> entry["entrypoint / aggregator"]
+
+    newcfg -.->|"add one file, no code change"| fw2
+```
+
+Extensibility contract: adding a backend / model / tuning knob = add a single file under
+the matching category folder; the loader picks it up automatically.

--- a/scripts/sglang_disagg/config/README.md
+++ b/scripts/sglang_disagg/config/README.md
@@ -1,0 +1,27 @@
+# sglang_disagg config files
+
+Bucket-aligned configuration extracted from `mori_ep_env.sh` and the entrypoint
+`sglang_disagg_mori_io_ep.sh`. See [../CONFIG.md](../CONFIG.md) for the full taxonomy.
+
+This is a behavior-preserving Stage 1 extraction: values and their `${VAR:-default}`
+fallbacks are copied verbatim; runtime behavior is unchanged.
+
+## Files
+
+- `nic-selection.env.sh` - Shared NIC selection prelude (not a CONFIG.md bucket). Sets `_DEFAULT_IB` / `IB_DEVICES` from `USE_CX7_NICS`.
+- `framework.env.sh` - Framework bucket (NCCL, GLOO/NCCL sockets, timeouts, PyTorch/aiter runtime).
+- `connectors.env.sh` - Connectors bucket (MoRI RDMA config, MoRI socket, DP_MODE=1 MoRI-EP tuning).
+- `runtime.defaults.sh` - Entrypoint inline defaults (multi-bucket aggregate: Cluster/Launcher/Model).
+
+## Sourcing order
+
+1. `runtime.defaults.sh` - sourced by the entrypoint after `SCRIPT_DIR` is set (line 7), before first use (line 37).
+2. `mori_ep_env.sh` aggregator - sourced by the entrypoint after YAML loading (line 185); it sources:
+   - `nic-selection.env.sh` first,
+   - then `framework.env.sh` and `connectors.env.sh`.
+
+## Dependencies
+
+- `framework.env.sh` and `connectors.env.sh` both depend on `_DEFAULT_IB` from `nic-selection.env.sh`.
+- `connectors.env.sh` reads `GLOO_SOCKET_IFNAME` (set in `framework.env.sh`) for the MoRI socket default.
+- `connectors.env.sh` MoRI-EP block requires `DP_MODE` to be set before sourcing (entrypoint sets it at line 44).

--- a/scripts/sglang_disagg/config/connectors.env.sh
+++ b/scripts/sglang_disagg/config/connectors.env.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Connectors bucket: MoRI RDMA config + DP_MODE=1 MoRI-EP tuning.
+# Depends on _DEFAULT_IB from nic-selection.env.sh (source that first).
+# Requires DP_MODE to be set before sourcing (entrypoint sets it at line 44).
+# See ../CONFIG.md section 3 (Connectors).
+
+# =============================================================
+# MORI CONFIGURATION - Use all CX7 NICs for expert parallelism
+# =============================================================
+# MoRI uses the same NIC set as NCCL
+export MORI_RDMA_DEVICES="${MORI_RDMA_DEVICES:-${_DEFAULT_IB}}"
+
+# Match NCCL GID index for consistency
+export MORI_IB_GID_INDEX="${MORI_IB_GID_INDEX:-3}"
+
+# QPs per connection for MoRI (similar reasoning as NCCL)
+export MORI_QPS_PER_CONNECTION="${MORI_QPS_PER_CONNECTION:-4}"
+
+# =============================================================
+# SOCKET INTERFACE - Keep mlx5_1 IP-side for control plane
+# =============================================================
+# MoRI control-plane socket; defaults to the GLOO socket iface (set in framework.env.sh)
+export MORI_SOCKET_IFNAME=${MORI_SOCKET_IFNAME:-${GLOO_SOCKET_IFNAME}}
+
+# MoRI EP tuning (DP_MODE=1 only)
+if [[ "${DP_MODE:-}" == "1" ]]; then
+    export SGLANG_MORI_FP8_DISP="${SGLANG_MORI_FP8_DISP:-True}"
+    [[ "${MODEL_NAME:-}" == *mxfp4* ]] && export SGLANG_MORI_FP8_DISP=False
+    export SGLANG_MORI_FP4_DISP="${SGLANG_MORI_FP4_DISP:-False}"
+    export SGLANG_MORI_FP8_COMB="${SGLANG_MORI_FP8_COMB:-False}"
+    export MORI_MAX_DISPATCH_TOKENS_DECODE="${MORI_MAX_DISPATCH_TOKENS_DECODE:-160}"
+    export SGLANG_MORI_DISPATCH_INTER_KERNEL_SWITCH_THRESHOLD="${SGLANG_MORI_DISPATCH_INTER_KERNEL_SWITCH_THRESHOLD:-$((MORI_MAX_DISPATCH_TOKENS_DECODE * 2))}"
+    # MoRI shmem heap: 4 GiB default is too small for EP>=32; use 16 GiB.
+    export MORI_SHMEM_HEAP_SIZE="${MORI_SHMEM_HEAP_SIZE:-17179869184}"
+fi

--- a/scripts/sglang_disagg/config/framework.env.sh
+++ b/scripts/sglang_disagg/config/framework.env.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Framework bucket: NCCL / GLOO / PyTorch / aiter runtime tuning.
+# Depends on _DEFAULT_IB from nic-selection.env.sh (source that first).
+# See ../CONFIG.md section 2 (Framework).
+
+# =============================================================
+# NCCL CONFIGURATION
+# =============================================================
+export NCCL_IB_HCA="${NCCL_IB_HCA:-${_DEFAULT_IB}}"
+
+# Critical: RoCE v2 with IPv4 routing (GID index 3 is typical)
+export NCCL_IB_GID_INDEX="${NCCL_IB_GID_INDEX:-3}"
+
+# Allow NCCL to use multiple NICs per GPU when beneficial
+export NCCL_CROSS_NIC="${NCCL_CROSS_NIC:-1}"
+
+# GPUDirect RDMA - level 3 enables PXB (PCI Bridge) crossing
+export NCCL_NET_GDR_LEVEL="${NCCL_NET_GDR_LEVEL:-3}"
+
+# Use IB transport (force IB over Socket)
+export NCCL_IB_DISABLE="${NCCL_IB_DISABLE:-0}"
+
+# Multiple QPs per connection for CX7 - improves parallelism
+# CX7 NDR can saturate with more QPs (default is 1, recommend 4-8)
+export NCCL_IB_QPS_PER_CONNECTION="${NCCL_IB_QPS_PER_CONNECTION:-4}"
+
+# Split data across QPs for better load balancing
+export NCCL_IB_SPLIT_DATA_ON_QPS="${NCCL_IB_SPLIT_DATA_ON_QPS:-1}"
+
+# Increase chunk size to better utilize CX7 bandwidth (default 128KB)
+# For NDR 400G, larger chunks reduce overhead
+export NCCL_BUFFSIZE="${NCCL_BUFFSIZE:-8388608}"   # 8MB buffer
+
+# Timeout for IB operations (increase for large clusters)
+export NCCL_IB_TIMEOUT="${NCCL_IB_TIMEOUT:-22}"
+export NCCL_IB_RETRY_CNT="${NCCL_IB_RETRY_CNT:-7}"
+
+# Service Level for QoS (if your fabric uses SL-based QoS)
+export NCCL_IB_SL="${NCCL_IB_SL:-0}"
+
+# Traffic Class for RoCE QoS (DSCP 26 = AF31, common for RDMA)
+export NCCL_IB_TC="${NCCL_IB_TC:-106}"  # = DSCP 26 << 2
+
+# PCIe relaxed ordering for better performance
+export NCCL_IB_PCI_RELAXED_ORDERING="${NCCL_IB_PCI_RELAXED_ORDERING:-1}"
+
+# Adaptive routing (if fabric supports it)
+export NCCL_IB_ADAPTIVE_ROUTING="${NCCL_IB_ADAPTIVE_ROUTING:-1}"
+
+# Enable NCCL topology auto-detection
+export NCCL_TOPO_DUMP_FILE="${NCCL_TOPO_DUMP_FILE:-/tmp/nccl_topo.xml}"
+
+export NCCL_DEBUG="${NCCL_DEBUG:-INFO}"
+export NCCL_DEBUG_SUBSYS="${NCCL_DEBUG_SUBSYS:-INIT,NET,GRAPH}"
+
+# =============================================================
+# SOCKET INTERFACE - Keep mlx5_1 IP-side for control plane
+# =============================================================
+# Default route NIC is typically the management interface
+export GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-$(ip route | grep '^default' | awk '{print $NF}' | head -n 1)}
+export NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-${GLOO_SOCKET_IFNAME}}
+
+# =============================================================
+# TIMEOUTS - Adjusted for larger fabric
+# =============================================================
+export GLOO_TIMEOUT_MS="${GLOO_TIMEOUT_MS:-300000}"
+export TORCH_DIST_INIT_BARRIER_TIMEOUT="${TORCH_DIST_INIT_BARRIER_TIMEOUT:-300}"
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT="${SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT:-1200}"
+export SGLANG_DISAGGREGATION_WAITING_TIMEOUT="${SGLANG_DISAGGREGATION_WAITING_TIMEOUT:-1200}"
+
+# =============================================================
+# RUNTIME OPTIMIZATIONS
+# =============================================================
+export PYTHONDONTWRITEBYTECODE="${PYTHONDONTWRITEBYTECODE:-1}"
+export SGLANG_USE_AITER="${SGLANG_USE_AITER:-1}"
+export SGLANG_ROUTER_STDOUT_LOGS="${SGLANG_ROUTER_STDOUT_LOGS:-0}"
+
+if [[ -d /sgl-workspace/aiter ]]; then
+    export PYTHONPATH="/sgl-workspace/aiter:${PYTHONPATH:-}"
+fi

--- a/scripts/sglang_disagg/config/nic-selection.env.sh
+++ b/scripts/sglang_disagg/config/nic-selection.env.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# NIC selection prelude (NOT a CONFIG.md bucket).
+# Sourced first to set _DEFAULT_IB for Framework (NCCL_IB_HCA) and Connectors (IB_DEVICES).
+# Boundary: USE_CX7_NICS (Cluster) -> IB_DEVICES (Connectors) + NCCL_IB_HCA (Framework).
+
+# =============================================================
+# NIC MODE SELECTION
+# =============================================================
+# USE_CX7_NICS=1 — use all 8 CX7 400G rail NICs (default)
+# USE_CX7_NICS=0 — use mlx5_1 100G management NIC
+USE_CX7_NICS="${USE_CX7_NICS:-1}"
+
+if [[ "$USE_CX7_NICS" == "1" ]]; then
+    _DEFAULT_IB="mlx5_0,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_7,mlx5_8,mlx5_9"
+    echo "[mori_ep_env] NIC mode: CX7 multi-rail (${_DEFAULT_IB}) — same-rail nodes required"
+else
+    _DEFAULT_IB="mlx5_1"
+    echo "[mori_ep_env] NIC mode: mlx5_1 management NIC — cross-rail safe"
+fi
+
+# =============================================================
+# CORE DEVICE LIST
+# =============================================================
+export IB_DEVICES="${IB_DEVICES:-${_DEFAULT_IB}}"

--- a/scripts/sglang_disagg/config/runtime.defaults.sh
+++ b/scripts/sglang_disagg/config/runtime.defaults.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Entrypoint runtime defaults - aggregates Cluster/Launcher/Model inline ${VAR:-default}s
+# lifted from sglang_disagg_mori_io_ep.sh. See ../CONFIG.md for the bucket taxonomy.
+# TODO(stage2): split into per-bucket defaults (defaults-cluster/launcher/model).
+#
+# Sourced by the entrypoint after SCRIPT_DIR is set (line 7) and before first use (line 37).
+# SCRIPT_DIR must be set by the caller (used by MODELS_YAML below).
+
+# Cluster: rendezvous + topology
+MASTER_ADDR="${MASTER_ADDR:-localhost}"
+MASTER_PORT="${MASTER_PORT:-23731}"
+IPADDRS="${IPADDRS:-localhost}"
+GPUS_PER_NODE="${GPUS_PER_NODE:-8}"
+
+# Launcher: barrier + router readiness knobs
+BARRIER_PORT="${BARRIER_PORT:-4342}"
+SEARCH_SIGNAL="${SEARCH_SIGNAL:-The server is fired up and ready to roll!}"
+ROUTER_READY_TIMEOUT_SECONDS="${ROUTER_READY_TIMEOUT_SECONDS:-4000}"
+ROUTER_POLL_SLEEP_SECONDS="${ROUTER_POLL_SLEEP_SECONDS:-10}"
+
+# Model: per-worker TP size + models.yaml path
+GENERIC_TP_SIZE="${GENERIC_TP_SIZE:-8}"
+MODELS_YAML="${MODELS_YAML:-${SCRIPT_DIR}/models.yaml}"

--- a/scripts/sglang_disagg/mori_ep_env.sh
+++ b/scripts/sglang_disagg/mori_ep_env.sh
@@ -1,124 +1,17 @@
 #!/bin/bash
 # NCCL/MORI RDMA configuration for multi-NIC nodes.
 # Toggle USE_CX7_NICS to switch between CX7 rail NICs and mlx5_1 management NIC.
+#
+# This file is now a thin aggregator: the config was extracted into config/
+# (bucket-aligned). It sources the pieces in dependency order. The single
+# `source mori_ep_env.sh` call in the entrypoint keeps working unchanged.
+# See config/README.md and ../CONFIG.md.
 
-# =============================================================
-# NIC MODE SELECTION
-# =============================================================
-# USE_CX7_NICS=1 — use all 8 CX7 400G rail NICs (default)
-# USE_CX7_NICS=0 — use mlx5_1 100G management NIC
-USE_CX7_NICS="${USE_CX7_NICS:-1}"
+_MORI_ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-if [[ "$USE_CX7_NICS" == "1" ]]; then
-    _DEFAULT_IB="mlx5_0,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_7,mlx5_8,mlx5_9"
-    echo "[mori_ep_env] NIC mode: CX7 multi-rail (${_DEFAULT_IB}) — same-rail nodes required"
-else
-    _DEFAULT_IB="mlx5_1"
-    echo "[mori_ep_env] NIC mode: mlx5_1 management NIC — cross-rail safe"
-fi
-
-# =============================================================
-# CORE DEVICE LIST
-# =============================================================
-export IB_DEVICES="${IB_DEVICES:-${_DEFAULT_IB}}"
-
-# =============================================================
-# NCCL CONFIGURATION
-# =============================================================
-export NCCL_IB_HCA="${NCCL_IB_HCA:-${_DEFAULT_IB}}"
-
-# Critical: RoCE v2 with IPv4 routing (GID index 3 is typical)
-export NCCL_IB_GID_INDEX="${NCCL_IB_GID_INDEX:-3}"
-
-# Allow NCCL to use multiple NICs per GPU when beneficial
-export NCCL_CROSS_NIC="${NCCL_CROSS_NIC:-1}"
-
-# GPUDirect RDMA - level 3 enables PXB (PCI Bridge) crossing
-export NCCL_NET_GDR_LEVEL="${NCCL_NET_GDR_LEVEL:-3}"
-
-# Use IB transport (force IB over Socket)
-export NCCL_IB_DISABLE="${NCCL_IB_DISABLE:-0}"
-
-# Multiple QPs per connection for CX7 - improves parallelism
-# CX7 NDR can saturate with more QPs (default is 1, recommend 4-8)
-export NCCL_IB_QPS_PER_CONNECTION="${NCCL_IB_QPS_PER_CONNECTION:-4}"
-
-# Split data across QPs for better load balancing
-export NCCL_IB_SPLIT_DATA_ON_QPS="${NCCL_IB_SPLIT_DATA_ON_QPS:-1}"
-
-# Increase chunk size to better utilize CX7 bandwidth (default 128KB)
-# For NDR 400G, larger chunks reduce overhead
-export NCCL_BUFFSIZE="${NCCL_BUFFSIZE:-8388608}"   # 8MB buffer
-
-# Timeout for IB operations (increase for large clusters)
-export NCCL_IB_TIMEOUT="${NCCL_IB_TIMEOUT:-22}"
-export NCCL_IB_RETRY_CNT="${NCCL_IB_RETRY_CNT:-7}"
-
-# Service Level for QoS (if your fabric uses SL-based QoS)
-export NCCL_IB_SL="${NCCL_IB_SL:-0}"
-
-# Traffic Class for RoCE QoS (DSCP 26 = AF31, common for RDMA)
-export NCCL_IB_TC="${NCCL_IB_TC:-106}"  # = DSCP 26 << 2
-
-# PCIe relaxed ordering for better performance
-export NCCL_IB_PCI_RELAXED_ORDERING="${NCCL_IB_PCI_RELAXED_ORDERING:-1}"
-
-# Adaptive routing (if fabric supports it)
-export NCCL_IB_ADAPTIVE_ROUTING="${NCCL_IB_ADAPTIVE_ROUTING:-1}"
-
-# Enable NCCL topology auto-detection
-export NCCL_TOPO_DUMP_FILE="${NCCL_TOPO_DUMP_FILE:-/tmp/nccl_topo.xml}"
-
-export NCCL_DEBUG="${NCCL_DEBUG:-INFO}"
-export NCCL_DEBUG_SUBSYS="${NCCL_DEBUG_SUBSYS:-INIT,NET,GRAPH}"
-
-# =============================================================
-# MORI CONFIGURATION - Use all CX7 NICs for expert parallelism
-# =============================================================
-# MoRI uses the same NIC set as NCCL
-export MORI_RDMA_DEVICES="${MORI_RDMA_DEVICES:-${_DEFAULT_IB}}"
-
-# Match NCCL GID index for consistency
-export MORI_IB_GID_INDEX="${MORI_IB_GID_INDEX:-3}"
-
-# QPs per connection for MoRI (similar reasoning as NCCL)
-export MORI_QPS_PER_CONNECTION="${MORI_QPS_PER_CONNECTION:-4}"
-
-# =============================================================
-# SOCKET INTERFACE - Keep mlx5_1 IP-side for control plane
-# =============================================================
-# Default route NIC is typically the management interface
-export GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-$(ip route | grep '^default' | awk '{print $NF}' | head -n 1)}
-export NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-${GLOO_SOCKET_IFNAME}}
-export MORI_SOCKET_IFNAME=${MORI_SOCKET_IFNAME:-${GLOO_SOCKET_IFNAME}}
-
-# =============================================================
-# TIMEOUTS - Adjusted for larger fabric
-# =============================================================
-export GLOO_TIMEOUT_MS="${GLOO_TIMEOUT_MS:-300000}"
-export TORCH_DIST_INIT_BARRIER_TIMEOUT="${TORCH_DIST_INIT_BARRIER_TIMEOUT:-300}"
-export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT="${SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT:-1200}"
-export SGLANG_DISAGGREGATION_WAITING_TIMEOUT="${SGLANG_DISAGGREGATION_WAITING_TIMEOUT:-1200}"
-
-# =============================================================
-# RUNTIME OPTIMIZATIONS
-# =============================================================
-export PYTHONDONTWRITEBYTECODE="${PYTHONDONTWRITEBYTECODE:-1}"
-export SGLANG_USE_AITER="${SGLANG_USE_AITER:-1}"
-export SGLANG_ROUTER_STDOUT_LOGS="${SGLANG_ROUTER_STDOUT_LOGS:-0}"
-
-if [[ -d /sgl-workspace/aiter ]]; then
-    export PYTHONPATH="/sgl-workspace/aiter:${PYTHONPATH:-}"
-fi
-
-# MoRI EP tuning (DP_MODE=1 only)
-if [[ "${DP_MODE:-}" == "1" ]]; then
-    export SGLANG_MORI_FP8_DISP="${SGLANG_MORI_FP8_DISP:-True}"
-    [[ "${MODEL_NAME:-}" == *mxfp4* ]] && export SGLANG_MORI_FP8_DISP=False
-    export SGLANG_MORI_FP4_DISP="${SGLANG_MORI_FP4_DISP:-False}"
-    export SGLANG_MORI_FP8_COMB="${SGLANG_MORI_FP8_COMB:-False}"
-    export MORI_MAX_DISPATCH_TOKENS_DECODE="${MORI_MAX_DISPATCH_TOKENS_DECODE:-160}"
-    export SGLANG_MORI_DISPATCH_INTER_KERNEL_SWITCH_THRESHOLD="${SGLANG_MORI_DISPATCH_INTER_KERNEL_SWITCH_THRESHOLD:-$((MORI_MAX_DISPATCH_TOKENS_DECODE * 2))}"
-    # MoRI shmem heap: 4 GiB default is too small for EP>=32; use 16 GiB.
-    export MORI_SHMEM_HEAP_SIZE="${MORI_SHMEM_HEAP_SIZE:-17179869184}"
-fi
+# shellcheck disable=SC1091
+source "${_MORI_ENV_DIR}/config/nic-selection.env.sh"
+# shellcheck disable=SC1091
+source "${_MORI_ENV_DIR}/config/framework.env.sh"
+# shellcheck disable=SC1091
+source "${_MORI_ENV_DIR}/config/connectors.env.sh"

--- a/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
+++ b/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
@@ -6,6 +6,10 @@
 _MORI_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_DIR="${_MORI_SCRIPT_DIR}"
 
+# Cluster/Launcher/Model inline defaults (extracted). Must be sourced before first use.
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/config/runtime.defaults.sh"
+
 # -----------------------------------------------------------------------------
 # DP_MODE=1 allowlist (MoRI IO EP). Must stay in sync with run_xPyD_models.slurm.
 # -----------------------------------------------------------------------------
@@ -34,8 +38,6 @@ mori_dp_mode1_allowed_models_lines() {
 # Environment Configuration
 # =============================================================================
 
-MASTER_ADDR="${MASTER_ADDR:-localhost}"
-MASTER_PORT="${MASTER_PORT:-23731}"
 NODE_RANK="${NODE_RANK:-0}"
 MODEL_PATH=$MODEL_PATH
 MODEL_NAME="${MODEL_NAME:-}"
@@ -66,8 +68,6 @@ if [[ "$DP_MODE" == "1" ]] && ! mori_model_allows_dp_mode_one "$MODEL_NAME"; the
     exit 1
 fi
 
-IPADDRS="${IPADDRS:-localhost}"
-BARRIER_PORT="${BARRIER_PORT:-4342}"
 # IB_DEVICES controls --disaggregation-ib-device (RDMA NICs for KV-cache transfer).
 # Default is set in mori_ep_env.sh (sourced below). Override: set IB_DEVICES env var.
 # Note: CX7 rail NICs require same-rail nodes; mlx5_1 (mgmt NIC) is cross-rail safe.
@@ -96,9 +96,6 @@ fi
 # DP_MODE=0: CLI --tp-size is IO_EP_TP_SIZE (default 8) on every worker; PREFILL_EP_SIZE/DECODE_EP_SIZE
 # still scale with xP/yD×GPUS_PER_NODE for MoRI env (not passed as CLI unless DP_MODE=1).
 # DP_MODE=1: --tp-size scales with cluster; --dp-size/--ep-size on CLI (same total degree as Nnodes×GPUS_PER_NODE).
-GPUS_PER_NODE="${GPUS_PER_NODE:-8}"
-GENERIC_TP_SIZE="${GENERIC_TP_SIZE:-8}"
-
 if [[ "$DP_MODE" == "1" ]]; then
     PREFILL_TP_SIZE=$((xP * GPUS_PER_NODE))
     DECODE_TP_SIZE=$((yD * GPUS_PER_NODE))
@@ -122,8 +119,6 @@ export PREFILL_TP_SIZE DECODE_TP_SIZE
 # =============================================================================
 # Model-Specific Configuration from YAML
 # =============================================================================
-
-MODELS_YAML="${MODELS_YAML:-${SCRIPT_DIR}/models.yaml}"
 
 if [[ ! -f "$MODELS_YAML" ]]; then
     echo "ERROR: models.yaml not found at $MODELS_YAML"
@@ -386,9 +381,8 @@ if [[ "$NODE_RANK" -eq 0 ]]; then
     # DP_MODE=0: wait for SEARCH_SIGNAL in every prefill (NODE 0..xP-1) and decode (NODE xP..xP+yD-1) log.
     # DP_MODE=1: wait for master prefill NODE 0 + master decode NODE xP only.
     # Requires shared /run_logs across nodes.
-    SEARCH_SIGNAL="${SEARCH_SIGNAL:-The server is fired up and ready to roll!}"
-    ROUTER_READY_TIMEOUT_SECONDS="${ROUTER_READY_TIMEOUT_SECONDS:-4000}"
-    ROUTER_POLL_SLEEP_SECONDS="${ROUTER_POLL_SLEEP_SECONDS:-10}"
+    # SEARCH_SIGNAL / ROUTER_READY_TIMEOUT_SECONDS / ROUTER_POLL_SLEEP_SECONDS
+    # defaults are set in config/runtime.defaults.sh (sourced at the top).
     _wait_start_ts=$(date +%s)
     _runlog="/run_logs/${SLURM_JOB_ID:-0}"
 


### PR DESCRIPTION
Stage 1 of a staged refactor of `scripts/sglang_disagg/`: document the configuration surface, then extract it into bucket-aligned files. No behavior change.

This is independent of #206 (GLM-5.1 wideEP, `scripts/vllm_dissag/`); the two branches share no files.

## What lands

- `CONFIG.md` — every env var, CLI parameter and config value the directory uses, grouped into 7 functional buckets (Cluster, Framework, Connectors, Parser, Benchmarking, Launcher, Model), pinned to the current commit.
- `DESIGN.md` — high-level overview, links into `CONFIG.md`.
- `ROADMAP.md` — the three staged steps (extract, categorize and validate, generalize) with diagrams, so the intent behind this PR is reviewable before later stages land.
- `config/{nic-selection,framework,connectors}.env.sh` and `config/runtime.defaults.sh` — the extracted config, mapped to the `CONFIG.md` buckets.

`mori_ep_env.sh` drops from 124 lines to 17 and becomes a thin aggregator that sources the three env files in dependency order (nic-selection, then framework, then connectors). The single `source mori_ep_env.sh` call in the entrypoint is unchanged, so callers see nothing different. `sglang_disagg_mori_io_ep.sh` sources `config/runtime.defaults.sh` near the top, before first use, replacing its inline `${VAR:-default}` assignments.

## Why

The config was spread across a 124-line env script and inline defaults scattered through a 400-line entrypoint, with no inventory of what is actually tunable. Splitting the two makes the surface auditable and is a precondition for the later stages, which add validation and generalize the path beyond MoRI IO EP.

## Test plan

Behavior preservation was checked by resolving the environment both ways and diffing, rather than by inspection:

- [x] `source mori_ep_env.sh` before and after, across all four `DP_MODE` x `USE_CX7_NICS` combinations: resolved env identical every time (31 vars for `DP_MODE=0`, 37 for `DP_MODE=1`, which adds the MoRI EP tuning block).
- [x] Override precedence unchanged: pre-setting `NCCL_IB_GID_INDEX`, `IB_DEVICES` or `SGLANG_USE_AITER` still wins over the defaults, matching the old file.
- [x] `bash -n` clean on all six changed or added shell files.

Only `scripts/sglang_disagg/` is touched, so no vLLM disagg recipe or image is affected.
