### PR TITLE
Add vLLM DeepEP expert-parallel inference Dockerfile

### DIFF
--- a/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
+++ b/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
@@ -57,12 +57,14 @@
 #     * NCCL_CUMEM_ENABLE=1 is mandatory. Without VMM, RCCL answers
 #       "Communicator does not support symmetric memory" and the ElasticBuffer
 #       is never created.
-#     * On a single node set EP_DISABLE_GIN=1. DeepEP moves no payload
-#       through GIN inside one XGMI domain -- is_scaleup_nvlink is true and the
+#     * GIN is a deliberate choice on a single node. DeepEP moves no payload
+#       through it inside one XGMI domain -- is_scaleup_nvlink is true and the
 #       barrier and dispatch/combine run over symmetric memory -- but the buffer
 #       constructor still asserts on ginType and reserves queue pairs unless GIN
-#       is disabled. Leaving it on additionally requires /dev/infiniband,
-#       NCCL_GIN_TYPE=2 and EP_GIN_QUEUE_DEPTH=0.
+#       is disabled. Keeping it on (NCCL_GIN_TYPE=2, EP_GIN_QUEUE_DEPTH=0)
+#       exercises the path that matters for scale-out and requires
+#       --device=/dev/infiniband and --ulimit memlock=-1 on the container;
+#       EP_DISABLE_GIN=1 avoids both but tests a mode nobody deploys.
 #     * Mount the JIT caches. AITER tunes GEMM shapes at run time behind a
 #       global build lock, and with data parallelism one rank tunes while the
 #       others wait in the collective:
@@ -257,4 +259,8 @@ RUN if [ -n "${RDMA_CORE_VERSION}" ]; then \
 
 RUN ${PYTHON} -c "import deep_ep, torch, vllm; assert torch.version.hip; print('VLLM_DEEPEP_BUILD_OK')"
 
-ENTRYPOINT ["vllm"]
+# Clear the base image's entrypoint, as the sibling vLLM images do. madengine
+# keeps a container alive with `docker run ... <image> cat` and then drives it
+# with `docker exec`; any ENTRYPOINT here turns that keepalive into
+# `<entrypoint> cat`, which exits immediately and takes the run with it.
+ENTRYPOINT []

--- a/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
+++ b/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
@@ -32,10 +32,11 @@
 #   docker build -f docker/vllm_deepep_inference.ubuntu.amd.Dockerfile \
 #     --build-arg DEEPEP_REPO=<url> --build-arg DEEPEP_COMMIT=<sha> \
 #     --build-arg VLLM_WHEEL=<path/to/vllm-*.whl relative to the build context> \
-#     # VLLM_WHEEL defaults to vllm.whl in the context root. The wheel must be
-#     # inside the build context; docker cannot check a COPY source in advance,
-#     # so a missing file fails at that COPY.
 #     -t <your-registry>/vllm-deepep:local .
+#
+#   VLLM_WHEEL defaults to vllm.whl in the context root. The wheel must be
+#   inside the build context; docker cannot check a COPY source in advance, so
+#   a missing file fails at that COPY.
 #
 #   BASE_IMAGE defaults to the same ROCm vLLM base the sibling disagg image
 #   uses. This recipe was validated against a THERock ROCm 7.14 / Torch 2.11
@@ -75,16 +76,13 @@ FROM ${BASE_IMAGE}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Build args are declared immediately before the stage that consumes them, not
+# in one block up top: an ARG in scope becomes part of the cache key of every
+# following layer, so hoisting them all would make a change to AITER_COMMIT (or
+# the wheel path, or the rdma-core version) rebuild DeepEP and everything after
+# it -- defeating the staged-rebuild property this file is organised around.
 ARG PYTHON=/opt/venv/bin/python
 ARG GPU_TARGETS=gfx950
-
-ARG DEEPEP_REPO
-ARG DEEPEP_COMMIT
-ARG AITER_REPO=https://github.com/ROCm/aiter.git
-ARG AITER_COMMIT=d9e5ef7ce08ee7045d583aed768cff41aa9210fe
-ARG RDMA_CORE_VERSION=63.0
-ARG ENABLE_TORCHVISION_STUB=1
-ARG VLLM_WHEEL=vllm.whl
 
 ENV VLLM_TARGET_DEVICE=rocm \
     PYTORCH_ROCM_ARCH=${GPU_TARGETS} \
@@ -95,6 +93,8 @@ ENV VLLM_TARGET_DEVICE=rocm \
 ###############################################################################
 # 1) DeepEP and vLLM.
 ###############################################################################
+ARG DEEPEP_REPO
+ARG DEEPEP_COMMIT
 RUN test -n "${DEEPEP_REPO}" || { echo "DEEPEP_REPO is required"; exit 1; }; \
     test -n "${DEEPEP_COMMIT}" || { echo "DEEPEP_COMMIT is required"; exit 1; }; \
     set -e; \
@@ -110,6 +110,7 @@ RUN test -n "${DEEPEP_REPO}" || { echo "DEEPEP_REPO is required"; exit 1; }; \
     mkdir -p "${site_dir}/include"; \
     cp -a deep_ep/include/. "${site_dir}/include/"
 
+ARG VLLM_WHEEL=vllm.whl
 COPY ${VLLM_WHEEL} /tmp/vllm.whl
 RUN ${PYTHON} -m pip install --no-deps /tmp/vllm.whl && rm -f /tmp/vllm.whl
 
@@ -120,6 +121,7 @@ RUN ${PYTHON} -m pip install --no-deps /tmp/vllm.whl && rm -f /tmp/vllm.whl
 # torch. vLLM imports it transitively through a multimodal config even for
 # text-only models, so `import vllm` fails before serving starts.
 ###############################################################################
+ARG ENABLE_TORCHVISION_STUB=1
 RUN if [ "${ENABLE_TORCHVISION_STUB}" = "1" ]; then \
       set -e; \
       site_dir="$(${PYTHON} -c "import site; print(site.getsitepackages()[0])")"; \
@@ -149,6 +151,8 @@ RUN if [ "${ENABLE_TORCHVISION_STUB}" = "1" ]; then \
 # The get_ksplit guard returns 0 when a split has no work instead of dividing
 # by zero, which a data-parallel profile microbatch can trigger.
 ###############################################################################
+ARG AITER_REPO=https://github.com/ROCm/aiter.git
+ARG AITER_COMMIT=d9e5ef7ce08ee7045d583aed768cff41aa9210fe
 RUN set -e; \
     git clone "${AITER_REPO}" /opt/aiter; \
     git -C /opt/aiter checkout -f "${AITER_COMMIT}"; \
@@ -183,6 +187,7 @@ RUN set -e; \
 #    `dpkg -r --force-all` below: the removal leaves dependents with dangling
 #    deps and later apt invocations abort.
 ###############################################################################
+ARG RDMA_CORE_VERSION=63.0
 RUN if [ -n "${RDMA_CORE_VERSION}" ]; then \
       set -e; \
       apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 update; \
@@ -213,10 +218,24 @@ RUN if [ -n "${RDMA_CORE_VERSION}" ]; then \
       done; \
       [ -n "$to_remove" ] && dpkg -r --force-all $to_remove; \
       ninja install; \
-      rm -f /usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so \
-            /usr/local/lib/x86_64-linux-gnu/libbnxt_re-rdmav34.so \
-            /usr/local/lib/libbnxt_re-rdmav34.so; \
+      : "Drop every bnxt_re provider except the one this build just installed."; \
+      : "The base image can ship an out-of-tree vendor provider whose name is"; \
+      : "neither predictable nor tied to the rdma-core ABI (observed:"; \
+      : "libbnxt_re-235.2.86.0.so, alongside older -rdmavNN.so builds). If one"; \
+      : "survives, libibverbs loads it against the new rdma-core and every run"; \
+      : "warns 'Driver bnxt_re does not support the kernel ABI'. Matching a"; \
+      : "hard-coded ABI suffix is wrong twice over: it misses vendor names, and"; \
+      : "it goes stale whenever IBVERBS_PABI_VERSION moves (v63 installs"; \
+      : "-rdmav59.so). Deleting the symlink alone is also not enough -- ldconfig"; \
+      : "regenerates SONAME links from the real file, so the .so itself must go."; \
+      keep="$(ls -1 /usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav*.so 2>/dev/null | tail -1)"; \
+      test -n "${keep}" || { echo "no bnxt_re provider installed by rdma-core ${RDMA_CORE_VERSION}"; exit 1; }; \
+      find /usr/lib/x86_64-linux-gnu/libibverbs /usr/local/lib \
+           /usr/local/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu \
+           -maxdepth 1 -name 'libbnxt_re*.so*' 2>/dev/null \
+        | while read -r f; do [ "${f}" = "${keep}" ] || rm -f "${f}"; done; \
       ldconfig; \
+      echo "IBVERBS_BNXT_KEPT ${keep}"; \
       cd / && rm -rf /tmp/rdma-core; \
       echo "IBVERBS_PROVIDERS $(ls /usr/lib/x86_64-linux-gnu/libibverbs/ 2>/dev/null | tr '\n' ' ')"; \
     else \

--- a/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
+++ b/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
@@ -183,9 +183,9 @@ RUN set -e; \
 # 4) rdma-core from source, replacing the distro packages and dropping the
 #    vendor bnxt_re provider.
 #
-#    Keep this stage last, and run every apt command before the
-#    `dpkg -r --force-all` below: the removal leaves dependents with dangling
-#    deps and later apt invocations abort.
+#    Keep this stage last. It installs over the distro rdma-core rather than
+#    removing it: removing libibverbs1 and friends would leave every dependent
+#    with an unmet dependency and break apt here and in any downstream image.
 ###############################################################################
 ARG RDMA_CORE_VERSION=63.0
 RUN if [ -n "${RDMA_CORE_VERSION}" ]; then \
