### PR TITLE
Add vLLM + DeepEP expert-parallel inference Dockerfile

### DIFF
--- a/docker/vllm_deepep_v2_inference.ubuntu.amd.Dockerfile
+++ b/docker/vllm_deepep_v2_inference.ubuntu.amd.Dockerfile
@@ -1,0 +1,217 @@
+# CONTEXT {'gpu_vendor': 'AMD', 'guest_os': 'UBUNTU'}
+###############################################################################
+#
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#################################################################################
+# =============================================================================
+# vllm_deepep_v2_inference.ubuntu.amd.Dockerfile
+#   vLLM expert-parallel serving over DeepEP v2 on MI350X (gfx950), validated
+#   with DeepSeek-R1 FP8 at TP=1 / DP=8 / EP=8 on a single node.
+#
+#   docker build -f docker/vllm_deepep_v2_inference.ubuntu.amd.Dockerfile \
+#     --build-arg DEEPEP_REPO=<url> --build-arg DEEPEP_COMMIT=<sha> \
+#     -t <your-registry>/vllm-deepep-v2:local .
+#
+#   Stages, each gated so a rebuild only pays for what changed:
+#     DEEPEP_REPO / DEEPEP_COMMIT  DeepEP v2 build (EP_TARGET_HIP=1,
+#                                  EP_DISABLE_LEGACY=1). Required; the source is
+#                                  not vendored here.
+#     AITER_COMMIT                 AITER, with the zero-token get_ksplit guard.
+#     RDMA_CORE_VERSION            rdma-core from source (default 63.0),
+#                                  replacing the distro packages. Empty keeps
+#                                  the base image's.
+#     ENABLE_TORCHVISION_STUB      Text-only torchvision surface, for ROCm bases
+#                                  whose torchvision ABI breaks `import vllm`.
+#
+#   Runtime notes that are easy to lose:
+#     * NCCL_CUMEM_ENABLE=1 is mandatory. Without VMM, RCCL answers
+#       "Communicator does not support symmetric memory" and the ElasticBuffer
+#       is never created.
+#     * On a single node set EP_DISABLE_GIN=1. DeepEP v2 moves no payload
+#       through GIN inside one XGMI domain -- is_scaleup_nvlink is true and the
+#       barrier and dispatch/combine run over symmetric memory -- but the buffer
+#       constructor still asserts on ginType and reserves queue pairs unless GIN
+#       is disabled. Leaving it on additionally requires /dev/infiniband,
+#       NCCL_GIN_TYPE=2 and EP_GIN_QUEUE_DEPTH=0.
+#     * Mount the JIT caches. AITER tunes GEMM shapes at run time behind a
+#       global build lock, and with data parallelism one rank tunes while the
+#       others wait in the collective:
+#         -v <host>/aiter_build:/opt/aiter-v2/aiter/jit/build
+#         -v <host>/aiter_configs:/tmp/aiter_configs
+#         -v <host>/deep_ep:/root/.deep_ep
+# =============================================================================
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG PYTHON=/opt/venv/bin/python
+ARG GPU_TARGETS=gfx950
+
+ARG DEEPEP_REPO
+ARG DEEPEP_COMMIT
+ARG AITER_REPO=https://github.com/ROCm/aiter.git
+ARG AITER_COMMIT=d9e5ef7ce08ee7045d583aed768cff41aa9210fe
+ARG RDMA_CORE_VERSION=63.0
+ARG ENABLE_TORCHVISION_STUB=1
+ARG VLLM_WHEEL
+
+ENV VLLM_TARGET_DEVICE=rocm \
+    PYTORCH_ROCM_ARCH=${GPU_TARGETS} \
+    PYTHONPATH=/opt/rocm/share/amd_smi \
+    EP_TARGET_HIP=1 \
+    EP_DISABLE_LEGACY=1
+
+###############################################################################
+# 1) DeepEP v2 and vLLM.
+###############################################################################
+RUN test -n "${DEEPEP_REPO}" || { echo "DEEPEP_REPO is required"; exit 1; }; \
+    set -e; \
+    git clone "${DEEPEP_REPO}" /opt/deepep-v2; \
+    git -C /opt/deepep-v2 checkout -f "${DEEPEP_COMMIT}"; \
+    cd /opt/deepep-v2; \
+    ${PYTHON} setup.py build; \
+    so="$(find build -name '_C.cpython-*.so' | sort | tail -1)"; \
+    test -n "${so}"; \
+    cp "${so}" deep_ep/; \
+    ${PYTHON} -m pip install --no-deps --no-build-isolation .; \
+    site_dir="$(${PYTHON} -c "import site; print(site.getsitepackages()[0] + '/deep_ep')")"; \
+    cp -a deep_ep/include/. "${site_dir}/include/"
+
+COPY ${VLLM_WHEEL} /tmp/vllm.whl
+RUN ${PYTHON} -m pip install --no-deps /tmp/vllm.whl && rm -f /tmp/vllm.whl
+
+###############################################################################
+# 2) Text-only torchvision surface.
+#
+# Some ROCm bases ship a torchvision whose ABI does not match the installed
+# torch. vLLM imports it transitively through a multimodal config even for
+# text-only models, so `import vllm` fails before serving starts.
+###############################################################################
+RUN if [ "${ENABLE_TORCHVISION_STUB}" = "1" ]; then \
+      set -e; \
+      site_dir="$(${PYTHON} -c "import site; print(site.getsitepackages()[0])")"; \
+      ${PYTHON} -m pip uninstall -y torchvision || true; \
+      mkdir -p "${site_dir}/torchvision/transforms"; \
+      printf '%s\n' \
+        '"""Text-only torchvision surface: import-compatible, no operators."""' \
+        '__version__ = "0.0.0+text-only"' \
+        'def _unsupported(*args, **kwargs):' \
+        '    raise NotImplementedError("text-only torchvision stub")' \
+        > "${site_dir}/torchvision/__init__.py"; \
+      printf '%s\n' \
+        'from enum import Enum' \
+        'class InterpolationMode(Enum):' \
+        '    NEAREST = "nearest"' \
+        '    BILINEAR = "bilinear"' \
+        '    BICUBIC = "bicubic"' \
+        > "${site_dir}/torchvision/transforms/__init__.py"; \
+      ${PYTHON} -c "from torchvision.transforms import InterpolationMode; print('TORCHVISION_STUB_OK')"; \
+    else \
+      echo "TORCHVISION_STUB <disabled>"; \
+    fi
+
+###############################################################################
+# 3) AITER.
+#
+# The get_ksplit guard returns 0 when a split has no work instead of dividing
+# by zero, which a data-parallel profile microbatch can trigger.
+###############################################################################
+RUN set -e; \
+    git clone "${AITER_REPO}" /opt/aiter-v2; \
+    git -C /opt/aiter-v2 checkout -f "${AITER_COMMIT}"; \
+    ${PYTHON} - <<'PY'
+path = "/opt/aiter-v2/aiter/fused_moe.py"
+src = open(path).read()
+needle = "    tg_num = tgN * tgM\n"
+guard = (
+    "    tg_num = tgN * tgM\n"
+    "    # A data-parallel profile microbatch can contain no tokens on this\n"
+    "    # rank. There is no work to split in that case.\n"
+    "    if tg_num == 0:\n"
+    "        return 0\n"
+)
+if "if tg_num == 0:" not in src:
+    assert needle in src, "get_ksplit prologue not found"
+    open(path, "w").write(src.replace(needle, guard, 1))
+print("AITER_KSPLIT_GUARD_OK")
+PY
+RUN set -e; \
+    git -C /opt/aiter-v2 submodule update --init --recursive; \
+    cd /opt/aiter-v2; \
+    ${PYTHON} -m pip install --no-cache-dir -r requirements.txt; \
+    AITER_USE_SYSTEM_TRITON=1 GPU_ARCHS=${GPU_TARGETS} \
+      ${PYTHON} -m pip install --no-cache-dir --no-build-isolation -e .
+
+###############################################################################
+# 4) rdma-core from source, replacing the distro packages and dropping the
+#    vendor bnxt_re provider.
+#
+#    Keep this stage last, and run every apt command before the
+#    `dpkg -r --force-all` below: the removal leaves dependents with dangling
+#    deps and later apt invocations abort.
+###############################################################################
+RUN if [ -n "${RDMA_CORE_VERSION}" ]; then \
+      set -e; \
+      apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 update; \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git ca-certificates cmake ninja-build build-essential pkg-config make \
+        libnl-3-dev libnl-route-3-dev libudev-dev libssl-dev libsystemd-dev \
+        python3-docutils pandoc; \
+      git clone --depth 1 --branch "v${RDMA_CORE_VERSION}" \
+        https://github.com/linux-rdma/rdma-core.git /tmp/rdma-core; \
+      mkdir -p /tmp/rdma-core/build && cd /tmp/rdma-core/build; \
+      cmake -GNinja \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu \
+        -DCMAKE_INSTALL_SYSCONFDIR=/etc \
+        -DCMAKE_INSTALL_RUNDIR=/run \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DNO_PYVERBS=1 \
+        ..; \
+      ninja -j"$(nproc)"; \
+      DEBIAN_FRONTEND=noninteractive apt-get purge -y python3-docutils pandoc; \
+      DEBIAN_FRONTEND=noninteractive apt-get autoremove -y; \
+      rm -rf /var/lib/apt/lists/*; \
+      to_remove=""; \
+      for p in ibverbs-providers libibverbs1 libibverbs-dev ibverbs-utils \
+               librdmacm1 librdmacm-dev rdma-core libibumad3 infiniband-diags; do \
+        dpkg-query -W -f='${Status}' "$p" 2>/dev/null | grep -q "install ok installed" \
+          && to_remove="$to_remove $p"; \
+      done; \
+      [ -n "$to_remove" ] && dpkg -r --force-all $to_remove; \
+      ninja install; \
+      rm -f /usr/local/lib/x86_64-linux-gnu/libbnxt_re-rdmav34.so \
+            /usr/local/lib/libbnxt_re-rdmav34.so; \
+      ldconfig; \
+      cd / && rm -rf /tmp/rdma-core; \
+      echo "IBVERBS_PROVIDERS $(ls /usr/lib/x86_64-linux-gnu/libibverbs/ 2>/dev/null | tr '\n' ' ')"; \
+    else \
+      echo "RDMA_CORE_FROM_SOURCE <disabled, keeping base rdma-core>"; \
+    fi
+
+RUN ${PYTHON} -c "import deep_ep, torch, vllm; assert torch.version.hip; print('VLLM_DEEPEP_V2_BUILD_OK')"
+
+ENTRYPOINT ["vllm"]


### PR DESCRIPTION
## Summary

Adds `docker/vllm_deepep_v2_inference.ubuntu.amd.Dockerfile`: a vLLM image that
serves mixture-of-experts models over DeepEP v2 on MI350X (gfx950). Validated
with DeepSeek-R1 FP8 at `TP=1 / DP=8 / EP=8` on a single node, and benchmarked
on DeepSeek-V2-Lite.

Follows the staging pattern of `sglang_disagg_inference_full_overlay`: every
component is a gated stage, so a rebuild only pays for what changed.

- `DEEPEP_REPO` / `DEEPEP_COMMIT` — DeepEP. Required, and taken as build args
  rather than vendored, since the source is not public.
- `AITER_COMMIT` — AITER plus the zero-token `get_ksplit` guard, which a
  data-parallel profile microbatch can otherwise trip into a division by zero.
- `RDMA_CORE_VERSION` — rdma-core from source, default `63.0`, replacing the
  distro packages and dropping the vendor `bnxt_re` provider. An empty value
  keeps the base image's.
- `ENABLE_TORCHVISION_STUB` — text-only torchvision surface, for ROCm bases
  whose torchvision ABI breaks `import vllm` through a multimodal config.

## Runtime notes captured in the header

These are the settings that cost the most time to rediscover:

- `NCCL_CUMEM_ENABLE=1` is mandatory. Without VMM, RCCL answers
  `Communicator does not support symmetric memory` and the ElasticBuffer is
  never created.
- `EP_DISABLE_GIN=1` on a single node. DeepEP v2 moves no payload through GIN
  inside one XGMI domain — `is_scaleup_nvlink` is true and the barrier and
  dispatch/combine run over symmetric memory — but the buffer constructor still
  asserts on `ginType` and reserves queue pairs unless GIN is disabled. Leaving
  it on additionally requires `/dev/infiniband`, `NCCL_GIN_TYPE=2` and
  `EP_GIN_QUEUE_DEPTH=0`.
- Mount the JIT caches. AITER tunes GEMM shapes at run time behind a global
  build lock; with data parallelism one rank tunes while the rest wait in the
  collective, which shows up as P99 TTFT in the tens of seconds until the cache
  covers the shapes in play.

## Test

Built and run on 8x MI350X. DeepSeek-R1 FP8 generates correctly. DeepSeek-V2-Lite
reaches 633 / 1238 / 2371 total tok/s at concurrency 8 / 16 / 32 for
`in=256, out=128`, measured after the tuning cache converges.

Made with [Cursor](https://cursor.com)