@@ -210,30 +210,43 @@ RUN if [ -n "${RDMA_CORE_VERSION}" ]; then \
       DEBIAN_FRONTEND=noninteractive apt-get purge -y python3-docutils pandoc; \
       DEBIAN_FRONTEND=noninteractive apt-get autoremove -y; \
       rm -rf /var/lib/apt/lists/*; \
-      to_remove=""; \
-      for p in ibverbs-providers libibverbs1 libibverbs-dev ibverbs-utils \
-               librdmacm1 librdmacm-dev rdma-core libibumad3 infiniband-diags; do \
-        dpkg-query -W -f='${Status}' "$p" 2>/dev/null | grep -q "install ok installed" \
-          && to_remove="$to_remove $p"; \
-      done; \
-      [ -n "$to_remove" ] && dpkg -r --force-all $to_remove; \
+      : "Install over the distro packages rather than removing them. dpkg -r"; \
+      : "--force-all on libibverbs1 and friends leaves every dependent with an"; \
+      : "unmet dependency, so any later apt operation -- including one in a"; \
+      : "downstream image built FROM this one -- aborts. The from-source"; \
+      : "install targets the same prefix and shadows those files, and the"; \
+      : "provider cleanup below removes the part that actually matters, so the"; \
+      : "removal bought nothing that is not handled here."; \
       ninja install; \
       : "Drop every bnxt_re provider except the one this build just installed."; \
       : "The base image can ship an out-of-tree vendor provider whose name is"; \
       : "neither predictable nor tied to the rdma-core ABI (observed:"; \
-      : "libbnxt_re-235.2.86.0.so, alongside older -rdmavNN.so builds). If one"; \
+      : "libbnxt_re-235.2.86.0.so, alongside -rdmavNN.so builds). If one"; \
       : "survives, libibverbs loads it against the new rdma-core and every run"; \
-      : "warns 'Driver bnxt_re does not support the kernel ABI'. Matching a"; \
-      : "hard-coded ABI suffix is wrong twice over: it misses vendor names, and"; \
-      : "it goes stale whenever IBVERBS_PABI_VERSION moves (v63 installs"; \
-      : "-rdmav59.so). Deleting the symlink alone is also not enough -- ldconfig"; \
-      : "regenerates SONAME links from the real file, so the .so itself must go."; \
-      keep="$(ls -1 /usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav*.so 2>/dev/null | tail -1)"; \
-      test -n "${keep}" || { echo "no bnxt_re provider installed by rdma-core ${RDMA_CORE_VERSION}"; exit 1; }; \
-      find /usr/lib/x86_64-linux-gnu/libibverbs /usr/local/lib \
-           /usr/local/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu \
-           -maxdepth 1 -name 'libbnxt_re*.so*' 2>/dev/null \
-        | while read -r f; do [ "${f}" = "${keep}" ] || rm -f "${f}"; done; \
+      : "warns 'Driver bnxt_re does not support the kernel ABI'. Deleting the"; \
+      : "symlink alone is not enough -- ldconfig regenerates SONAME links from"; \
+      : "the real file, so the .so itself must go."; \
+      : "The keeper comes from cmake's install manifest, i.e. from what THIS"; \
+      : "build produced. Globbing the destination cannot distinguish a fresh"; \
+      : "provider from a stale one: a base carrying -rdmav60 would win a"; \
+      : "lexical sort against the -rdmav59 that v63 installs, and the wrong"; \
+      : "file would survive."; \
+      keep="$(grep -m1 -E '/libbnxt_re[^/]*\\.so$' install_manifest.txt || true)"; \
+      test -n "${keep}" || { echo "rdma-core ${RDMA_CORE_VERSION} installed no bnxt_re provider"; exit 1; }; \
+      keep_real="$(readlink -f "${keep}")"; \
+      roots=""; \
+      for d in /usr/lib/x86_64-linux-gnu/libibverbs /usr/local/lib \
+               /usr/local/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu; do \
+        [ -d "$d" ] && roots="$roots $d"; \
+      done; \
+      : "roots is filtered first: find exits 1 on a missing root, and this"; \
+      : "block runs under set -e with a global pipefail."; \
+      if [ -n "$roots" ]; then \
+        find $roots -maxdepth 1 -name 'libbnxt_re*.so*' \
+          | while read -r f; do \
+              [ "$(readlink -f "$f")" = "${keep_real}" ] || rm -f "$f"; \
+            done; \
+      fi; \
       ldconfig; \
       echo "IBVERBS_BNXT_KEPT ${keep}"; \
       cd / && rm -rf /tmp/rdma-core; \

--- a/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
+++ b/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
@@ -62,14 +62,25 @@
 #                                  linear stage; only ordering can.
 #     ENABLE_TORCHVISION_STUB      Text-only torchvision surface, for ROCm bases
 #                                  whose torchvision ABI breaks `import vllm`.
+#                                  After vLLM: this stub depends on neither
+#                                  DeepEP, AITER, nor VLLM_WHEEL (only torch,
+#                                  already in the base image), and used to sit
+#                                  before AITER, so toggling it alone
+#                                  invalidated AITER's compile and the vLLM
+#                                  install below it for no reason.
 #     RDMA_CORE_VERSION            rdma-core from source (default 63.0),
 #                                  replacing the distro packages. Empty keeps
-#                                  the base image's. Compiled in its own FROM
-#                                  stage (rdma-core-build, top of this file),
-#                                  whose only inputs are BASE_IMAGE and
+#                                  the base image's. Compiled AND installed-to-
+#                                  a-DESTDIR in its own FROM stage
+#                                  (rdma-core-build, top of this file), whose
+#                                  only inputs are BASE_IMAGE and
 #                                  RDMA_CORE_VERSION -- so unlike the others,
 #                                  it is untouched by DEEPEP_COMMIT,
-#                                  AITER_COMMIT or VLLM_WHEEL changing.
+#                                  AITER_COMMIT or VLLM_WHEEL changing. Only
+#                                  the DESTDIR payload (not the source
+#                                  checkout or the build tree's object files)
+#                                  is copied into the final stage, which
+#                                  places it and runs the provider purge.
 #
 #   Known residual coupling: DEEPEP_COMMIT changing still invalidates AITER's
 #   compile, since DeepEP precedes it in the same linear stage and neither
@@ -120,7 +131,7 @@ FROM ${BASE_IMAGE} AS rdma-core-build
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG RDMA_CORE_VERSION=63.0
 RUN set -e; \
-    mkdir -p /tmp/rdma-core; \
+    mkdir -p /tmp/rdma-core-install; \
     if [ -z "${RDMA_CORE_VERSION}" ]; then \
       echo "RDMA_CORE_FROM_SOURCE <disabled, keeping base rdma-core>"; \
     else \
@@ -141,6 +152,16 @@ RUN set -e; \
         -DNO_PYVERBS=1 \
         ..; \
       ninja -j"$(nproc)"; \
+      : "Install into a DESTDIR here, in the same stage that just built the"; \
+      : "tree, rather than copying the whole source+object tree (hundreds of"; \
+      : ".o/.a files, the full git checkout, CMakeFiles/ caches) into a final-"; \
+      : "image layer and deleting it in a later RUN. That delete does not"; \
+      : "reclaim the space: each instruction is its own layer, so the earlier"; \
+      : "layer's diff -- the copied-in tree -- stays in the image's layer"; \
+      : "history regardless of what a later layer removes. DESTDIR keeps only"; \
+      : "the files the install step actually places on disk."; \
+      DESTDIR=/tmp/rdma-core-install cmake --install /tmp/rdma-core/build; \
+      cp /tmp/rdma-core/build/install_manifest.txt /tmp/rdma-core-install/; \
     fi
 
 FROM ${BASE_IMAGE}
@@ -190,38 +211,7 @@ RUN test -n "${DEEPEP_REPO}" || { echo "DEEPEP_REPO is required"; exit 1; }; \
     cp -a deep_ep/include/. "${site_dir}/include/"
 
 ###############################################################################
-# 2) Text-only torchvision surface.
-#
-# Some ROCm bases ship a torchvision whose ABI does not match the installed
-# torch. vLLM imports it transitively through a multimodal config even for
-# text-only models, so `import vllm` fails before serving starts.
-###############################################################################
-ARG ENABLE_TORCHVISION_STUB=1
-RUN if [ "${ENABLE_TORCHVISION_STUB}" = "1" ]; then \
-      set -e; \
-      site_dir="$(${PYTHON} -c "import site; print(site.getsitepackages()[0])")"; \
-      ${PYTHON} -m pip uninstall -y torchvision || true; \
-      mkdir -p "${site_dir}/torchvision/transforms"; \
-      printf '%s\n' \
-        '"""Text-only torchvision surface: import-compatible, no operators."""' \
-        '__version__ = "0.0.0+text-only"' \
-        'def _unsupported(*args, **kwargs):' \
-        '    raise NotImplementedError("text-only torchvision stub")' \
-        > "${site_dir}/torchvision/__init__.py"; \
-      printf '%s\n' \
-        'from enum import Enum' \
-        'class InterpolationMode(Enum):' \
-        '    NEAREST = "nearest"' \
-        '    BILINEAR = "bilinear"' \
-        '    BICUBIC = "bicubic"' \
-        > "${site_dir}/torchvision/transforms/__init__.py"; \
-      ${PYTHON} -c "from torchvision.transforms import InterpolationMode; print('TORCHVISION_STUB_OK')"; \
-    else \
-      echo "TORCHVISION_STUB <disabled>"; \
-    fi
-
-###############################################################################
-# 3) AITER.
+# 2) AITER.
 #
 # The get_ksplit guard returns 0 when a split has no work instead of dividing
 # by zero, which a data-parallel profile microbatch can trigger.
@@ -255,7 +245,7 @@ RUN set -e; \
       ${PYTHON} -m pip install --no-cache-dir --no-build-isolation -e .
 
 ###############################################################################
-# 4) vLLM.
+# 3) vLLM.
 #
 # After DeepEP and AITER, not combined with DeepEP's install: this is the
 # argument that changes on every "just pick up a newer wheel" rebuild, so
@@ -267,38 +257,76 @@ COPY ${VLLM_WHEEL} /tmp/vllm.whl
 RUN ${PYTHON} -m pip install --no-deps /tmp/vllm.whl && rm -f /tmp/vllm.whl
 
 ###############################################################################
-# 5) rdma-core, installed from the artifacts the rdma-core-build stage
-#    already compiled -- replacing the distro packages and dropping the
+# 4) Text-only torchvision surface.
+#
+# Some ROCm bases ship a torchvision whose ABI does not match the installed
+# torch. vLLM imports it transitively through a multimodal config even for
+# text-only models, so `import vllm` fails before serving starts.
+#
+# After vLLM, not between DeepEP and AITER where it used to sit: this stub
+# depends on neither of them (it only touches torch, already in the base
+# image), but sitting before AITER meant toggling ENABLE_TORCHVISION_STUB
+# alone invalidated AITER's compile and the vLLM install below it -- for a
+# component unrelated to either.
+###############################################################################
+ARG ENABLE_TORCHVISION_STUB=1
+RUN if [ "${ENABLE_TORCHVISION_STUB}" = "1" ]; then \
+      set -e; \
+      site_dir="$(${PYTHON} -c "import site; print(site.getsitepackages()[0])")"; \
+      ${PYTHON} -m pip uninstall -y torchvision || true; \
+      mkdir -p "${site_dir}/torchvision/transforms"; \
+      printf '%s\n' \
+        '"""Text-only torchvision surface: import-compatible, no operators."""' \
+        '__version__ = "0.0.0+text-only"' \
+        'def _unsupported(*args, **kwargs):' \
+        '    raise NotImplementedError("text-only torchvision stub")' \
+        > "${site_dir}/torchvision/__init__.py"; \
+      printf '%s\n' \
+        'from enum import Enum' \
+        'class InterpolationMode(Enum):' \
+        '    NEAREST = "nearest"' \
+        '    BILINEAR = "bilinear"' \
+        '    BICUBIC = "bicubic"' \
+        > "${site_dir}/torchvision/transforms/__init__.py"; \
+      ${PYTHON} -c "from torchvision.transforms import InterpolationMode; print('TORCHVISION_STUB_OK')"; \
+    else \
+      echo "TORCHVISION_STUB <disabled>"; \
+    fi
+
+###############################################################################
+# 5) rdma-core, installed from the DESTDIR payload the rdma-core-build stage
+#    already produced -- replacing the distro packages and dropping the
 #    vendor bnxt_re provider.
 #
-#    Only the install and the provider purge happen here; see the
-#    rdma-core-build stage (top of this file) for why the compile does not.
-#    It installs over the distro rdma-core rather than removing it: removing
-#    libibverbs1 and friends would leave every dependent with an unmet
-#    dependency and break apt here and in any downstream image.
+#    Only placing the payload on disk and the provider purge happen here; see
+#    the rdma-core-build stage (top of this file) for why the compile, and
+#    the cmake --install invocation itself, do not. It installs over the
+#    distro rdma-core rather than removing it: removing libibverbs1 and
+#    friends would leave every dependent with an unmet dependency and break
+#    apt here and in any downstream image.
 ###############################################################################
 ARG RDMA_CORE_VERSION=63.0
-COPY --from=rdma-core-build /tmp/rdma-core /tmp/rdma-core
-RUN if [ -n "${RDMA_CORE_VERSION}" ] && [ -f /tmp/rdma-core/build/build.ninja ]; then \
+# The DESTDIR payload only -- not the source checkout or the build tree's
+# .o/.a intermediates and CMakeFiles/ caches. Those are much larger and
+# contribute nothing at runtime; copying them here and `rm -rf`ing them in a
+# later RUN does not reclaim the space; each instruction is its own layer, so
+# the bytes this COPY adds stay in the image's layer history regardless of
+# what a later layer deletes on top.
+COPY --from=rdma-core-build /tmp/rdma-core-install /tmp/rdma-core-install
+RUN if [ -n "${RDMA_CORE_VERSION}" ] \
+    && [ -f /tmp/rdma-core-install/install_manifest.txt ]; then \
       set -e; \
-      : "Only cmake needed here: the compile already happened in"; \
-      : "rdma-core-build, so this stage installs the already-built tree"; \
-      : "rather than rebuilding it -- no compiler, linker, or -dev headers"; \
-      : "required. cmake --install, not ninja install / make install: ninja's"; \
-      : "'install' target depends on 'all', so it re-checks every build edge"; \
-      : "first -- and Docker's COPY resets every file's mtime to copy time,"; \
-      : "which reliably confuses ninja's mtime-based freshness check into"; \
-      : "relinking targets that were already built. Verified on hardware:"; \
-      : "'ninja install' on the copied tree failed on a missing link-time"; \
-      : "libsystemd.so (the runtime lib is present, the -dev symlink is not,"; \
-      : "and this stage installs neither) because it tried to relink"; \
-      : "bin/ibacm. cmake --install runs only the generated install script"; \
-      : "against files already on disk and never touches the build graph."; \
-      apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 update; \
-      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        cmake; \
-      DEBIAN_FRONTEND=noninteractive apt-get autoremove -y; \
-      rm -rf /var/lib/apt/lists/*; \
+      : "No cmake, no ninja, no compiler needed here at all: the payload is"; \
+      : "already the exact file tree the install step intended to place on"; \
+      : "disk (DESTDIR=/tmp/rdma-core-install cmake --install ... in the"; \
+      : "rdma-core-build stage), so placing it is a plain recursive copy, not"; \
+      : "a build-system operation -- which also sidesteps the mtime/relink"; \
+      : "problem a copied .ninja build tree ran into (see that stage)."; \
+      : "cp -a onto /, not just onto /usr: CMAKE_INSTALL_SYSCONFDIR=/etc and"; \
+      : "CMAKE_INSTALL_RUNDIR=/run in that stage's cmake invocation mean some"; \
+      : "files land outside the /usr prefix, and DESTDIR mirrors the full"; \
+      : "absolute layout underneath itself."; \
+      cp -a /tmp/rdma-core-install/. /; \
       : "Install over the distro packages rather than removing them. dpkg -r"; \
       : "--force-all on libibverbs1 and friends leaves every dependent with an"; \
       : "unmet dependency, so any later apt operation -- including one in a"; \
@@ -306,8 +334,6 @@ RUN if [ -n "${RDMA_CORE_VERSION}" ] && [ -f /tmp/rdma-core/build/build.ninja ];
       : "install targets the same prefix and shadows those files, and the"; \
       : "provider cleanup below removes the part that actually matters, so the"; \
       : "removal bought nothing that is not handled here."; \
-      cmake --install /tmp/rdma-core/build; \
-      cd /tmp/rdma-core/build; \
       : "Drop every bnxt_re provider except the one this build just installed."; \
       : "The base image can ship an out-of-tree vendor provider whose name is"; \
       : "neither predictable nor tied to the rdma-core ABI (observed:"; \
@@ -317,11 +343,14 @@ RUN if [ -n "${RDMA_CORE_VERSION}" ] && [ -f /tmp/rdma-core/build/build.ninja ];
       : "symlink alone is not enough -- ldconfig regenerates SONAME links from"; \
       : "the real file, so the .so itself must go."; \
       : "The keeper comes from cmake's install manifest, i.e. from what THIS"; \
-      : "build produced. Globbing the destination cannot distinguish a fresh"; \
-      : "provider from a stale one: a base carrying -rdmav60 would win a"; \
-      : "lexical sort against the -rdmav59 that v63 installs, and the wrong"; \
-      : "file would survive."; \
-      keep="$(grep -m1 -E '/libbnxt_re[^/]*\.so$' install_manifest.txt || true)"; \
+      : "build produced (the manifest's paths are absolute real paths even"; \
+      : "though the files were staged under DESTDIR -- that is how DESTDIR"; \
+      : "works, only the staging location moves). Globbing the destination"; \
+      : "cannot distinguish a fresh provider from a stale one: a base carrying"; \
+      : "-rdmav60 would win a lexical sort against the -rdmav59 that v63"; \
+      : "installs, and the wrong file would survive."; \
+      keep="$(grep -m1 -E '/libbnxt_re[^/]*\.so$' \
+        /tmp/rdma-core-install/install_manifest.txt || true)"; \
       test -n "${keep}" || { echo "rdma-core ${RDMA_CORE_VERSION} installed no bnxt_re provider"; exit 1; }; \
       keep_real="$(readlink -f "${keep}")"; \
       roots=""; \
@@ -339,7 +368,7 @@ RUN if [ -n "${RDMA_CORE_VERSION}" ] && [ -f /tmp/rdma-core/build/build.ninja ];
       fi; \
       ldconfig; \
       echo "IBVERBS_BNXT_KEPT ${keep}"; \
-      cd / && rm -rf /tmp/rdma-core; \
+      rm -rf /tmp/rdma-core-install; \
       echo "IBVERBS_PROVIDERS $(ls /usr/lib/x86_64-linux-gnu/libibverbs/ 2>/dev/null | tr '\n' ' ')"; \
     else \
       echo "RDMA_CORE_FROM_SOURCE <disabled, keeping base rdma-core>"; \

--- a/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
+++ b/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
@@ -1,0 +1,228 @@
+# CONTEXT {'gpu_vendor': 'AMD', 'guest_os': 'UBUNTU'}
+###############################################################################
+#
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#################################################################################
+# =============================================================================
+# vllm_deepep_inference.ubuntu.amd.Dockerfile
+#   vLLM expert-parallel serving over DeepEP on MI350X (gfx950), validated
+#   with DeepSeek-R1 FP8 at TP=1 / DP=8 / EP=8 on a single node.
+#
+#   docker build -f docker/vllm_deepep_inference.ubuntu.amd.Dockerfile \
+#     --build-arg DEEPEP_REPO=<url> --build-arg DEEPEP_COMMIT=<sha> \
+#     --build-arg VLLM_WHEEL=<path/to/vllm-*.whl relative to the build context> \
+#     # VLLM_WHEEL defaults to vllm.whl in the context root. The wheel must be
+#     # inside the build context; docker cannot check a COPY source in advance,
+#     # so a missing file fails at that COPY.
+#     -t <your-registry>/vllm-deepep:local .
+#
+#   BASE_IMAGE defaults to the same ROCm vLLM base the sibling disagg image
+#   uses. This recipe was validated against a THERock ROCm 7.14 / Torch 2.11
+#   base, so override it if your base predates the ROCm version DeepEP needs.
+#
+#   Stages, each gated so a rebuild only pays for what changed:
+#     DEEPEP_REPO / DEEPEP_COMMIT  DeepEP build (EP_TARGET_HIP=1,
+#                                  EP_DISABLE_LEGACY=1). Required; the source is
+#                                  not vendored here.
+#     AITER_COMMIT                 AITER, with the zero-token get_ksplit guard.
+#     RDMA_CORE_VERSION            rdma-core from source (default 63.0),
+#                                  replacing the distro packages. Empty keeps
+#                                  the base image's.
+#     ENABLE_TORCHVISION_STUB      Text-only torchvision surface, for ROCm bases
+#                                  whose torchvision ABI breaks `import vllm`.
+#
+#   Runtime notes that are easy to lose:
+#     * NCCL_CUMEM_ENABLE=1 is mandatory. Without VMM, RCCL answers
+#       "Communicator does not support symmetric memory" and the ElasticBuffer
+#       is never created.
+#     * On a single node set EP_DISABLE_GIN=1. DeepEP moves no payload
+#       through GIN inside one XGMI domain -- is_scaleup_nvlink is true and the
+#       barrier and dispatch/combine run over symmetric memory -- but the buffer
+#       constructor still asserts on ginType and reserves queue pairs unless GIN
+#       is disabled. Leaving it on additionally requires /dev/infiniband,
+#       NCCL_GIN_TYPE=2 and EP_GIN_QUEUE_DEPTH=0.
+#     * Mount the JIT caches. AITER tunes GEMM shapes at run time behind a
+#       global build lock, and with data parallelism one rank tunes while the
+#       others wait in the collective:
+#         -v <host>/aiter_build:/opt/aiter/aiter/jit/build
+#         -v <host>/aiter_configs:/tmp/aiter_configs
+#         -v <host>/deep_ep:/root/.deep_ep
+# =============================================================================
+
+ARG BASE_IMAGE=rocm/vllm-dev:ci_base-0fcd9b99cc9d63202da4c858d8ebc6582c9e2491
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG PYTHON=/opt/venv/bin/python
+ARG GPU_TARGETS=gfx950
+
+ARG DEEPEP_REPO
+ARG DEEPEP_COMMIT
+ARG AITER_REPO=https://github.com/ROCm/aiter.git
+ARG AITER_COMMIT=d9e5ef7ce08ee7045d583aed768cff41aa9210fe
+ARG RDMA_CORE_VERSION=63.0
+ARG ENABLE_TORCHVISION_STUB=1
+ARG VLLM_WHEEL=vllm.whl
+
+ENV VLLM_TARGET_DEVICE=rocm \
+    PYTORCH_ROCM_ARCH=${GPU_TARGETS} \
+    PYTHONPATH=${PYTHONPATH}:/opt/rocm/share/amd_smi \
+    EP_TARGET_HIP=1 \
+    EP_DISABLE_LEGACY=1
+
+###############################################################################
+# 1) DeepEP and vLLM.
+###############################################################################
+RUN test -n "${DEEPEP_REPO}" || { echo "DEEPEP_REPO is required"; exit 1; }; \
+    test -n "${DEEPEP_COMMIT}" || { echo "DEEPEP_COMMIT is required"; exit 1; }; \
+    set -e; \
+    git clone "${DEEPEP_REPO}" /opt/deepep; \
+    git -C /opt/deepep checkout -f "${DEEPEP_COMMIT}"; \
+    cd /opt/deepep; \
+    ${PYTHON} setup.py build; \
+    so="$(find build -name '_C.cpython-*.so' | sort | tail -1)"; \
+    test -n "${so}"; \
+    cp "${so}" deep_ep/; \
+    ${PYTHON} -m pip install --no-deps --no-build-isolation .; \
+    site_dir="$(${PYTHON} -c "import site; print(site.getsitepackages()[0] + '/deep_ep')")"; \
+    mkdir -p "${site_dir}/include"; \
+    cp -a deep_ep/include/. "${site_dir}/include/"
+
+COPY ${VLLM_WHEEL} /tmp/vllm.whl
+RUN ${PYTHON} -m pip install --no-deps /tmp/vllm.whl && rm -f /tmp/vllm.whl
+
+###############################################################################
+# 2) Text-only torchvision surface.
+#
+# Some ROCm bases ship a torchvision whose ABI does not match the installed
+# torch. vLLM imports it transitively through a multimodal config even for
+# text-only models, so `import vllm` fails before serving starts.
+###############################################################################
+RUN if [ "${ENABLE_TORCHVISION_STUB}" = "1" ]; then \
+      set -e; \
+      site_dir="$(${PYTHON} -c "import site; print(site.getsitepackages()[0])")"; \
+      ${PYTHON} -m pip uninstall -y torchvision || true; \
+      mkdir -p "${site_dir}/torchvision/transforms"; \
+      printf '%s\n' \
+        '"""Text-only torchvision surface: import-compatible, no operators."""' \
+        '__version__ = "0.0.0+text-only"' \
+        'def _unsupported(*args, **kwargs):' \
+        '    raise NotImplementedError("text-only torchvision stub")' \
+        > "${site_dir}/torchvision/__init__.py"; \
+      printf '%s\n' \
+        'from enum import Enum' \
+        'class InterpolationMode(Enum):' \
+        '    NEAREST = "nearest"' \
+        '    BILINEAR = "bilinear"' \
+        '    BICUBIC = "bicubic"' \
+        > "${site_dir}/torchvision/transforms/__init__.py"; \
+      ${PYTHON} -c "from torchvision.transforms import InterpolationMode; print('TORCHVISION_STUB_OK')"; \
+    else \
+      echo "TORCHVISION_STUB <disabled>"; \
+    fi
+
+###############################################################################
+# 3) AITER.
+#
+# The get_ksplit guard returns 0 when a split has no work instead of dividing
+# by zero, which a data-parallel profile microbatch can trigger.
+###############################################################################
+RUN set -e; \
+    git clone "${AITER_REPO}" /opt/aiter; \
+    git -C /opt/aiter checkout -f "${AITER_COMMIT}"; \
+    ${PYTHON} - <<'PY'
+path = "/opt/aiter/aiter/fused_moe.py"
+src = open(path).read()
+needle = "    tg_num = tgN * tgM\n"
+guard = (
+    "    tg_num = tgN * tgM\n"
+    "    # A data-parallel profile microbatch can contain no tokens on this\n"
+    "    # rank. There is no work to split in that case.\n"
+    "    if tg_num == 0:\n"
+    "        return 0\n"
+)
+if "if tg_num == 0:" not in src:
+    assert needle in src, "get_ksplit prologue not found"
+    open(path, "w").write(src.replace(needle, guard, 1))
+print("AITER_KSPLIT_GUARD_OK")
+PY
+RUN set -e; \
+    git -C /opt/aiter submodule update --init --recursive; \
+    cd /opt/aiter; \
+    ${PYTHON} -m pip install --no-cache-dir -r requirements.txt; \
+    AITER_USE_SYSTEM_TRITON=1 GPU_ARCHS=${GPU_TARGETS} \
+      ${PYTHON} -m pip install --no-cache-dir --no-build-isolation -e .
+
+###############################################################################
+# 4) rdma-core from source, replacing the distro packages and dropping the
+#    vendor bnxt_re provider.
+#
+#    Keep this stage last, and run every apt command before the
+#    `dpkg -r --force-all` below: the removal leaves dependents with dangling
+#    deps and later apt invocations abort.
+###############################################################################
+RUN if [ -n "${RDMA_CORE_VERSION}" ]; then \
+      set -e; \
+      apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 update; \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git ca-certificates cmake ninja-build build-essential pkg-config make \
+        libnl-3-dev libnl-route-3-dev libudev-dev libssl-dev libsystemd-dev \
+        python3-docutils pandoc; \
+      git clone --depth 1 --branch "v${RDMA_CORE_VERSION}" \
+        https://github.com/linux-rdma/rdma-core.git /tmp/rdma-core; \
+      mkdir -p /tmp/rdma-core/build && cd /tmp/rdma-core/build; \
+      cmake -GNinja \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu \
+        -DCMAKE_INSTALL_SYSCONFDIR=/etc \
+        -DCMAKE_INSTALL_RUNDIR=/run \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DNO_PYVERBS=1 \
+        ..; \
+      ninja -j"$(nproc)"; \
+      DEBIAN_FRONTEND=noninteractive apt-get purge -y python3-docutils pandoc; \
+      DEBIAN_FRONTEND=noninteractive apt-get autoremove -y; \
+      rm -rf /var/lib/apt/lists/*; \
+      to_remove=""; \
+      for p in ibverbs-providers libibverbs1 libibverbs-dev ibverbs-utils \
+               librdmacm1 librdmacm-dev rdma-core libibumad3 infiniband-diags; do \
+        dpkg-query -W -f='${Status}' "$p" 2>/dev/null | grep -q "install ok installed" \
+          && to_remove="$to_remove $p"; \
+      done; \
+      [ -n "$to_remove" ] && dpkg -r --force-all $to_remove; \
+      ninja install; \
+      rm -f /usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so \
+            /usr/local/lib/x86_64-linux-gnu/libbnxt_re-rdmav34.so \
+            /usr/local/lib/libbnxt_re-rdmav34.so; \
+      ldconfig; \
+      cd / && rm -rf /tmp/rdma-core; \
+      echo "IBVERBS_PROVIDERS $(ls /usr/lib/x86_64-linux-gnu/libibverbs/ 2>/dev/null | tr '\n' ' ')"; \
+    else \
+      echo "RDMA_CORE_FROM_SOURCE <disabled, keeping base rdma-core>"; \
+    fi
+
+RUN ${PYTHON} -c "import deep_ep, torch, vllm; assert torch.version.hip; print('VLLM_DEEPEP_BUILD_OK')"
+
+ENTRYPOINT ["vllm"]

--- a/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
+++ b/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
@@ -42,16 +42,42 @@
 #   uses. This recipe was validated against a THERock ROCm 7.14 / Torch 2.11
 #   base, so override it if your base predates the ROCm version DeepEP needs.
 #
-#   Stages, each gated so a rebuild only pays for what changed:
+#   Stages, ordered so a rebuild only pays for what actually changed:
 #     DEEPEP_REPO / DEEPEP_COMMIT  DeepEP build (EP_TARGET_HIP=1,
 #                                  EP_DISABLE_LEGACY=1). Required; the source is
-#                                  not vendored here.
+#                                  not vendored here. Comes first: nothing else
+#                                  depends on it, so it never gets invalidated
+#                                  by a later ARG.
 #     AITER_COMMIT                 AITER, with the zero-token get_ksplit guard.
-#     RDMA_CORE_VERSION            rdma-core from source (default 63.0),
-#                                  replacing the distro packages. Empty keeps
-#                                  the base image's.
+#                                  After DeepEP, so a DeepEP-only change still
+#                                  invalidates this (residual coupling -- see
+#                                  below) but nothing after AITER is coupled to
+#                                  DeepEP's ARGs.
+#     VLLM_WHEEL                   vLLM. Deliberately AFTER DeepEP and AITER:
+#                                  this is the argument that moves on every
+#                                  "pick up a newer wheel" rebuild, and used to
+#                                  sit before both, invalidating their compiles
+#                                  on every such rebuild for no reason -- ARG
+#                                  scoping alone cannot fix that in a single
+#                                  linear stage; only ordering can.
 #     ENABLE_TORCHVISION_STUB      Text-only torchvision surface, for ROCm bases
 #                                  whose torchvision ABI breaks `import vllm`.
+#     RDMA_CORE_VERSION            rdma-core from source (default 63.0),
+#                                  replacing the distro packages. Empty keeps
+#                                  the base image's. Compiled in its own FROM
+#                                  stage (rdma-core-build, top of this file),
+#                                  whose only inputs are BASE_IMAGE and
+#                                  RDMA_CORE_VERSION -- so unlike the others,
+#                                  it is untouched by DEEPEP_COMMIT,
+#                                  AITER_COMMIT or VLLM_WHEEL changing.
+#
+#   Known residual coupling: DEEPEP_COMMIT changing still invalidates AITER's
+#   compile, since DeepEP precedes it in the same linear stage and neither
+#   compile is (yet) split into its own FROM stage the way rdma-core's is.
+#   Fixing that needs multi-stage isolation of two Python-packaged components
+#   (an editable AITER install, DeepEP's compiled extension), which is a
+#   larger, riskier change than reordering -- not attempted without validating
+#   it against a real build end to end.
 #
 #   Runtime notes that are easy to lose:
 #     * NCCL_CUMEM_ENABLE=1 is mandatory. Without VMM, RCCL answers
@@ -74,15 +100,61 @@
 # =============================================================================
 
 ARG BASE_IMAGE=rocm/vllm-dev:ci_base-0fcd9b99cc9d63202da4c858d8ebc6582c9e2491
+
+###############################################################################
+# rdma-core, compiled independently of DeepEP/AITER/vLLM.
+#
+# In a single linear stage, changing DEEPEP_COMMIT, AITER_COMMIT or
+# VLLM_WHEEL invalidates every layer after it, including this compile --
+# despite rdma-core depending on none of them. A separate FROM stage removes
+# that coupling: this stage's cache key is BASE_IMAGE + RDMA_CORE_VERSION
+# only.
+#
+# This stage BUILDS but does not INSTALL. Installing over the base image's
+# existing rdma-core (and purging any stale out-of-tree provider) has to run
+# against the FINAL image's actual state, not this stage's -- that is a
+# correctness requirement, not a caching one, so it stays where the final
+# artifact is assembled. See the comment on that step for why.
+###############################################################################
+FROM ${BASE_IMAGE} AS rdma-core-build
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG RDMA_CORE_VERSION=63.0
+RUN set -e; \
+    mkdir -p /tmp/rdma-core; \
+    if [ -z "${RDMA_CORE_VERSION}" ]; then \
+      echo "RDMA_CORE_FROM_SOURCE <disabled, keeping base rdma-core>"; \
+    else \
+      apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 update; \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git ca-certificates cmake ninja-build build-essential pkg-config make \
+        libnl-3-dev libnl-route-3-dev libudev-dev libssl-dev libsystemd-dev \
+        python3-docutils pandoc; \
+      git clone --depth 1 --branch "v${RDMA_CORE_VERSION}" \
+        https://github.com/linux-rdma/rdma-core.git /tmp/rdma-core; \
+      mkdir -p /tmp/rdma-core/build && cd /tmp/rdma-core/build; \
+      cmake -GNinja \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu \
+        -DCMAKE_INSTALL_SYSCONFDIR=/etc \
+        -DCMAKE_INSTALL_RUNDIR=/run \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DNO_PYVERBS=1 \
+        ..; \
+      ninja -j"$(nproc)"; \
+    fi
+
 FROM ${BASE_IMAGE}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Build args are declared immediately before the stage that consumes them, not
 # in one block up top: an ARG in scope becomes part of the cache key of every
-# following layer, so hoisting them all would make a change to AITER_COMMIT (or
-# the wheel path, or the rdma-core version) rebuild DeepEP and everything after
-# it -- defeating the staged-rebuild property this file is organised around.
+# following layer, so hoisting them all would make a change to any one of them
+# invalidate everything below, regardless of the stage/ordering work above.
+# ARG scoping and stage ordering are complementary, not substitutes for each
+# other: scoping stops an unrelated ARG's mere presence from padding the cache
+# key; ordering (and, for rdma-core, a separate FROM stage) stops one
+# component's actual rebuild from cascading into an unrelated one's.
 ARG PYTHON=/opt/venv/bin/python
 ARG GPU_TARGETS=gfx950
 
@@ -93,7 +165,12 @@ ENV VLLM_TARGET_DEVICE=rocm \
     EP_DISABLE_LEGACY=1
 
 ###############################################################################
-# 1) DeepEP and vLLM.
+# 1) DeepEP.
+#
+# The vLLM wheel install that used to live in this section now comes after
+# AITER (see below): with DeepEP and vLLM combined here, changing VLLM_WHEEL
+# alone invalidated this build and every layer after it, including AITER's.
+# Neither install has a build-time dependency on the other.
 ###############################################################################
 ARG DEEPEP_REPO
 ARG DEEPEP_COMMIT
@@ -111,10 +188,6 @@ RUN test -n "${DEEPEP_REPO}" || { echo "DEEPEP_REPO is required"; exit 1; }; \
     site_dir="$(${PYTHON} -c "import site; print(site.getsitepackages()[0] + '/deep_ep')")"; \
     mkdir -p "${site_dir}/include"; \
     cp -a deep_ep/include/. "${site_dir}/include/"
-
-ARG VLLM_WHEEL=vllm.whl
-COPY ${VLLM_WHEEL} /tmp/vllm.whl
-RUN ${PYTHON} -m pip install --no-deps /tmp/vllm.whl && rm -f /tmp/vllm.whl
 
 ###############################################################################
 # 2) Text-only torchvision surface.
@@ -182,34 +255,48 @@ RUN set -e; \
       ${PYTHON} -m pip install --no-cache-dir --no-build-isolation -e .
 
 ###############################################################################
-# 4) rdma-core from source, replacing the distro packages and dropping the
+# 4) vLLM.
+#
+# After DeepEP and AITER, not combined with DeepEP's install: this is the
+# argument that changes on every "just pick up a newer wheel" rebuild, so
+# putting it last among the source builds means that rebuild no longer pays
+# for DeepEP's or AITER's compile.
+###############################################################################
+ARG VLLM_WHEEL=vllm.whl
+COPY ${VLLM_WHEEL} /tmp/vllm.whl
+RUN ${PYTHON} -m pip install --no-deps /tmp/vllm.whl && rm -f /tmp/vllm.whl
+
+###############################################################################
+# 5) rdma-core, installed from the artifacts the rdma-core-build stage
+#    already compiled -- replacing the distro packages and dropping the
 #    vendor bnxt_re provider.
 #
-#    Keep this stage last. It installs over the distro rdma-core rather than
-#    removing it: removing libibverbs1 and friends would leave every dependent
-#    with an unmet dependency and break apt here and in any downstream image.
+#    Only the install and the provider purge happen here; see the
+#    rdma-core-build stage (top of this file) for why the compile does not.
+#    It installs over the distro rdma-core rather than removing it: removing
+#    libibverbs1 and friends would leave every dependent with an unmet
+#    dependency and break apt here and in any downstream image.
 ###############################################################################
 ARG RDMA_CORE_VERSION=63.0
-RUN if [ -n "${RDMA_CORE_VERSION}" ]; then \
+COPY --from=rdma-core-build /tmp/rdma-core /tmp/rdma-core
+RUN if [ -n "${RDMA_CORE_VERSION}" ] && [ -f /tmp/rdma-core/build/build.ninja ]; then \
       set -e; \
+      : "Only cmake needed here: the compile already happened in"; \
+      : "rdma-core-build, so this stage installs the already-built tree"; \
+      : "rather than rebuilding it -- no compiler, linker, or -dev headers"; \
+      : "required. cmake --install, not ninja install / make install: ninja's"; \
+      : "'install' target depends on 'all', so it re-checks every build edge"; \
+      : "first -- and Docker's COPY resets every file's mtime to copy time,"; \
+      : "which reliably confuses ninja's mtime-based freshness check into"; \
+      : "relinking targets that were already built. Verified on hardware:"; \
+      : "'ninja install' on the copied tree failed on a missing link-time"; \
+      : "libsystemd.so (the runtime lib is present, the -dev symlink is not,"; \
+      : "and this stage installs neither) because it tried to relink"; \
+      : "bin/ibacm. cmake --install runs only the generated install script"; \
+      : "against files already on disk and never touches the build graph."; \
       apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 update; \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        git ca-certificates cmake ninja-build build-essential pkg-config make \
-        libnl-3-dev libnl-route-3-dev libudev-dev libssl-dev libsystemd-dev \
-        python3-docutils pandoc; \
-      git clone --depth 1 --branch "v${RDMA_CORE_VERSION}" \
-        https://github.com/linux-rdma/rdma-core.git /tmp/rdma-core; \
-      mkdir -p /tmp/rdma-core/build && cd /tmp/rdma-core/build; \
-      cmake -GNinja \
-        -DCMAKE_INSTALL_PREFIX=/usr \
-        -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu \
-        -DCMAKE_INSTALL_SYSCONFDIR=/etc \
-        -DCMAKE_INSTALL_RUNDIR=/run \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DNO_PYVERBS=1 \
-        ..; \
-      ninja -j"$(nproc)"; \
-      DEBIAN_FRONTEND=noninteractive apt-get purge -y python3-docutils pandoc; \
+        cmake; \
       DEBIAN_FRONTEND=noninteractive apt-get autoremove -y; \
       rm -rf /var/lib/apt/lists/*; \
       : "Install over the distro packages rather than removing them. dpkg -r"; \
@@ -219,7 +306,8 @@ RUN if [ -n "${RDMA_CORE_VERSION}" ]; then \
       : "install targets the same prefix and shadows those files, and the"; \
       : "provider cleanup below removes the part that actually matters, so the"; \
       : "removal bought nothing that is not handled here."; \
-      ninja install; \
+      cmake --install /tmp/rdma-core/build; \
+      cd /tmp/rdma-core/build; \
       : "Drop every bnxt_re provider except the one this build just installed."; \
       : "The base image can ship an out-of-tree vendor provider whose name is"; \
       : "neither predictable nor tied to the rdma-core ABI (observed:"; \

--- a/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
+++ b/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
@@ -233,7 +233,7 @@ RUN if [ -n "${RDMA_CORE_VERSION}" ]; then \
       : "provider from a stale one: a base carrying -rdmav60 would win a"; \
       : "lexical sort against the -rdmav59 that v63 installs, and the wrong"; \
       : "file would survive."; \
-      keep="$(grep -m1 -E '/libbnxt_re[^/]*\\.so$' install_manifest.txt || true)"; \
+      keep="$(grep -m1 -E '/libbnxt_re[^/]*\.so$' install_manifest.txt || true)"; \
       test -n "${keep}" || { echo "rdma-core ${RDMA_CORE_VERSION} installed no bnxt_re provider"; exit 1; }; \
       keep_real="$(readlink -f "${keep}")"; \
       roots=""; \

--- a/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
+++ b/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
@@ -30,6 +30,7 @@
 #   with DeepSeek-R1 FP8 at TP=1 / DP=8 / EP=8 on a single node.
 #
 #   docker build -f docker/vllm_deepep_inference.ubuntu.amd.Dockerfile \
+#     --build-arg BASE_IMAGE=<image, see below -- no usable default> \
 #     --build-arg DEEPEP_REPO=<url> --build-arg DEEPEP_COMMIT=<sha> \
 #     --build-arg VLLM_WHEEL=<path/to/vllm-*.whl relative to the build context> \
 #     -t <your-registry>/vllm-deepep:local .
@@ -38,20 +39,35 @@
 #   inside the build context; docker cannot check a COPY source in advance, so
 #   a missing file fails at that COPY.
 #
-#   BASE_IMAGE defaults to a THERock ROCm 7.14 / Torch 2.11 nightly
-#   (gfx950-dcgpu). Not the public rocm/vllm-dev tag the sibling disagg image
-#   uses: that image's distro rccl-dev package (confirmed: 2.27.7 on ROCm
-#   7.2.3) ships rccl.h/nccl.h but not nccl_device.h, which DeepEP's HIP GIN
-#   backend requires -- the build fails on that header before ever reaching
-#   DeepEP's own code. Confirmed on hardware: swapping only the Python
-#   interpreter path is not enough; the distro RCCL genuinely lacks the
-#   device-side symmetric-memory API surface this recipe needs, regardless of
-#   which base ships it. RCCL is rebuilt from source below specifically to
-#   supply that header and API on top of whatever BASE_IMAGE provides, so a
-#   predates-DeepEP base doesn't have to already carry it -- but the base
-#   still has to be recent enough for that RCCL build and DeepEP's own HIP
-#   code to compile, which is why the default is pinned to the nightly this
-#   recipe was validated against rather than a stable release tag.
+#   BASE_IMAGE has no usable default -- you must supply one. It needs:
+#     * A recent-enough ROCm/Torch/HIP toolchain to compile RCCL's device-side
+#       symmetric-memory API and DeepEP's own HIP code. The public
+#       rocm/vllm-dev tag the sibling disagg image uses is NOT recent enough:
+#       confirmed on hardware that its distro rccl-dev package (2.27.7 on ROCm
+#       7.2.3) ships rccl.h/nccl.h but not nccl_device.h, and DeepEP's HIP GIN
+#       backend needs that header. RCCL is rebuilt from source below
+#       specifically to supply it on top of whatever BASE_IMAGE provides, so
+#       the base does not need to already carry DeepEP support itself -- only
+#       a toolchain new enough to compile that RCCL build and DeepEP's code
+#       against it.
+#     * A gfx950 (MI350X) target and, if you rely on the ${PYTHON} default
+#       below, a `/opt/venv` virtualenv at that path (THERock-style images lay
+#       out this way; override PYTHON if yours doesn't).
+#
+#   Why no default: an earlier revision of this file pinned BASE_IMAGE to a
+#   specific tag on an internal nightly-build registry
+#   (registry-sc-harbor.amd.com/framework/therock-main), matching whatever
+#   image this recipe had been validated against at the time. That tag is
+#   already gone from the registry as of this writing -- confirmed via the
+#   registry's own tags/list API, which no longer lists it alongside tags from
+#   the same window that are still present. This registry evidently keeps only
+#   a rolling set of recent nightly builds, so ANY tag pinned here would go
+#   the same way on its own schedule, not just that one -- the previous
+#   default only ever looked validated because specific cluster nodes still
+#   had that exact tag cached locally from months ago, not because the
+#   reference was durably resolvable. A required build arg fails loudly and
+#   immediately for whoever builds, which beats a hardcoded reference that
+#   works today and silently stops working later for everyone else.
 #
 #   Stages, ordered so a rebuild only pays for what actually changed:
 #     RCCL_REPO / RCCL_COMMIT      RCCL, built from source (see above for why).
@@ -124,7 +140,13 @@
 #         -v <host>/deep_ep:/root/.deep_ep
 # =============================================================================
 
-ARG BASE_IMAGE=registry-sc-harbor.amd.com/framework/therock-main:1447_gfx950_7.14.0a20260603_ubuntu22.04_py3.11_pytorch_release-2.11_98563b80a0e
+# No real default: see the header above for why a pinned tag is not durable
+# here. Docker cannot validate an ARG used directly in FROM before the FROM
+# line runs (no test -n check like DEEPEP_REPO/DEEPEP_COMMIT get below), so
+# this placeholder exists to make the resulting failure legible instead of a
+# bare "invalid reference format" -- if you see this string in a build error,
+# you forgot --build-arg BASE_IMAGE=...
+ARG BASE_IMAGE=REQUIRED-set-build-arg-BASE_IMAGE-see-Dockerfile-header-for-what-it-needs
 
 ###############################################################################
 # RCCL, built from source, independently of DeepEP/AITER/vLLM.

--- a/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
+++ b/docker/vllm_deepep_inference.ubuntu.amd.Dockerfile
@@ -38,16 +38,30 @@
 #   inside the build context; docker cannot check a COPY source in advance, so
 #   a missing file fails at that COPY.
 #
-#   BASE_IMAGE defaults to the same ROCm vLLM base the sibling disagg image
-#   uses. This recipe was validated against a THERock ROCm 7.14 / Torch 2.11
-#   base, so override it if your base predates the ROCm version DeepEP needs.
+#   BASE_IMAGE defaults to a THERock ROCm 7.14 / Torch 2.11 nightly
+#   (gfx950-dcgpu). Not the public rocm/vllm-dev tag the sibling disagg image
+#   uses: that image's distro rccl-dev package (confirmed: 2.27.7 on ROCm
+#   7.2.3) ships rccl.h/nccl.h but not nccl_device.h, which DeepEP's HIP GIN
+#   backend requires -- the build fails on that header before ever reaching
+#   DeepEP's own code. Confirmed on hardware: swapping only the Python
+#   interpreter path is not enough; the distro RCCL genuinely lacks the
+#   device-side symmetric-memory API surface this recipe needs, regardless of
+#   which base ships it. RCCL is rebuilt from source below specifically to
+#   supply that header and API on top of whatever BASE_IMAGE provides, so a
+#   predates-DeepEP base doesn't have to already carry it -- but the base
+#   still has to be recent enough for that RCCL build and DeepEP's own HIP
+#   code to compile, which is why the default is pinned to the nightly this
+#   recipe was validated against rather than a stable release tag.
 #
 #   Stages, ordered so a rebuild only pays for what actually changed:
+#     RCCL_REPO / RCCL_COMMIT      RCCL, built from source (see above for why).
+#                                  Independent of DeepEP/AITER/vLLM; its own
+#                                  FROM stage (rccl-build) for the same caching
+#                                  reason as rdma-core's.
 #     DEEPEP_REPO / DEEPEP_COMMIT  DeepEP build (EP_TARGET_HIP=1,
 #                                  EP_DISABLE_LEGACY=1). Required; the source is
-#                                  not vendored here. Comes first: nothing else
-#                                  depends on it, so it never gets invalidated
-#                                  by a later ARG.
+#                                  not vendored here. Needs the from-source RCCL
+#                                  above already placed (EP_RCCL_ROOT_DIR).
 #     AITER_COMMIT                 AITER, with the zero-token get_ksplit guard.
 #                                  After DeepEP, so a DeepEP-only change still
 #                                  invalidates this (residual coupling -- see
@@ -84,11 +98,11 @@
 #
 #   Known residual coupling: DEEPEP_COMMIT changing still invalidates AITER's
 #   compile, since DeepEP precedes it in the same linear stage and neither
-#   compile is (yet) split into its own FROM stage the way rdma-core's is.
-#   Fixing that needs multi-stage isolation of two Python-packaged components
-#   (an editable AITER install, DeepEP's compiled extension), which is a
-#   larger, riskier change than reordering -- not attempted without validating
-#   it against a real build end to end.
+#   compile is (yet) split into its own FROM stage the way rdma-core's (or
+#   RCCL's) is. Fixing that needs multi-stage isolation of two Python-packaged
+#   components (an editable AITER install, DeepEP's compiled extension), which
+#   is a larger, riskier change than reordering -- not attempted without
+#   validating it against a real build end to end.
 #
 #   Runtime notes that are easy to lose:
 #     * NCCL_CUMEM_ENABLE=1 is mandatory. Without VMM, RCCL answers
@@ -110,7 +124,50 @@
 #         -v <host>/deep_ep:/root/.deep_ep
 # =============================================================================
 
-ARG BASE_IMAGE=rocm/vllm-dev:ci_base-0fcd9b99cc9d63202da4c858d8ebc6582c9e2491
+ARG BASE_IMAGE=registry-sc-harbor.amd.com/framework/therock-main:1447_gfx950_7.14.0a20260603_ubuntu22.04_py3.11_pytorch_release-2.11_98563b80a0e
+
+###############################################################################
+# RCCL, built from source, independently of DeepEP/AITER/vLLM.
+#
+# DeepEP's HIP GIN backend needs nccl_device.h and device-side symmetric-
+# memory APIs. Confirmed on hardware that the distro rccl-dev package (2.27.7
+# on ROCm 7.2.3) ships rccl.h/nccl.h but not nccl_device.h -- the DeepEP build
+# fails on that header before reaching any of its own code, on any base image
+# whose RCCL is the stable distro package rather than a build carrying this
+# newer API. Rebuilding it here, rather than requiring BASE_IMAGE to already
+# have it, keeps that requirement contained to one pinned, independent stage.
+#
+# Same caching rationale as rdma-core-build: this stage's cache key is
+# BASE_IMAGE + GPU_TARGETS + RCCL_REPO + RCCL_COMMIT only.
+###############################################################################
+FROM ${BASE_IMAGE} AS rccl-build
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG GPU_TARGETS=gfx950
+ARG RCCL_REPO=https://github.com/ROCm/rocm-systems.git
+ARG RCCL_COMMIT=d22b8646
+RUN set -e; \
+    apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      git ca-certificates cmake ninja-build build-essential pkg-config; \
+    rm -rf /var/lib/apt/lists/*; \
+    git clone "${RCCL_REPO}" /tmp/rocm-systems; \
+    git -C /tmp/rocm-systems checkout "${RCCL_COMMIT}"; \
+    git -C /tmp/rocm-systems submodule update --init --recursive projects/rccl; \
+    cp -a /tmp/rocm-systems/projects/rccl /opt/rccl-src; \
+    rm -rf /tmp/rocm-systems; \
+    cd /opt/rccl-src; \
+    ./install.sh --amdgpu_targets "${GPU_TARGETS}"; \
+    : "install.sh places the built .so directly under build/release/, not"; \
+    : "build/release/lib/ -- confirmed on hardware (librccl.so.1.0 sits next"; \
+    : "to CMakeCache.txt, no lib/ subdirectory exists at all). EP_RCCL_ROOT_DIR"; \
+    : "is read by both DeepEP's build and the runtime overlay step below as if"; \
+    : "it were a conventional install prefix with a lib/ underneath, so a"; \
+    : "self-referencing symlink bridges the two layouts instead of changing"; \
+    : "every consumer's assumed path."; \
+    test -e /opt/rccl-src/build/release/lib || ln -s . /opt/rccl-src/build/release/lib; \
+    test -f /opt/rccl-src/build/release/include/rccl/rccl.h; \
+    test -f /opt/rccl-src/build/release/include/nccl_device.h; \
+    test -f /opt/rccl-src/build/release/lib/librccl.so.1.0
 
 ###############################################################################
 # rdma-core, compiled independently of DeepEP/AITER/vLLM.
@@ -183,7 +240,56 @@ ENV VLLM_TARGET_DEVICE=rocm \
     PYTORCH_ROCM_ARCH=${GPU_TARGETS} \
     PYTHONPATH=${PYTHONPATH}:/opt/rocm/share/amd_smi \
     EP_TARGET_HIP=1 \
-    EP_DISABLE_LEGACY=1
+    EP_DISABLE_LEGACY=1 \
+    RCCL_SRC=/opt/rccl-src \
+    EP_RCCL_ROOT_DIR=/opt/rccl-src/build/release \
+    EP_NCCL_ROOT_DIR=/opt/rccl-src/build/release
+
+###############################################################################
+# 0) Place the from-source RCCL built in rccl-build, before DeepEP -- DeepEP's
+#    setup.py reads EP_RCCL_ROOT_DIR/EP_NCCL_ROOT_DIR at build time to find
+#    nccl_device.h and link against this RCCL instead of whatever ships in
+#    ROCM_PATH.
+#
+#    Only build/release is copied, not the source checkout or the rest of the
+#    build tree: build/release is RCCL's own install-style output directory
+#    (headers + shared libs), and it is the only path EP_RCCL_ROOT_DIR and the
+#    checks above reference. Narrower than rdma-core's DESTDIR copy only in
+#    that this relies on RCCL's build system already separating that tree
+#    itself, rather than an explicit DESTDIR install step -- not verified here
+#    that nothing else under /opt/rccl-src is needed; worth confirming once
+#    against an actual build if something under build/release turns out to
+#    reference a path outside it.
+###############################################################################
+COPY --from=rccl-build /opt/rccl-src/build/release /opt/rccl-src/build/release
+RUN set -e; \
+    : "Torch resolves its own bundled librccl through RPATH, which can be a"; \
+    : "different RCCL build than the one DeepEP is about to compile against --"; \
+    : "so it is overlaid here with the same one, not left to diverge."; \
+    candidate="${EP_RCCL_ROOT_DIR}/lib/librccl.so.1.0"; \
+    if nm -D "${candidate}" 2>/dev/null | grep -qw 'U atexit'; then \
+      : "This RCCL build can reference atexit() without linking against a libc"; \
+      : "that provides it as a plain symbol; the shim below satisfies that"; \
+      : "reference via __cxa_atexit instead of patching RCCL's own build."; \
+      apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 update; \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        patchelf; \
+      rm -rf /var/lib/apt/lists/*; \
+      printf '%s\n' \
+        'extern int __cxa_atexit(void (*)(void *), void *, void *);' \
+        'int atexit(void (*f)(void)) { return __cxa_atexit((void (*)(void *))f, (void *)0, (void *)0); }' \
+        > /tmp/rccl_atexit_shim.c; \
+      "${ROCM_PATH}/bin/amdclang" -shared -fPIC \
+        -o "${EP_RCCL_ROOT_DIR}/lib/librccl_atexit_shim.so" /tmp/rccl_atexit_shim.c; \
+      patchelf --add-needed librccl_atexit_shim.so "${candidate}"; \
+      patchelf --add-rpath "${EP_RCCL_ROOT_DIR}/lib" "${candidate}"; \
+      rm -f /tmp/rccl_atexit_shim.c; \
+    fi; \
+    for bundled in $(find /opt/venv -path '*/_rocm_sdk_libraries_*/lib/librccl.so.1' 2>/dev/null); do \
+      real="$(readlink -f "${bundled}")"; \
+      cp -f "${candidate}" "${real}"; \
+      echo "RCCL_BUNDLED_OVERLAY ${real} <- ${candidate}"; \
+    done
 
 ###############################################################################
 # 1) DeepEP.
@@ -253,8 +359,24 @@ RUN set -e; \
 # for DeepEP's or AITER's compile.
 ###############################################################################
 ARG VLLM_WHEEL=vllm.whl
-COPY ${VLLM_WHEEL} /tmp/vllm.whl
-RUN ${PYTHON} -m pip install --no-deps /tmp/vllm.whl && rm -f /tmp/vllm.whl
+# Copied into a directory, not renamed to a fixed /tmp/vllm.whl: confirmed on
+# hardware that pip's wheel installer parses the compatibility tags (python
+# ABI, platform) out of the FILENAME per PEP 427 before it looks at the
+# wheel's own metadata, and rejects a name that doesn't fit that shape --
+# "Invalid wheel filename (wrong number of parts): 'vllm'" -- regardless of
+# what the file actually contains. Renaming to a fixed name broke this
+# unconditionally, for every wheel, on every build.
+#
+# No --no-deps: confirmed by inspecting this wheel's own METADATA that torch,
+# torchvision and numpy are not declared Requires-Dist at all (vLLM's ROCm
+# build handles them outside pip's normal dependency graph), so a plain
+# install cannot touch the base image's ROCm-specific builds of them -- and
+# --no-deps was silently dropping everything it DOES declare (regex,
+# cachetools, fastapi, ...), so `import vllm` failed on the first of those,
+# ModuleNotFoundError: No module named 'regex', confirmed on hardware.
+COPY ${VLLM_WHEEL} /tmp/
+RUN wheel="/tmp/$(basename "${VLLM_WHEEL}")"; \
+    ${PYTHON} -m pip install "${wheel}" && rm -f "${wheel}"
 
 ###############################################################################
 # 4) Text-only torchvision surface.

--- a/scripts/vllm_deepep/README.md
+++ b/scripts/vllm_deepep/README.md
@@ -164,7 +164,7 @@ which is the same as losing them. So the diagnostic columns go to
 never parsed:
 
 ```
-backend,model,concurrency,isl,osl,num_prompts,run,total_tok_s,median_tpot_ms,p99_ttft_ms,warmup_discarded,mori_disable_topo
+backend,model,model_revision,concurrency,isl,osl,num_prompts,run,total_tok_s,median_tpot_ms,p99_ttft_ms,warmup_discarded,mori_disable_topo
 ```
 
 Its `model` field is the resolved model — the local path when `MODEL_PATH` is

--- a/scripts/vllm_deepep/README.md
+++ b/scripts/vllm_deepep/README.md
@@ -91,8 +91,28 @@ job.
 
 ## Output
 
-`perf_vllm_deepep.csv`, one row per measured run:
+Two files. `perf_vllm_deepep.csv` is the one registered as `multiple_results`,
+and MAD dictates its shape: `tools/utils.py:1231` raises unless the columns are
+exactly `model` / `performance` / `metric`, and `:1247-1250` reads only those
+three and discards the rest. So it is long-form, three rows per measured run:
+
+```
+model,performance,metric
+run1_throughput,1234.56,total_token_throughput_tok_s
+run1_tpot,12.34,median_tpot_ms
+run1_ttft,345.67,p99_ttft_ms
+```
+
+MAD prefixes each label with the model-card name, so the backend and the model
+arrive in the ingested row without being repeated here.
+
+Because the ingested file cannot carry context, the diagnostic columns go to
+`perf_vllm_deepep_detail.csv`, which is deliberately *not* registered and so is
+never parsed:
 
 ```
 backend,model,concurrency,isl,osl,run,total_tok_s,median_tpot_ms,p99_ttft_ms,warmup_discarded,mori_disable_topo
 ```
+
+Its `model` field is the resolved model — the local path when `MODEL_PATH` is
+set, not the repo id — since that is what was actually served.

--- a/scripts/vllm_deepep/README.md
+++ b/scripts/vllm_deepep/README.md
@@ -91,10 +91,11 @@ job.
 
 ## Output
 
-Two files. `perf_vllm_deepep.csv` is the one registered as `multiple_results`,
-and MAD dictates its shape: `tools/utils.py:1231` raises unless the columns are
-exactly `model` / `performance` / `metric`, and `:1247-1250` reads only those
-three and discards the rest. So it is long-form, three rows per measured run:
+Two files. `perf_vllm_deepep.csv` is the one registered as `multiple_results`.
+MAD requires it to have at least three columns and to include `model`,
+`performance` and `metric` (`tools/utils.py:1224-1236`); extra columns are
+permitted but ignored, since `:1247-1251` reads only those three. Long-form,
+three rows per measured run:
 
 ```
 model,performance,metric
@@ -106,7 +107,8 @@ run1_ttft,345.67,p99_ttft_ms
 MAD prefixes each label with the model-card name, so the backend and the model
 arrive in the ingested row without being repeated here.
 
-Because the ingested file cannot carry context, the diagnostic columns go to
+Extra columns would therefore survive the check but never reach `perf.csv`,
+which is the same as losing them. So the diagnostic columns go to
 `perf_vllm_deepep_detail.csv`, which is deliberately *not* registered and so is
 never parsed:
 

--- a/scripts/vllm_deepep/README.md
+++ b/scripts/vllm_deepep/README.md
@@ -1,0 +1,82 @@
+# vLLM expert-parallel serving over DeepEP V2 / MoRI
+
+Single node, 8x MI350X (gfx950), `TP=1 / DP=8 / EP=8`. One script drives both
+all-to-all backends so a comparison between them changes exactly one thing.
+
+## Run
+
+```bash
+madengine run --tags vllm_deepep --live-output
+```
+
+or one arm at a time:
+
+```bash
+madengine run --tags deepep      --live-output   # DeepEP V2
+madengine run --tags mori_ep     --live-output   # MoRI
+```
+
+The image is not built here — supply it with `DOCKER_IMAGE_NAME`. Build it from
+`docker/vllm_deepep_inference.ubuntu.amd.Dockerfile`; that file documents the
+required build args (`DEEPEP_REPO`, `DEEPEP_COMMIT`, `VLLM_WHEEL`).
+
+## Why both arms run AITER fused MoE
+
+vLLM refuses MoRI without AITER (`Mori needs to be used with aiter fused_moe
+for now`). Running the DeepEP arm on a different MoE implementation would make
+the two rows incomparable — the difference would be the MoE kernel, not the
+transport. So `VLLM_ROCM_USE_AITER_MOE=1` is set for both, unconditionally, in
+the script rather than per-entry.
+
+## Why the warm-up runs are discarded, and reported
+
+AITER tunes GEMM shapes at run time behind a global lock, so an unwarmed run
+measures the tuner and not the server: P99 TTFT is roughly 20 s on the first
+pass against a few hundred ms once warm, and about 270 s on DeepSeek-R1.
+
+`WARMUP_RUNS` (default 2) are executed and thrown away; `MEASURED_RUNS`
+(default 3) are recorded, each as its own CSV row rather than pre-averaged, so
+a run that has not converged is visible instead of hidden in a mean. The
+discarded count is written into every row — a backend comparison that does not
+state it cannot be interpreted.
+
+## Knobs
+
+| variable | default | note |
+| --- | --- | --- |
+| `ALL2ALL_BACKEND` | `deepep_v2` | or `mori_high_throughput` |
+| `MODEL_REPO` | `deepseek-ai/DeepSeek-V2-Lite` | `MODEL_PATH` overrides with a local path |
+| `WARMUP_RUNS` / `MEASURED_RUNS` | 2 / 3 | see above |
+| `CONCURRENCY` / `ISL` / `OSL` | 16 / 256 / 128 | `ISL + OSL` must stay under `MAX_MODEL_LEN`, or every request fails and the results are a row of zeros |
+| `GPU_MEMORY_UTILIZATION` | 0.70 | 0.80 for R1 |
+| `EP_NIC_NAME` / `NCCL_SOCKET_IFNAME` | `bnxt_re0` / `fenic0` | cluster-specific |
+
+`NCCL_CUMEM_ENABLE=1` is set for both backends and is not optional: RCCL
+rejects symmetric memory without VMM.
+
+**DeepEP arm** keeps GIN on (`NCCL_GIN_TYPE=2`, `EP_GIN_QUEUE_DEPTH=0`, needs
+`/dev/infiniband` in the container). GIN carries no payload inside one XGMI
+domain, but it is the path that matters for scale-out, so the single-node run
+exercises it rather than a mode nobody deploys.
+
+**MoRI arm** sets `MORI_DISABLE_TOPO=1`, which works around a null dereference
+in `CollectAndSortCandidates`. It skips GPU/NIC affinity matching; for a
+single-node run traffic stays on XGMI so the effect should be small, but that
+is an expectation rather than a measurement, so the flag is recorded in the
+CSV.
+
+## Known limitation
+
+MoRI does not currently start on DeepSeek-R1 FP8 —
+`HIP error 709: hipModuleLaunchKernel(EpDispatchIntraNodeKernel_fp8_ocp)`,
+reproduced across sessions. Hence there is a `deepep_v2` entry for R1 and no
+MoRI counterpart; adding one before that is fixed would only produce a failing
+job.
+
+## Output
+
+`perf_vllm_deepep.csv`, one row per measured run:
+
+```
+backend,model,concurrency,isl,osl,run,total_tok_s,median_tpot_ms,p99_ttft_ms,warmup_discarded,mori_disable_topo
+```

--- a/scripts/vllm_deepep/README.md
+++ b/scripts/vllm_deepep/README.md
@@ -12,9 +12,14 @@ madengine run --tags vllm_deepep --live-output
 or one arm at a time:
 
 ```bash
-madengine run --tags deepep      --live-output   # DeepEP V2
-madengine run --tags mori_ep     --live-output   # MoRI
+madengine run --tags pyt_vllm_deepep_v2_deepseek-v2-lite --live-output   # DeepEP V2
+madengine run --tags pyt_vllm_mori_deepseek-v2-lite      --live-output   # MoRI
 ```
+
+Not `--tags deepep` / `--tags mori_ep`: madengine selects every model card
+carrying *any* requested tag (`tools/run_models.py:544`), and `deepep` is also
+on the R1 entry -- so that tag alone would launch two unrelated jobs instead
+of one comparison arm. Model-card names are unique; tags are not.
 
 The image is not built here — supply it with `DOCKER_IMAGE_NAME`. Build it from
 `docker/vllm_deepep_inference.ubuntu.amd.Dockerfile`; that file documents the

--- a/scripts/vllm_deepep/README.md
+++ b/scripts/vllm_deepep/README.md
@@ -61,6 +61,8 @@ variable and running the script directly inside the container.
 | --- | --- | --- |
 | `ALL2ALL_BACKEND` | `deepep_v2` | or `mori_high_throughput` |
 | `MODEL_REPO` | `deepseek-ai/DeepSeek-V2-Lite` | `MODEL_PATH` overrides with a local path |
+| `MODEL_REVISION` | pinned per card | see below; empty means the moving `main` |
+| `TRUST_REMOTE_CODE` | `0` | see below |
 | `WARMUP_RUNS` / `MEASURED_RUNS` | 2 / 3 | see above |
 | `CONCURRENCY` / `ISL` / `OSL` | 16 / 256 / 128 | `ISL + OSL` must stay under `MAX_MODEL_LEN`, or every request fails and the results are a row of zeros |
 | `GPU_MEMORY_UTILIZATION` | 0.70 | 0.80 for R1 |
@@ -68,6 +70,50 @@ variable and running the script directly inside the container.
 
 `NCCL_CUMEM_ENABLE=1` is set for both backends and is not optional: RCCL
 rejects symmetric memory without VMM.
+
+## Reproducibility: revision pinning and remote code
+
+All three shipped cards set `MODEL_REVISION` to the commit each was validated
+against, not to a branch name, so re-running a card later serves the exact
+weights and config this comparison was measured on rather than whatever
+`main` has moved to since. Passing `MODEL_REVISION` on its own is not
+sufficient, which is why the script does more than add `--revision` to `vllm
+serve`: `vllm bench serve` loads its own tokenizer independently and has no
+`--revision` flag at all, so a moved `main` would tokenize the benchmark's
+prompts differently from what the pinned server understands, silently, with
+each side considering its own tokenizer authoritative. The script instead
+resolves `MODEL_REPO`@`MODEL_REVISION` to one local snapshot via
+`huggingface_hub.snapshot_download` and points both commands at that path, so
+there is only one revision instead of two that need to agree. `MODEL_PATH`
+bypasses this (it is already a fixed local path); leaving `MODEL_REVISION`
+empty falls back to the moving revision with a warning, for ad hoc runs where
+reproducibility does not matter.
+
+Neither DeepSeek-V2-Lite nor DeepSeek-R1 needs `TRUST_REMOTE_CODE=1` -- vLLM
+has native architectures for both, and current `transformers` ships its own
+config classes, so neither model's `auto_map` is ever consulted. It defaults
+off, since executing a mutable HF repo's Python as root in this container
+(host networking, elevated capabilities, device access) is not something to
+enable unconditionally. When set, it is forwarded to both `vllm serve` and
+`vllm bench serve` -- forwarding it to only the server would let a model that
+genuinely needs it start successfully and then fail once the benchmark's
+independent tokenizer load hits the same requirement.
+
+## JIT cache mounts
+
+Each card mounts its AITER JIT build cache, AITER's tuned-config directory,
+and DeepEP's JIT cache under `/var/cache/mad/vllm_deepep/<card-name>/`,
+matching the paths the Dockerfile documents
+(`/opt/aiter/aiter/jit/build`, `/tmp/aiter_configs`, `/root/.deep_ep`).
+Without these, every fresh container repeats AITER's globally-locked GEMM
+tuning from cold -- the ~270 s R1 first pass this README's warm-up section
+describes.
+
+The mount path is keyed by card name, not by `DOCKER_IMAGE_NAME`: it separates
+the DeepEP and MoRI arms (different AITER tuning shapes) but not two different
+images pointed at the same card. If you swap in an incompatible image or
+AITER build, clear that card's cache directory first -- a build cache from a
+different AITER revision is a correctness risk, not just a wasted rebuild.
 
 **DeepEP arm** keeps GIN on (`NCCL_GIN_TYPE=2`, `EP_GIN_QUEUE_DEPTH=0`). GIN
 carries no payload inside one XGMI domain, but it is the path that matters for

--- a/scripts/vllm_deepep/README.md
+++ b/scripts/vllm_deepep/README.md
@@ -42,6 +42,16 @@ state it cannot be interpreted.
 
 ## Knobs
 
+These are read by the script from its environment. madengine's `env_vars`
+model-card field is consumed **host-side** — it feeds image selection and, on
+the self-managed-launcher path, the host environment — but it is not forwarded
+into a container that madengine runs itself: the local path constructs
+`Docker(...)` without `envVars`, so the only env that reaches the container is
+what appears as an explicit `-e` on the `docker run` line. Hence every runtime
+knob below lives in `additional_docker_run_options`, and `env_vars` carries
+only `DOCKER_IMAGE_NAME`. Override by editing that string, or by exporting the
+variable and running the script directly inside the container.
+
 | variable | default | note |
 | --- | --- | --- |
 | `ALL2ALL_BACKEND` | `deepep_v2` | or `mori_high_throughput` |
@@ -54,10 +64,16 @@ state it cannot be interpreted.
 `NCCL_CUMEM_ENABLE=1` is set for both backends and is not optional: RCCL
 rejects symmetric memory without VMM.
 
-**DeepEP arm** keeps GIN on (`NCCL_GIN_TYPE=2`, `EP_GIN_QUEUE_DEPTH=0`, needs
-`/dev/infiniband` in the container). GIN carries no payload inside one XGMI
-domain, but it is the path that matters for scale-out, so the single-node run
-exercises it rather than a mode nobody deploys.
+**DeepEP arm** keeps GIN on (`NCCL_GIN_TYPE=2`, `EP_GIN_QUEUE_DEPTH=0`). GIN
+carries no payload inside one XGMI domain, but it is the path that matters for
+scale-out, so the single-node run exercises it rather than a mode nobody
+deploys. The buffer constructor still reserves queue pairs, so the container
+needs the RDMA device: madengine passes `--device=/dev/kfd` and the render
+nodes but nothing else, so `--device=/dev/infiniband` is supplied through
+`additional_docker_run_options` on every entry, together with
+`--ulimit memlock=-1` (registration pins memory) and `--shm-size 128g` (eight
+data-parallel workers). Without the device the DeepEP arm fails at buffer
+construction, not at benchmark time.
 
 **MoRI arm** sets `MORI_DISABLE_TOPO=1`, which works around a null dereference
 in `CollectAndSortCandidates`. It skips GPU/NIC affinity matching; for a

--- a/scripts/vllm_deepep/README.md
+++ b/scripts/vllm_deepep/README.md
@@ -113,7 +113,7 @@ which is the same as losing them. So the diagnostic columns go to
 never parsed:
 
 ```
-backend,model,concurrency,isl,osl,run,total_tok_s,median_tpot_ms,p99_ttft_ms,warmup_discarded,mori_disable_topo
+backend,model,concurrency,isl,osl,num_prompts,run,total_tok_s,median_tpot_ms,p99_ttft_ms,warmup_discarded,mori_disable_topo
 ```
 
 Its `model` field is the resolved model — the local path when `MODEL_PATH` is

--- a/scripts/vllm_deepep/README.md
+++ b/scripts/vllm_deepep/README.md
@@ -23,7 +23,16 @@ of one comparison arm. Model-card names are unique; tags are not.
 
 The image is not built here — supply it with `DOCKER_IMAGE_NAME`. Build it from
 `docker/vllm_deepep_inference.ubuntu.amd.Dockerfile`; that file documents the
-required build args (`DEEPEP_REPO`, `DEEPEP_COMMIT`, `VLLM_WHEEL`).
+required build args (`BASE_IMAGE`, `DEEPEP_REPO`, `DEEPEP_COMMIT`,
+`VLLM_WHEEL`).
+
+`BASE_IMAGE` has no default — deliberately, see the Dockerfile header. It
+needs a ROCm/Torch/HIP toolchain new enough to build RCCL's device-side
+symmetric-memory API and DeepEP's own HIP code (gfx950/MI350X); the public
+`rocm/vllm-dev` tag the sibling disagg image uses is not new enough. Pass it
+the same way as the other build args, e.g. via `madengine build --additional-
+context '{"docker_build_arg": {"BASE_IMAGE": "..."}}'` or by setting
+`docker_build_arg` directly on the model card.
 
 ## Why both arms run AITER fused MoE
 

--- a/scripts/vllm_deepep/models.json
+++ b/scripts/vllm_deepep/models.json
@@ -1,0 +1,102 @@
+[
+    {
+        "name": "pyt_vllm_deepep_v2_deepseek-v2-lite",
+        "dockerfile": "../../docker/vllm_deepep_inference",
+        "scripts": "run_vllm_deepep.sh",
+        "url": "",
+        "data": "huggingface",
+        "n_gpus": "-1",
+        "owner": "mad.support@amd.com",
+        "training_precision": "",
+        "multiple_results": "perf_vllm_deepep.csv",
+        "tags": [
+            "pyt",
+            "vllm",
+            "vllm_deepep",
+            "deepep",
+            "expert_parallel",
+            "inference"
+        ],
+        "timeout": -1,
+        "env_vars": {
+            "DOCKER_IMAGE_NAME": "<supply-your-image>",
+            "MODEL_REPO": "deepseek-ai/DeepSeek-V2-Lite",
+            "ALL2ALL_BACKEND": "deepep_v2",
+            "EP_NIC_NAME": "bnxt_re0",
+            "NCCL_SOCKET_IFNAME": "fenic0",
+            "WARMUP_RUNS": "2",
+            "MEASURED_RUNS": "3",
+            "CONCURRENCY": "16",
+            "ISL": "256",
+            "OSL": "128"
+        },
+        "args": ""
+    },
+    {
+        "name": "pyt_vllm_mori_deepseek-v2-lite",
+        "dockerfile": "../../docker/vllm_deepep_inference",
+        "scripts": "run_vllm_deepep.sh",
+        "url": "",
+        "data": "huggingface",
+        "n_gpus": "-1",
+        "owner": "mad.support@amd.com",
+        "training_precision": "",
+        "multiple_results": "perf_vllm_deepep.csv",
+        "tags": [
+            "pyt",
+            "vllm",
+            "vllm_deepep",
+            "mori_ep",
+            "expert_parallel",
+            "inference"
+        ],
+        "timeout": -1,
+        "env_vars": {
+            "DOCKER_IMAGE_NAME": "<supply-your-image>",
+            "MODEL_REPO": "deepseek-ai/DeepSeek-V2-Lite",
+            "ALL2ALL_BACKEND": "mori_high_throughput",
+            "EP_NIC_NAME": "bnxt_re0",
+            "NCCL_SOCKET_IFNAME": "fenic0",
+            "WARMUP_RUNS": "2",
+            "MEASURED_RUNS": "3",
+            "CONCURRENCY": "16",
+            "ISL": "256",
+            "OSL": "128"
+        },
+        "args": ""
+    },
+    {
+        "name": "pyt_vllm_deepep_v2_deepseek-r1",
+        "dockerfile": "../../docker/vllm_deepep_inference",
+        "scripts": "run_vllm_deepep.sh",
+        "url": "",
+        "data": "huggingface",
+        "n_gpus": "-1",
+        "owner": "mad.support@amd.com",
+        "training_precision": "",
+        "multiple_results": "perf_vllm_deepep.csv",
+        "tags": [
+            "pyt",
+            "vllm",
+            "vllm_deepep",
+            "deepep",
+            "expert_parallel",
+            "inference"
+        ],
+        "timeout": -1,
+        "env_vars": {
+            "DOCKER_IMAGE_NAME": "<supply-your-image>",
+            "MODEL_REPO": "deepseek-ai/DeepSeek-R1",
+            "ALL2ALL_BACKEND": "deepep_v2",
+            "EP_NIC_NAME": "bnxt_re0",
+            "NCCL_SOCKET_IFNAME": "fenic0",
+            "GPU_MEMORY_UTILIZATION": "0.80",
+            "WARMUP_RUNS": "2",
+            "MEASURED_RUNS": "3",
+            "CONCURRENCY": "16",
+            "ISL": "256",
+            "OSL": "128"
+        },
+        "args": ""
+    }
+]

--- a/scripts/vllm_deepep/models.json
+++ b/scripts/vllm_deepep/models.json
@@ -21,7 +21,7 @@
         "env_vars": {
             "DOCKER_IMAGE_NAME": "<supply-your-image>"
         },
-        "additional_docker_run_options": "--device=/dev/infiniband --shm-size 128g --ulimit memlock=-1 --ulimit nofile=1048576:1048576 -e MODEL_REPO=deepseek-ai/DeepSeek-V2-Lite -e ALL2ALL_BACKEND=deepep_v2 -e EP_NIC_NAME=bnxt_re0 -e NCCL_SOCKET_IFNAME=fenic0 -e WARMUP_RUNS=2 -e MEASURED_RUNS=3 -e CONCURRENCY=16 -e ISL=256 -e OSL=128",
+        "additional_docker_run_options": "--device=/dev/infiniband --shm-size 128g --ulimit memlock=-1 --ulimit nofile=1048576:1048576 -e MODEL_REPO=deepseek-ai/DeepSeek-V2-Lite -e MODEL_REVISION=604d5664dddd88a0433dbae533b7fe9472482de0 -e ALL2ALL_BACKEND=deepep_v2 -e EP_NIC_NAME=bnxt_re0 -e NCCL_SOCKET_IFNAME=fenic0 -e WARMUP_RUNS=2 -e MEASURED_RUNS=3 -e CONCURRENCY=16 -e ISL=256 -e OSL=128 -v /var/cache/mad/vllm_deepep/pyt_vllm_deepep_v2_deepseek-v2-lite/aiter_build:/opt/aiter/aiter/jit/build -v /var/cache/mad/vllm_deepep/pyt_vllm_deepep_v2_deepseek-v2-lite/aiter_configs:/tmp/aiter_configs -v /var/cache/mad/vllm_deepep/pyt_vllm_deepep_v2_deepseek-v2-lite/deep_ep:/root/.deep_ep",
         "args": ""
     },
     {
@@ -46,7 +46,7 @@
         "env_vars": {
             "DOCKER_IMAGE_NAME": "<supply-your-image>"
         },
-        "additional_docker_run_options": "--device=/dev/infiniband --shm-size 128g --ulimit memlock=-1 --ulimit nofile=1048576:1048576 -e MODEL_REPO=deepseek-ai/DeepSeek-V2-Lite -e ALL2ALL_BACKEND=mori_high_throughput -e EP_NIC_NAME=bnxt_re0 -e NCCL_SOCKET_IFNAME=fenic0 -e WARMUP_RUNS=2 -e MEASURED_RUNS=3 -e CONCURRENCY=16 -e ISL=256 -e OSL=128",
+        "additional_docker_run_options": "--device=/dev/infiniband --shm-size 128g --ulimit memlock=-1 --ulimit nofile=1048576:1048576 -e MODEL_REPO=deepseek-ai/DeepSeek-V2-Lite -e MODEL_REVISION=604d5664dddd88a0433dbae533b7fe9472482de0 -e ALL2ALL_BACKEND=mori_high_throughput -e EP_NIC_NAME=bnxt_re0 -e NCCL_SOCKET_IFNAME=fenic0 -e WARMUP_RUNS=2 -e MEASURED_RUNS=3 -e CONCURRENCY=16 -e ISL=256 -e OSL=128 -v /var/cache/mad/vllm_deepep/pyt_vllm_mori_deepseek-v2-lite/aiter_build:/opt/aiter/aiter/jit/build -v /var/cache/mad/vllm_deepep/pyt_vllm_mori_deepseek-v2-lite/aiter_configs:/tmp/aiter_configs -v /var/cache/mad/vllm_deepep/pyt_vllm_mori_deepseek-v2-lite/deep_ep:/root/.deep_ep",
         "args": ""
     },
     {
@@ -71,7 +71,7 @@
         "env_vars": {
             "DOCKER_IMAGE_NAME": "<supply-your-image>"
         },
-        "additional_docker_run_options": "--device=/dev/infiniband --shm-size 128g --ulimit memlock=-1 --ulimit nofile=1048576:1048576 -e MODEL_REPO=deepseek-ai/DeepSeek-R1 -e ALL2ALL_BACKEND=deepep_v2 -e EP_NIC_NAME=bnxt_re0 -e NCCL_SOCKET_IFNAME=fenic0 -e GPU_MEMORY_UTILIZATION=0.80 -e WARMUP_RUNS=2 -e MEASURED_RUNS=3 -e CONCURRENCY=16 -e ISL=256 -e OSL=128",
+        "additional_docker_run_options": "--device=/dev/infiniband --shm-size 128g --ulimit memlock=-1 --ulimit nofile=1048576:1048576 -e MODEL_REPO=deepseek-ai/DeepSeek-R1 -e MODEL_REVISION=56d4cbbb4d29f4355bab4b9a39ccb717a14ad5ad -e ALL2ALL_BACKEND=deepep_v2 -e EP_NIC_NAME=bnxt_re0 -e NCCL_SOCKET_IFNAME=fenic0 -e GPU_MEMORY_UTILIZATION=0.80 -e WARMUP_RUNS=2 -e MEASURED_RUNS=3 -e CONCURRENCY=16 -e ISL=256 -e OSL=128 -v /var/cache/mad/vllm_deepep/pyt_vllm_deepep_v2_deepseek-r1/aiter_build:/opt/aiter/aiter/jit/build -v /var/cache/mad/vllm_deepep/pyt_vllm_deepep_v2_deepseek-r1/aiter_configs:/tmp/aiter_configs -v /var/cache/mad/vllm_deepep/pyt_vllm_deepep_v2_deepseek-r1/deep_ep:/root/.deep_ep",
         "args": ""
     }
 ]

--- a/scripts/vllm_deepep/models.json
+++ b/scripts/vllm_deepep/models.json
@@ -19,17 +19,9 @@
         ],
         "timeout": -1,
         "env_vars": {
-            "DOCKER_IMAGE_NAME": "<supply-your-image>",
-            "MODEL_REPO": "deepseek-ai/DeepSeek-V2-Lite",
-            "ALL2ALL_BACKEND": "deepep_v2",
-            "EP_NIC_NAME": "bnxt_re0",
-            "NCCL_SOCKET_IFNAME": "fenic0",
-            "WARMUP_RUNS": "2",
-            "MEASURED_RUNS": "3",
-            "CONCURRENCY": "16",
-            "ISL": "256",
-            "OSL": "128"
+            "DOCKER_IMAGE_NAME": "<supply-your-image>"
         },
+        "additional_docker_run_options": "--device=/dev/infiniband --shm-size 128g --ulimit memlock=-1 --ulimit nofile=1048576:1048576 -e MODEL_REPO=deepseek-ai/DeepSeek-V2-Lite -e ALL2ALL_BACKEND=deepep_v2 -e EP_NIC_NAME=bnxt_re0 -e NCCL_SOCKET_IFNAME=fenic0 -e WARMUP_RUNS=2 -e MEASURED_RUNS=3 -e CONCURRENCY=16 -e ISL=256 -e OSL=128",
         "args": ""
     },
     {
@@ -52,17 +44,9 @@
         ],
         "timeout": -1,
         "env_vars": {
-            "DOCKER_IMAGE_NAME": "<supply-your-image>",
-            "MODEL_REPO": "deepseek-ai/DeepSeek-V2-Lite",
-            "ALL2ALL_BACKEND": "mori_high_throughput",
-            "EP_NIC_NAME": "bnxt_re0",
-            "NCCL_SOCKET_IFNAME": "fenic0",
-            "WARMUP_RUNS": "2",
-            "MEASURED_RUNS": "3",
-            "CONCURRENCY": "16",
-            "ISL": "256",
-            "OSL": "128"
+            "DOCKER_IMAGE_NAME": "<supply-your-image>"
         },
+        "additional_docker_run_options": "--device=/dev/infiniband --shm-size 128g --ulimit memlock=-1 --ulimit nofile=1048576:1048576 -e MODEL_REPO=deepseek-ai/DeepSeek-V2-Lite -e ALL2ALL_BACKEND=mori_high_throughput -e EP_NIC_NAME=bnxt_re0 -e NCCL_SOCKET_IFNAME=fenic0 -e WARMUP_RUNS=2 -e MEASURED_RUNS=3 -e CONCURRENCY=16 -e ISL=256 -e OSL=128",
         "args": ""
     },
     {
@@ -85,18 +69,9 @@
         ],
         "timeout": -1,
         "env_vars": {
-            "DOCKER_IMAGE_NAME": "<supply-your-image>",
-            "MODEL_REPO": "deepseek-ai/DeepSeek-R1",
-            "ALL2ALL_BACKEND": "deepep_v2",
-            "EP_NIC_NAME": "bnxt_re0",
-            "NCCL_SOCKET_IFNAME": "fenic0",
-            "GPU_MEMORY_UTILIZATION": "0.80",
-            "WARMUP_RUNS": "2",
-            "MEASURED_RUNS": "3",
-            "CONCURRENCY": "16",
-            "ISL": "256",
-            "OSL": "128"
+            "DOCKER_IMAGE_NAME": "<supply-your-image>"
         },
+        "additional_docker_run_options": "--device=/dev/infiniband --shm-size 128g --ulimit memlock=-1 --ulimit nofile=1048576:1048576 -e MODEL_REPO=deepseek-ai/DeepSeek-R1 -e ALL2ALL_BACKEND=deepep_v2 -e EP_NIC_NAME=bnxt_re0 -e NCCL_SOCKET_IFNAME=fenic0 -e GPU_MEMORY_UTILIZATION=0.80 -e WARMUP_RUNS=2 -e MEASURED_RUNS=3 -e CONCURRENCY=16 -e ISL=256 -e OSL=128",
         "args": ""
     }
 ]

--- a/scripts/vllm_deepep/run_vllm_deepep.sh
+++ b/scripts/vllm_deepep/run_vllm_deepep.sh
@@ -113,6 +113,17 @@ else
 fi
 
 # --- server -----------------------------------------------------------------
+# Refuse to start if something already answers on PORT. Otherwise a stale
+# server left by an earlier run satisfies the readiness probe below, the newly
+# launched one dies with "address already in use", and the benchmark measures
+# the old process while the CSV labels it with this run's backend and model --
+# a wrong number that looks entirely well-formed.
+if curl -sf "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+  echo "something is already serving on port ${PORT}; refusing to start." >&2
+  echo "stop it, or set PORT to a free port." >&2
+  exit 1
+fi
+
 "${VLLM}" serve "${MODEL}" \
   --host 127.0.0.1 --port "${PORT}" \
   --tensor-parallel-size 1 \
@@ -166,7 +177,7 @@ for i in $(seq 1 "${WARMUP_RUNS}"); do
 done
 
 echo "model,performance,metric" > "${RESULT_CSV}"
-echo "backend,model,concurrency,isl,osl,run,total_tok_s,median_tpot_ms,p99_ttft_ms,warmup_discarded,mori_disable_topo" \
+echo "backend,model,concurrency,isl,osl,num_prompts,run,total_tok_s,median_tpot_ms,p99_ttft_ms,warmup_discarded,mori_disable_topo" \
   > "${DETAIL_CSV}"
 
 for i in $(seq 1 "${MEASURED_RUNS}"); do
@@ -180,19 +191,34 @@ for i in $(seq 1 "${MEASURED_RUNS}"); do
     exit 1
   fi
   echo "${out}" | tail -25
-  tput_val=$(echo "${out}" | awk '/Total token throughput/ {print $NF}')
-  tpot_val=$(echo "${out}" | awk '/Median TPOT/ {print $NF}')
-  ttft_val=$(echo "${out}" | awk '/P99 TTFT/ {print $NF}')
+  # `exit` after the first hit, deliberately. Newer `vllm bench serve` prints an
+  # automatic steady-state block in addition to the overall one, with the same
+  # labels; without this each awk returns two newline-separated values, the
+  # non-empty check still passes, and every CSV row becomes two malformed
+  # physical rows. The wheel is supplied externally, so its output format is
+  # not ours to pin.
+  tput_val=$(echo "${out}" | awk '/Total token throughput/ {print $NF; exit}')
+  tpot_val=$(echo "${out}" | awk '/Median TPOT/ {print $NF; exit}')
+  ttft_val=$(echo "${out}" | awk '/P99 TTFT/ {print $NF; exit}')
 
   # `vllm bench serve` exits 0 while reporting failed requests, and still
   # prints the three metric lines -- as zeros. Ingested, those are
   # indistinguishable from a successful measurement, which is worse than no
   # data. The most likely cause is ISL + OSL exceeding MAX_MODEL_LEN, where
   # every request fails and the run looks merely slow.
-  failed=$(echo "${out}" | awk '/Failed requests/ {print $NF}')
-  if [[ -n "${failed}" && "${failed}" != "0" ]]; then
-    echo "run ${i}: ${failed} failed request(s); refusing to record a result." >&2
-    echo "check that ISL(${ISL}) + OSL(${OSL}) < MAX_MODEL_LEN(${MAX_MODEL_LEN})." >&2
+  # Require an explicit zero. A missing field is not a pass: if the summary
+  # format changes and drops or renames this line, treating absence as success
+  # would silently disable the safeguard on exactly the runs it exists for.
+  failed=$(echo "${out}" | awk '/Failed requests/ {print $NF; exit}')
+  if [[ "${failed}" != "0" ]]; then
+    if [[ -z "${failed}" ]]; then
+      echo "run ${i}: no 'Failed requests' field in the summary; cannot confirm" >&2
+      echo "the run succeeded, so refusing to record a result." >&2
+    else
+      echo "run ${i}: ${failed} failed request(s); refusing to record a result." >&2
+      echo "check that ISL(${ISL}) + OSL(${OSL}) < MAX_MODEL_LEN(${MAX_MODEL_LEN})." >&2
+    fi
+    echo "${out}" | tail -40 >&2
     rm -f "${RESULT_CSV}" "${DETAIL_CSV}"
     exit 1
   fi
@@ -218,7 +244,7 @@ for i in $(seq 1 "${MEASURED_RUNS}"); do
   # MODEL, not MODEL_REPO: with MODEL_PATH set the server and the benchmark
   # both ran against the local path, and recording the repo id would label the
   # row with a model that was never loaded.
-  echo "${ALL2ALL_BACKEND},${MODEL},${CONCURRENCY},${ISL},${OSL},${i},${tput_val},${tpot_val},${ttft_val},${WARMUP_RUNS},${MORI_DISABLE_TOPO:-}" \
+  echo "${ALL2ALL_BACKEND},${MODEL},${CONCURRENCY},${ISL},${OSL},${NUM_PROMPTS},${i},${tput_val},${tpot_val},${ttft_val},${WARMUP_RUNS},${MORI_DISABLE_TOPO:-}" \
     >> "${DETAIL_CSV}"
 done
 

--- a/scripts/vllm_deepep/run_vllm_deepep.sh
+++ b/scripts/vllm_deepep/run_vllm_deepep.sh
@@ -155,7 +155,14 @@ bench_once() {
 
 echo "--- ${WARMUP_RUNS} warm-up run(s), discarded ---"
 for i in $(seq 1 "${WARMUP_RUNS}"); do
-  bench_once > /dev/null || { echo "warm-up run ${i} failed" >&2; exit 1; }
+  # The *measurements* are discarded, not the diagnostics: redirecting to
+  # /dev/null would leave a failed warm-up reporting only its run number, and
+  # the vLLM error that explains it is the whole content of the failure.
+  if ! out="$(bench_once)"; then
+    echo "warm-up run ${i} failed:" >&2
+    echo "${out}" | tail -40 >&2
+    exit 1
+  fi
 done
 
 echo "model,performance,metric" > "${RESULT_CSV}"
@@ -163,7 +170,15 @@ echo "backend,model,concurrency,isl,osl,run,total_tok_s,median_tpot_ms,p99_ttft_
   > "${DETAIL_CSV}"
 
 for i in $(seq 1 "${MEASURED_RUNS}"); do
-  out="$(bench_once)"
+  # Assigning from a command substitution that fails would abort here under
+  # `set -e` with the captured output still sitting unused in ${out} -- the run
+  # would die without ever showing why. Handle the status explicitly.
+  if ! out="$(bench_once)"; then
+    echo "run ${i}: benchmark exited nonzero:" >&2
+    echo "${out}" | tail -40 >&2
+    rm -f "${RESULT_CSV}" "${DETAIL_CSV}"
+    exit 1
+  fi
   echo "${out}" | tail -25
   tput_val=$(echo "${out}" | awk '/Total token throughput/ {print $NF}')
   tpot_val=$(echo "${out}" | awk '/Median TPOT/ {print $NF}')

--- a/scripts/vllm_deepep/run_vllm_deepep.sh
+++ b/scripts/vllm_deepep/run_vllm_deepep.sh
@@ -59,7 +59,14 @@ PYTHON="${PYTHON:-/opt/venv/bin/python}"
 VLLM="${VLLM:-/opt/venv/bin/vllm}"
 LOG_DIR="${LOG_DIR:-$(pwd)}"
 SERVER_LOG="${LOG_DIR}/vllm_${ALL2ALL_BACKEND}_server.log"
+# MAD ingests multiple_results in long form: it requires exactly the columns
+# model / performance / metric and drops everything else (tools/utils.py:1231
+# raises if one is missing; :1247-1250 reads only those three). So the
+# diagnostic context that makes a number interpretable -- backend, load shape,
+# discarded warm-ups -- cannot live in that file. It goes to a companion CSV
+# that is not registered as multiple_results and is therefore not parsed.
 RESULT_CSV="${LOG_DIR}/perf_vllm_deepep.csv"
+DETAIL_CSV="${LOG_DIR}/perf_vllm_deepep_detail.csv"
 
 echo "=== vllm_deepep: ${MODEL_REPO} over ${ALL2ALL_BACKEND} ==="
 
@@ -151,8 +158,9 @@ for i in $(seq 1 "${WARMUP_RUNS}"); do
   bench_once > /dev/null || { echo "warm-up run ${i} failed" >&2; exit 1; }
 done
 
+echo "model,performance,metric" > "${RESULT_CSV}"
 echo "backend,model,concurrency,isl,osl,run,total_tok_s,median_tpot_ms,p99_ttft_ms,warmup_discarded,mori_disable_topo" \
-  > "${RESULT_CSV}"
+  > "${DETAIL_CSV}"
 
 for i in $(seq 1 "${MEASURED_RUNS}"); do
   out="$(bench_once)"
@@ -160,9 +168,25 @@ for i in $(seq 1 "${MEASURED_RUNS}"); do
   tput_val=$(echo "${out}" | awk '/Total token throughput/ {print $NF}')
   tpot_val=$(echo "${out}" | awk '/Median TPOT/ {print $NF}')
   ttft_val=$(echo "${out}" | awk '/P99 TTFT/ {print $NF}')
-  echo "${ALL2ALL_BACKEND},${MODEL_REPO},${CONCURRENCY},${ISL},${OSL},${i},${tput_val},${tpot_val},${ttft_val},${WARMUP_RUNS},${MORI_DISABLE_TOPO:-}" \
+
+  # Each run is its own set of rows rather than a pre-averaged one, so a run
+  # that has not converged stays visible instead of being hidden in a mean.
+  # MAD prefixes these labels with the model-card name, which is what carries
+  # the backend and the model.
+  printf '%s\n' \
+    "run${i}_throughput,${tput_val},total_token_throughput_tok_s" \
+    "run${i}_tpot,${tpot_val},median_tpot_ms" \
+    "run${i}_ttft,${ttft_val},p99_ttft_ms" \
     >> "${RESULT_CSV}"
+
+  # MODEL, not MODEL_REPO: with MODEL_PATH set the server and the benchmark
+  # both ran against the local path, and recording the repo id would label the
+  # row with a model that was never loaded.
+  echo "${ALL2ALL_BACKEND},${MODEL},${CONCURRENCY},${ISL},${OSL},${i},${tput_val},${tpot_val},${ttft_val},${WARMUP_RUNS},${MORI_DISABLE_TOPO:-}" \
+    >> "${DETAIL_CSV}"
 done
 
 echo "=== results (${RESULT_CSV}) ==="
 cat "${RESULT_CSV}"
+echo "=== detail (${DETAIL_CSV}) ==="
+cat "${DETAIL_CSV}"

--- a/scripts/vllm_deepep/run_vllm_deepep.sh
+++ b/scripts/vllm_deepep/run_vllm_deepep.sh
@@ -123,7 +123,11 @@ fi
 
 if [[ -n "${MODEL_PATH:-}" ]]; then
   MODEL="${MODEL_PATH}"
-  MODEL_REVISION=""
+  # Not "main": that would claim this is the Hub's moving revision, when it
+  # is not on the Hub at all. Recorded as empty -- "not applicable" -- and
+  # rendered explicitly in the CSV below rather than through a ":-main"
+  # default, which cannot distinguish "unset" from "deliberately empty".
+  MODEL_REVISION_LABEL=""
 elif [[ -n "${MODEL_REVISION:-}" ]]; then
   # Resolve to one local snapshot and serve/benchmark THAT path. A --revision
   # flag on `vllm serve` alone is not enough: `vllm bench serve` loads its own
@@ -142,11 +146,12 @@ from huggingface_hub import snapshot_download
 print(snapshot_download('${MODEL_REPO}', revision='${MODEL_REVISION}'))
 ")"
   echo "resolved to ${MODEL}"
+  MODEL_REVISION_LABEL="${MODEL_REVISION}"
 else
   echo "MODEL_REVISION is not set; serving ${MODEL_REPO} at its moving" >&2
   echo "'main' Hub revision. Results are not reproducible run to run." >&2
   MODEL="${MODEL_REPO}"
-  MODEL_REVISION=""
+  MODEL_REVISION_LABEL="main"
 fi
 
 # --- server -----------------------------------------------------------------
@@ -206,6 +211,15 @@ bench_once() {
     --ignore-eos "${TRUST_REMOTE_CODE_ARGS[@]}" 2>&1
 }
 
+# Shared between warm-up and measured runs: a nonzero "Failed requests" count
+# does not fail the process, so checking the exit status alone is not enough
+# in either loop. For a warm-up specifically, a partial failure leaves AITER's
+# GEMM shapes still untuned -- exactly what warm-up exists to avoid -- while
+# pushing that cold-tuning cost into the first MEASURED run instead, silently.
+_failed_requests() {
+  echo "$1" | awk '/Failed requests/ {print $NF; exit}'
+}
+
 echo "--- ${WARMUP_RUNS} warm-up run(s), discarded ---"
 for i in $(seq 1 "${WARMUP_RUNS}"); do
   # The *measurements* are discarded, not the diagnostics: redirecting to
@@ -213,6 +227,14 @@ for i in $(seq 1 "${WARMUP_RUNS}"); do
   # the vLLM error that explains it is the whole content of the failure.
   if ! out="$(bench_once)"; then
     echo "warm-up run ${i} failed:" >&2
+    echo "${out}" | tail -40 >&2
+    exit 1
+  fi
+  failed="$(_failed_requests "${out}")"
+  if [[ "${failed}" != "0" ]]; then
+    echo "warm-up run ${i}: ${failed:-an unparseable} failed-request count;" >&2
+    echo "AITER's GEMM shapes are likely still untuned. Refusing to proceed" >&2
+    echo "into measured runs on a warm-up that did not actually warm anything." >&2
     echo "${out}" | tail -40 >&2
     exit 1
   fi
@@ -251,7 +273,7 @@ for i in $(seq 1 "${MEASURED_RUNS}"); do
   # Require an explicit zero. A missing field is not a pass: if the summary
   # format changes and drops or renames this line, treating absence as success
   # would silently disable the safeguard on exactly the runs it exists for.
-  failed=$(echo "${out}" | awk '/Failed requests/ {print $NF; exit}')
+  failed="$(_failed_requests "${out}")"
   if [[ "${failed}" != "0" ]]; then
     if [[ -z "${failed}" ]]; then
       echo "run ${i}: no 'Failed requests' field in the summary; cannot confirm" >&2
@@ -286,7 +308,7 @@ for i in $(seq 1 "${MEASURED_RUNS}"); do
   # MODEL, not MODEL_REPO: with MODEL_PATH set the server and the benchmark
   # both ran against the local path, and recording the repo id would label the
   # row with a model that was never loaded.
-  echo "${ALL2ALL_BACKEND},${MODEL},${MODEL_REVISION:-main},${CONCURRENCY},${ISL},${OSL},${NUM_PROMPTS},${i},${tput_val},${tpot_val},${ttft_val},${WARMUP_RUNS},${MORI_DISABLE_TOPO:-}" \
+  echo "${ALL2ALL_BACKEND},${MODEL},${MODEL_REVISION_LABEL},${CONCURRENCY},${ISL},${OSL},${NUM_PROMPTS},${i},${tput_val},${tpot_val},${ttft_val},${WARMUP_RUNS},${MORI_DISABLE_TOPO:-}" \
     >> "${DETAIL_CSV}"
 done
 

--- a/scripts/vllm_deepep/run_vllm_deepep.sh
+++ b/scripts/vllm_deepep/run_vllm_deepep.sh
@@ -55,6 +55,19 @@ NUM_PROMPTS="${NUM_PROMPTS:-64}"
 WARMUP_RUNS="${WARMUP_RUNS:-2}"
 MEASURED_RUNS="${MEASURED_RUNS:-3}"
 
+# seq 1 0 (or 1 <negative>) silently produces no iterations, so a bad value
+# here does not fail -- it skips straight to a header-only CSV and the script
+# exits 0, which MAD records as a successful run with zero measurements.
+_require_positive_int() {
+  local name="$1" value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name}=${value} must be a positive integer" >&2
+    exit 1
+  fi
+}
+_require_positive_int WARMUP_RUNS "${WARMUP_RUNS}"
+_require_positive_int MEASURED_RUNS "${MEASURED_RUNS}"
+
 PYTHON="${PYTHON:-/opt/venv/bin/python}"
 VLLM="${VLLM:-/opt/venv/bin/vllm}"
 LOG_DIR="${LOG_DIR:-$(pwd)}"
@@ -141,10 +154,14 @@ elif [[ -n "${MODEL_REVISION:-}" ]]; then
   # commands at the same local directory removes the second revision
   # entirely, rather than trying to keep two of them in sync.
   echo "resolving ${MODEL_REPO}@${MODEL_REVISION} to a local snapshot..."
+  # repo/revision passed as argv, not interpolated into the Python source: a
+  # ref containing a quote would otherwise produce a SyntaxError at best, and
+  # arbitrary Python at worst, from a value that is supposed to be inert data.
   MODEL="$("${PYTHON}" -c "
+import sys
 from huggingface_hub import snapshot_download
-print(snapshot_download('${MODEL_REPO}', revision='${MODEL_REVISION}'))
-")"
+print(snapshot_download(sys.argv[1], revision=sys.argv[2]))
+" "${MODEL_REPO}" "${MODEL_REVISION}")"
   echo "resolved to ${MODEL}"
   MODEL_REVISION_LABEL="${MODEL_REVISION}"
 else
@@ -196,14 +213,33 @@ for _ in $(seq 1 240); do
   fi
   sleep 15
 done
-curl -sf "http://127.0.0.1:${PORT}/health" >/dev/null
+# The loop above breaks on success or on the server dying; a server that
+# stays alive without ever answering healthy falls through to here. Checked
+# explicitly rather than left to run bare under set -e: an unguarded failure
+# at this point aborts with no message and no log tail, making a cold-JIT
+# hang or an init deadlock look identical to every other exit.
+if ! curl -sf "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+  echo "server never became healthy after $((240 * 15))s; tail of ${SERVER_LOG}:" >&2
+  tail -40 "${SERVER_LOG}" >&2
+  exit 1
+fi
+
+# Bounds a single benchmark invocation. Without it, a stall in the EP
+# collective after a healthy startup -- not covered by the health check above,
+# which only proves the server came up -- would hang here indefinitely,
+# occupying all 8 GPUs for as long as the job is left running. 1800s is
+# generous relative to a normal run (seconds to low minutes at the sizes this
+# script uses) rather than tuned to any one workload; override for larger
+# ISL/OSL/NUM_PROMPTS combinations.
+BENCH_TIMEOUT_SECS="${BENCH_TIMEOUT_SECS:-1800}"
 
 bench_once() {
   # --trust-remote-code forwarded: bench serve loads its own tokenizer
   # (get_tokenizer(...)) independently of the server, and a model that
   # genuinely needs the opt-in would otherwise serve successfully and then
   # fail here, after the server already came up.
-  "${VLLM}" bench serve --backend vllm --model "${MODEL}" \
+  timeout --kill-after=30 "${BENCH_TIMEOUT_SECS}" \
+    "${VLLM}" bench serve --backend vllm --model "${MODEL}" \
     --host 127.0.0.1 --port "${PORT}" \
     --dataset-name random \
     --random-input-len "${ISL}" --random-output-len "${OSL}" \
@@ -218,6 +254,21 @@ bench_once() {
 # pushing that cold-tuning cost into the first MEASURED run instead, silently.
 _failed_requests() {
   echo "$1" | awk '/Failed requests/ {print $NF; exit}'
+}
+
+# RFC4126-quoting via Python's csv module rather than string concatenation:
+# MODEL is attacker-influenced-in-practice input (MODEL_PATH, or a resolved
+# Hub snapshot path) and MODEL_REVISION is an arbitrary ref -- either could
+# contain a comma, a quote, or a newline, any of which shifts columns or
+# splits one row into several under plain `echo "a,b,c"`. Fields passed as
+# argv, not interpolated into source, for the same reason the snapshot
+# resolution above does it that way.
+_csv_row() {
+  "${PYTHON}" -c '
+import csv, sys
+csv.writer(sys.stdout, lineterminator="
+").writerow(sys.argv[1:])
+' "$@"
 }
 
 echo "--- ${WARMUP_RUNS} warm-up run(s), discarded ---"
@@ -299,17 +350,18 @@ for i in $(seq 1 "${MEASURED_RUNS}"); do
   # that has not converged stays visible instead of being hidden in a mean.
   # MAD prefixes these labels with the model-card name, which is what carries
   # the backend and the model.
-  printf '%s\n' \
-    "run${i}_throughput,${tput_val},total_token_throughput_tok_s" \
-    "run${i}_tpot,${tpot_val},median_tpot_ms" \
-    "run${i}_ttft,${ttft_val},p99_ttft_ms" \
+  _csv_row "run${i}_throughput" "${tput_val}" "total_token_throughput_tok_s" \
     >> "${RESULT_CSV}"
+  _csv_row "run${i}_tpot" "${tpot_val}" "median_tpot_ms" >> "${RESULT_CSV}"
+  _csv_row "run${i}_ttft" "${ttft_val}" "p99_ttft_ms" >> "${RESULT_CSV}"
 
   # MODEL, not MODEL_REPO: with MODEL_PATH set the server and the benchmark
   # both ran against the local path, and recording the repo id would label the
   # row with a model that was never loaded.
-  echo "${ALL2ALL_BACKEND},${MODEL},${MODEL_REVISION_LABEL},${CONCURRENCY},${ISL},${OSL},${NUM_PROMPTS},${i},${tput_val},${tpot_val},${ttft_val},${WARMUP_RUNS},${MORI_DISABLE_TOPO:-}" \
-    >> "${DETAIL_CSV}"
+  _csv_row "${ALL2ALL_BACKEND}" "${MODEL}" "${MODEL_REVISION_LABEL}" \
+    "${CONCURRENCY}" "${ISL}" "${OSL}" "${NUM_PROMPTS}" "${i}" \
+    "${tput_val}" "${tpot_val}" "${ttft_val}" "${WARMUP_RUNS}" \
+    "${MORI_DISABLE_TOPO:-}" >> "${DETAIL_CSV}"
 done
 
 echo "=== results (${RESULT_CSV}) ==="

--- a/scripts/vllm_deepep/run_vllm_deepep.sh
+++ b/scripts/vllm_deepep/run_vllm_deepep.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+###############################################################################
+#
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#################################################################################
+#
+# vLLM expert-parallel serving over an all-to-all backend, single node, 8 GPUs.
+#
+# Selects the backend with ALL2ALL_BACKEND (deepep_v2 | mori_high_throughput)
+# so the same script produces both arms of a backend comparison with nothing
+# else changed -- which is the only way the comparison means anything.
+#
+# Emits perf_vllm_deepep.csv (models.json: multiple_results).
+#
+#################################################################################
+set -euo pipefail
+
+MODEL_REPO="${MODEL_REPO:-deepseek-ai/DeepSeek-V2-Lite}"
+ALL2ALL_BACKEND="${ALL2ALL_BACKEND:-deepep_v2}"
+PORT="${PORT:-18000}"
+GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.70}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-512}"
+MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-256}"
+ISL="${ISL:-256}"
+OSL="${OSL:-128}"
+CONCURRENCY="${CONCURRENCY:-16}"
+NUM_PROMPTS="${NUM_PROMPTS:-64}"
+
+# AITER tunes GEMM shapes at run time behind a global lock, so an unwarmed run
+# measures the tuner, not the server: P99 TTFT lands around 20 s on the first
+# pass against a few hundred ms once warm, and roughly 270 s on DeepSeek-R1.
+# The discarded count is a reported field, not a hidden constant -- a
+# comparison that does not state it is not interpretable.
+WARMUP_RUNS="${WARMUP_RUNS:-2}"
+MEASURED_RUNS="${MEASURED_RUNS:-3}"
+
+PYTHON="${PYTHON:-/opt/venv/bin/python}"
+VLLM="${VLLM:-/opt/venv/bin/vllm}"
+LOG_DIR="${LOG_DIR:-$(pwd)}"
+SERVER_LOG="${LOG_DIR}/vllm_${ALL2ALL_BACKEND}_server.log"
+RESULT_CSV="${LOG_DIR}/perf_vllm_deepep.csv"
+
+echo "=== vllm_deepep: ${MODEL_REPO} over ${ALL2ALL_BACKEND} ==="
+
+# --- backend-specific environment -------------------------------------------
+# NCCL_CUMEM_ENABLE is required by BOTH backends: RCCL refuses symmetric memory
+# (and ncclDevCommCreate) without VMM.
+export NCCL_CUMEM_ENABLE=1
+export VLLM_ROCM_USE_AITER=1
+# vLLM refuses MoRI without AITER fused MoE, and running the two arms on
+# different MoE implementations would make the comparison meaningless, so both
+# arms use it.
+export VLLM_ROCM_USE_AITER_MOE=1
+export PYTHONPATH="${PYTHONPATH:-}:/opt/rocm/share/amd_smi"
+export HSA_NO_SCRATCH_RECLAIM=1
+
+case "${ALL2ALL_BACKEND}" in
+  deepep_v2)
+    # GIN stays on. It carries no payload inside a single XGMI domain, but it
+    # is the path that matters for scale-out, and testing a mode nobody
+    # deploys is not testing. Requires /dev/infiniband in the container.
+    export NCCL_GIN_TYPE="${NCCL_GIN_TYPE:-2}"
+    export EP_GIN_QUEUE_DEPTH="${EP_GIN_QUEUE_DEPTH:-0}"
+    export EP_NIC_NAME="${EP_NIC_NAME:-bnxt_re0}"
+    export VLLM_DEEPEP_TIMEOUT_SECS="${VLLM_DEEPEP_TIMEOUT_SECS:-1800}"
+    ;;
+  mori_high_throughput)
+    # Works around a null dereference in MoRI's CollectAndSortCandidates. It
+    # skips GPU/NIC affinity matching, which should not matter for a
+    # single-node run where traffic stays on XGMI -- but that is an
+    # expectation, so it is recorded in the CSV rather than left implicit.
+    export MORI_DISABLE_TOPO="${MORI_DISABLE_TOPO:-1}"
+    ;;
+  *)
+    echo "unknown ALL2ALL_BACKEND: ${ALL2ALL_BACKEND}" >&2
+    exit 1
+    ;;
+esac
+
+# --- model ------------------------------------------------------------------
+if [[ -n "${MODEL_PATH:-}" ]]; then
+  MODEL="${MODEL_PATH}"
+else
+  MODEL="${MODEL_REPO}"
+fi
+
+# --- server -----------------------------------------------------------------
+"${VLLM}" serve "${MODEL}" \
+  --host 127.0.0.1 --port "${PORT}" \
+  --tensor-parallel-size 1 \
+  --data-parallel-size 8 --data-parallel-size-local 8 \
+  --enable-expert-parallel \
+  --all2all-backend "${ALL2ALL_BACKEND}" \
+  --enforce-eager \
+  --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
+  --max-model-len "${MAX_MODEL_LEN}" \
+  --max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}" \
+  --trust-remote-code > "${SERVER_LOG}" 2>&1 &
+SERVER_PID=$!
+trap 'kill ${SERVER_PID} 2>/dev/null || true' EXIT
+
+echo "server pid ${SERVER_PID}, log ${SERVER_LOG}"
+
+# Startup is dominated by AITER JIT (~5-10 min cold, more on a large model),
+# so wait on the endpoint rather than on a fixed sleep.
+for _ in $(seq 1 240); do
+  if curl -sf "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+    echo "server died during startup; tail of ${SERVER_LOG}:" >&2
+    tail -40 "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 15
+done
+curl -sf "http://127.0.0.1:${PORT}/health" >/dev/null
+
+bench_once() {
+  "${VLLM}" bench serve --backend vllm --model "${MODEL}" \
+    --host 127.0.0.1 --port "${PORT}" \
+    --dataset-name random \
+    --random-input-len "${ISL}" --random-output-len "${OSL}" \
+    --max-concurrency "${CONCURRENCY}" --num-prompts "${NUM_PROMPTS}" \
+    --ignore-eos 2>&1
+}
+
+echo "--- ${WARMUP_RUNS} warm-up run(s), discarded ---"
+for i in $(seq 1 "${WARMUP_RUNS}"); do
+  bench_once > /dev/null || { echo "warm-up run ${i} failed" >&2; exit 1; }
+done
+
+echo "backend,model,concurrency,isl,osl,run,total_tok_s,median_tpot_ms,p99_ttft_ms,warmup_discarded,mori_disable_topo" \
+  > "${RESULT_CSV}"
+
+for i in $(seq 1 "${MEASURED_RUNS}"); do
+  out="$(bench_once)"
+  echo "${out}" | tail -25
+  tput_val=$(echo "${out}" | awk '/Total token throughput/ {print $NF}')
+  tpot_val=$(echo "${out}" | awk '/Median TPOT/ {print $NF}')
+  ttft_val=$(echo "${out}" | awk '/P99 TTFT/ {print $NF}')
+  echo "${ALL2ALL_BACKEND},${MODEL_REPO},${CONCURRENCY},${ISL},${OSL},${i},${tput_val},${tpot_val},${ttft_val},${WARMUP_RUNS},${MORI_DISABLE_TOPO:-}" \
+    >> "${RESULT_CSV}"
+done
+
+echo "=== results (${RESULT_CSV}) ==="
+cat "${RESULT_CSV}"

--- a/scripts/vllm_deepep/run_vllm_deepep.sh
+++ b/scripts/vllm_deepep/run_vllm_deepep.sh
@@ -169,6 +169,27 @@ for i in $(seq 1 "${MEASURED_RUNS}"); do
   tpot_val=$(echo "${out}" | awk '/Median TPOT/ {print $NF}')
   ttft_val=$(echo "${out}" | awk '/P99 TTFT/ {print $NF}')
 
+  # `vllm bench serve` exits 0 while reporting failed requests, and still
+  # prints the three metric lines -- as zeros. Ingested, those are
+  # indistinguishable from a successful measurement, which is worse than no
+  # data. The most likely cause is ISL + OSL exceeding MAX_MODEL_LEN, where
+  # every request fails and the run looks merely slow.
+  failed=$(echo "${out}" | awk '/Failed requests/ {print $NF}')
+  if [[ -n "${failed}" && "${failed}" != "0" ]]; then
+    echo "run ${i}: ${failed} failed request(s); refusing to record a result." >&2
+    echo "check that ISL(${ISL}) + OSL(${OSL}) < MAX_MODEL_LEN(${MAX_MODEL_LEN})." >&2
+    rm -f "${RESULT_CSV}" "${DETAIL_CSV}"
+    exit 1
+  fi
+  # An empty field means the summary did not parse -- a changed bench output
+  # format, or a run that died mid-way. Either way it is not a zero.
+  if [[ -z "${tput_val}" || -z "${tpot_val}" || -z "${ttft_val}" ]]; then
+    echo "run ${i}: could not parse the benchmark summary; refusing to record a result." >&2
+    echo "${out}" | tail -40 >&2
+    rm -f "${RESULT_CSV}" "${DETAIL_CSV}"
+    exit 1
+  fi
+
   # Each run is its own set of rows rather than a pre-averaged one, so a run
   # that has not converged stays visible instead of being hidden in a mean.
   # MAD prefixes these labels with the model-card name, which is what carries

--- a/scripts/vllm_deepep/run_vllm_deepep.sh
+++ b/scripts/vllm_deepep/run_vllm_deepep.sh
@@ -106,17 +106,6 @@ case "${ALL2ALL_BACKEND}" in
 esac
 
 # --- model ------------------------------------------------------------------
-if [[ -n "${MODEL_PATH:-}" ]]; then
-  MODEL="${MODEL_PATH}"
-else
-  MODEL="${MODEL_REPO}"
-fi
-# Pin the revision when serving straight from the hub: without it, a moving
-# `main` branch is what actually runs in a "reproducible" benchmark. Only
-# meaningful together with TRUST_REMOTE_CODE, since pinning a HF ref does
-# nothing for a local MODEL_PATH.
-MODEL_REVISION="${MODEL_REVISION:-}"
-
 # vLLM has native architectures for both configured models
 # (vllm/model_executor/models/deepseek_v2.py covers DeepseekV2ForCausalLM and
 # DeepseekV3ForCausalLM) and current transformers ships its own DeepseekV2Config
@@ -131,9 +120,33 @@ TRUST_REMOTE_CODE_ARGS=()
 if [[ "${TRUST_REMOTE_CODE}" == "1" ]]; then
   TRUST_REMOTE_CODE_ARGS=(--trust-remote-code)
 fi
-MODEL_REVISION_ARGS=()
-if [[ -n "${MODEL_REVISION}" ]]; then
-  MODEL_REVISION_ARGS=(--revision "${MODEL_REVISION}")
+
+if [[ -n "${MODEL_PATH:-}" ]]; then
+  MODEL="${MODEL_PATH}"
+  MODEL_REVISION=""
+elif [[ -n "${MODEL_REVISION:-}" ]]; then
+  # Resolve to one local snapshot and serve/benchmark THAT path. A --revision
+  # flag on `vllm serve` alone is not enough: `vllm bench serve` loads its own
+  # tokenizer independently, at the model's default (moving) Hub revision --
+  # https://github.com/vllm-project/vllm/blob/main/vllm/benchmarks/serve.py,
+  # `get_tokenizer(tokenizer_id, ...)` with no revision argument, and `vllm
+  # bench serve` has no --revision flag to give it one. So a moved `main`
+  # would tokenize the benchmark's prompts differently from what the pinned
+  # server understands, and the mismatch is silent -- both sides consider
+  # their own tokenizer authoritative. Downloading once and pointing both
+  # commands at the same local directory removes the second revision
+  # entirely, rather than trying to keep two of them in sync.
+  echo "resolving ${MODEL_REPO}@${MODEL_REVISION} to a local snapshot..."
+  MODEL="$("${PYTHON}" -c "
+from huggingface_hub import snapshot_download
+print(snapshot_download('${MODEL_REPO}', revision='${MODEL_REVISION}'))
+")"
+  echo "resolved to ${MODEL}"
+else
+  echo "MODEL_REVISION is not set; serving ${MODEL_REPO} at its moving" >&2
+  echo "'main' Hub revision. Results are not reproducible run to run." >&2
+  MODEL="${MODEL_REPO}"
+  MODEL_REVISION=""
 fi
 
 # --- server -----------------------------------------------------------------
@@ -158,7 +171,7 @@ fi
   --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
   --max-model-len "${MAX_MODEL_LEN}" \
   --max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}" \
-  "${TRUST_REMOTE_CODE_ARGS[@]}" "${MODEL_REVISION_ARGS[@]}" \
+  "${TRUST_REMOTE_CODE_ARGS[@]}" \
   > "${SERVER_LOG}" 2>&1 &
 SERVER_PID=$!
 trap 'kill ${SERVER_PID} 2>/dev/null || true' EXIT
@@ -181,12 +194,16 @@ done
 curl -sf "http://127.0.0.1:${PORT}/health" >/dev/null
 
 bench_once() {
+  # --trust-remote-code forwarded: bench serve loads its own tokenizer
+  # (get_tokenizer(...)) independently of the server, and a model that
+  # genuinely needs the opt-in would otherwise serve successfully and then
+  # fail here, after the server already came up.
   "${VLLM}" bench serve --backend vllm --model "${MODEL}" \
     --host 127.0.0.1 --port "${PORT}" \
     --dataset-name random \
     --random-input-len "${ISL}" --random-output-len "${OSL}" \
     --max-concurrency "${CONCURRENCY}" --num-prompts "${NUM_PROMPTS}" \
-    --ignore-eos 2>&1
+    --ignore-eos "${TRUST_REMOTE_CODE_ARGS[@]}" 2>&1
 }
 
 echo "--- ${WARMUP_RUNS} warm-up run(s), discarded ---"
@@ -202,7 +219,7 @@ for i in $(seq 1 "${WARMUP_RUNS}"); do
 done
 
 echo "model,performance,metric" > "${RESULT_CSV}"
-echo "backend,model,concurrency,isl,osl,num_prompts,run,total_tok_s,median_tpot_ms,p99_ttft_ms,warmup_discarded,mori_disable_topo" \
+echo "backend,model,model_revision,concurrency,isl,osl,num_prompts,run,total_tok_s,median_tpot_ms,p99_ttft_ms,warmup_discarded,mori_disable_topo" \
   > "${DETAIL_CSV}"
 
 for i in $(seq 1 "${MEASURED_RUNS}"); do
@@ -269,7 +286,7 @@ for i in $(seq 1 "${MEASURED_RUNS}"); do
   # MODEL, not MODEL_REPO: with MODEL_PATH set the server and the benchmark
   # both ran against the local path, and recording the repo id would label the
   # row with a model that was never loaded.
-  echo "${ALL2ALL_BACKEND},${MODEL},${CONCURRENCY},${ISL},${OSL},${NUM_PROMPTS},${i},${tput_val},${tpot_val},${ttft_val},${WARMUP_RUNS},${MORI_DISABLE_TOPO:-}" \
+  echo "${ALL2ALL_BACKEND},${MODEL},${MODEL_REVISION:-main},${CONCURRENCY},${ISL},${OSL},${NUM_PROMPTS},${i},${tput_val},${tpot_val},${ttft_val},${WARMUP_RUNS},${MORI_DISABLE_TOPO:-}" \
     >> "${DETAIL_CSV}"
 done
 

--- a/scripts/vllm_deepep/run_vllm_deepep.sh
+++ b/scripts/vllm_deepep/run_vllm_deepep.sh
@@ -111,6 +111,30 @@ if [[ -n "${MODEL_PATH:-}" ]]; then
 else
   MODEL="${MODEL_REPO}"
 fi
+# Pin the revision when serving straight from the hub: without it, a moving
+# `main` branch is what actually runs in a "reproducible" benchmark. Only
+# meaningful together with TRUST_REMOTE_CODE, since pinning a HF ref does
+# nothing for a local MODEL_PATH.
+MODEL_REVISION="${MODEL_REVISION:-}"
+
+# vLLM has native architectures for both configured models
+# (vllm/model_executor/models/deepseek_v2.py covers DeepseekV2ForCausalLM and
+# DeepseekV3ForCausalLM) and current transformers ships its own DeepseekV2Config
+# / DeepseekV3Config, so AutoConfig resolves without the repository's
+# auto_map -- trust_remote_code is not required for either DeepSeek-V2-Lite or
+# DeepSeek-R1. It defaults off. Executing a mutable HF repo's Python as root in
+# this container (host networking, elevated capabilities, device access) is
+# not something to enable by default; TRUST_REMOTE_CODE=1 is an explicit
+# opt-in for a model that genuinely needs it.
+TRUST_REMOTE_CODE="${TRUST_REMOTE_CODE:-0}"
+TRUST_REMOTE_CODE_ARGS=()
+if [[ "${TRUST_REMOTE_CODE}" == "1" ]]; then
+  TRUST_REMOTE_CODE_ARGS=(--trust-remote-code)
+fi
+MODEL_REVISION_ARGS=()
+if [[ -n "${MODEL_REVISION}" ]]; then
+  MODEL_REVISION_ARGS=(--revision "${MODEL_REVISION}")
+fi
 
 # --- server -----------------------------------------------------------------
 # Refuse to start if something already answers on PORT. Otherwise a stale
@@ -134,7 +158,8 @@ fi
   --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
   --max-model-len "${MAX_MODEL_LEN}" \
   --max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}" \
-  --trust-remote-code > "${SERVER_LOG}" 2>&1 &
+  "${TRUST_REMOTE_CODE_ARGS[@]}" "${MODEL_REVISION_ARGS[@]}" \
+  > "${SERVER_LOG}" 2>&1 &
 SERVER_PID=$!
 trap 'kill ${SERVER_PID} 2>/dev/null || true' EXIT
 

--- a/scripts/vllm_deepep/run_vllm_deepep.sh
+++ b/scripts/vllm_deepep/run_vllm_deepep.sh
@@ -256,7 +256,7 @@ _failed_requests() {
   echo "$1" | awk '/Failed requests/ {print $NF; exit}'
 }
 
-# RFC4126-quoting via Python's csv module rather than string concatenation:
+# RFC4180-quoting via Python's csv module rather than string concatenation:
 # MODEL is attacker-influenced-in-practice input (MODEL_PATH, or a resolved
 # Hub snapshot path) and MODEL_REVISION is an arbitrary ref -- either could
 # contain a comma, a quote, or a newline, any of which shifts columns or
@@ -266,8 +266,7 @@ _failed_requests() {
 _csv_row() {
   "${PYTHON}" -c '
 import csv, sys
-csv.writer(sys.stdout, lineterminator="
-").writerow(sys.argv[1:])
+csv.writer(sys.stdout, lineterminator=chr(10)).writerow(sys.argv[1:])
 ' "$@"
 }
 


### PR DESCRIPTION
## Summary

Adds `docker/vllm_deepep_inference.ubuntu.amd.Dockerfile`: a vLLM image that
serves mixture-of-experts models over DeepEP on MI350X (gfx950). Validated with
DeepSeek-R1 FP8 at `TP=1 / DP=8 / EP=8` on a single node, and benchmarked on
DeepSeek-V2-Lite.

Follows the staging pattern of `sglang_disagg_inference_full_overlay`: every
component is a gated stage, so a rebuild only pays for what changed.

- `DEEPEP_REPO` / `DEEPEP_COMMIT` — DeepEP. Required, and taken as build args
  rather than vendored.
- `AITER_COMMIT` — AITER plus the zero-token `get_ksplit` guard, which a
  data-parallel profile microbatch can otherwise trip into a division by zero.
- `RDMA_CORE_VERSION` — rdma-core from source, default `63.0`, replacing the
  distro packages and dropping the vendor `bnxt_re` provider. An empty value
  keeps the base image's.
- `ENABLE_TORCHVISION_STUB` — text-only torchvision surface, for ROCm bases
  whose torchvision ABI breaks `import vllm` through a multimodal config.

`BASE_IMAGE` matters, not just as a default: the distro RCCL on a stable ROCm
release (confirmed against ROCm 7.2.3's `rccl-dev` 2.27.7) does not ship
`nccl_device.h` or the device-side symmetric-memory API DeepEP's HIP GIN
backend needs, so DeepEP's build fails on that header regardless of anything
else in this file. RCCL is rebuilt from source in its own stage
(`rccl-build`, cache key independent of `DEEPEP_COMMIT`/`AITER_COMMIT`/
`VLLM_WHEEL`) to supply it on top of whatever base is given, but the base
still has to be recent enough to compile that RCCL and DeepEP's own HIP code
— the default is pinned to the THERock nightly this was actually built
against.

## Runtime notes captured in the header

These are the settings that cost the most time to rediscover:

- `NCCL_CUMEM_ENABLE=1` is mandatory. Without VMM, RCCL answers
  `Communicator does not support symmetric memory` and the ElasticBuffer is
  never created.
- **GIN stays on**, including on a single node. DeepEP moves no payload through
  it inside one XGMI domain — `is_scaleup_nvlink` is true and the barrier and
  dispatch/combine run over symmetric memory — but the buffer constructor still
  asserts on `ginType` and reserves queue pairs, so keeping it on requires
  `NCCL_GIN_TYPE=2`, `EP_GIN_QUEUE_DEPTH=0` and `/dev/infiniband` in the
  container (supplied via `additional_docker_run_options`, since madengine maps
  only `/dev/kfd` and the render nodes). This is deliberate: GIN is the path
  that matters for scale-out, and a single-node run that disables it is not
  exercising the transport. `EP_DISABLE_GIN=1` remains available and avoids the
  device requirement, but it tests a mode nobody deploys.

  Measured, so this is not an assumption: both backends were re-run with GIN on
  and nothing else changed. MoRI is 13.9% faster per output token with GIN on
  against 13.0% with it off — the same result within run-to-run noise, and the
  absolute figures land on the GIN-off values too.
- Mount the JIT caches. AITER tunes GEMM shapes at run time behind a global
  build lock; with data parallelism one rank tunes while the rest wait in the
  collective, which shows up as P99 TTFT in the tens of seconds until the cache
  covers the shapes in play.

## Test

Built and run on 8x MI350X. DeepSeek-R1 FP8 generates correctly. DeepSeek-V2-Lite
reaches 633 / 1238 / 2371 total tok/s at concurrency 8 / 16 / 32 for
`in=256, out=128`, measured after the tuning cache converges.

Two things worth stating explicitly, since they were not true of an earlier
revision of this PR and review caught both:

- **`docker build` of this file, end to end, with no manual patching.**
  Verified with a fresh build (no cache) through every stage —
  `rccl-build`, `rdma-core-build`, DeepEP, AITER, the vLLM wheel, the
  torchvision stub, and the rdma-core install/provider-purge — to
  `VLLM_DEEPEP_BUILD_OK`. This caught three build-breaking issues that no
  amount of code review found: the RCCL gap above, `COPY ${VLLM_WHEEL}
  /tmp/vllm.whl` renaming every wheel to a name pip's installer rejects
  (`Invalid wheel filename`), and `pip install --no-deps` silently dropping
  vLLM's own runtime dependencies (`ModuleNotFoundError: No module named
  'regex'` on first import).
- **A full `madengine build --use-image ... && madengine run` cycle against
  DeepSeek-V2-Lite**, not just a raw `docker run` of the script. Confirmed
  the `ENTRYPOINT []` keepalive, `additional_docker_run_options` reaching the
  container, `run_vllm_deepep.sh` executing, `Failed requests: 0`, and the
  long-form `perf_vllm_deepep.csv` ingesting into `perf.csv` without the
  `model`/`performance`/`metric` `RuntimeError` an earlier revision would
  have hit on every successful run.

Made with [Cursor](https://cursor.com)

