### PR TITLE
Llama-4-Scout: Primus training and SGLang inference

### DIFF
--- a/.claude/skills/mad-slurm-multinode/assets/manifests/primus_llama-4-scout.template.json
+++ b/.claude/skills/mad-slurm-multinode/assets/manifests/primus_llama-4-scout.template.json
@@ -1,0 +1,122 @@
+{
+  "built_images": {
+    "rocm-primus-llama4scout": {
+      "model": "primus_pyt_megatron_lm_train_llama-4-scout-17b-16e_overlay",
+      "docker_image": "rocm/primus:v26.3-<FILL_RCCL_TAG e.g. rccl-7.2.1 or rccl-develop-<sha7>>",
+      "dockerfile": "docker/primus_megatron_train_rccl_overlay.ubuntu.amd.Dockerfile",
+      "base_docker": "rocm/primus:v26.3",
+      "build_duration": 0,
+      "local_image": true,
+      "registry_image": null,
+      "registry": null,
+      "gpu_vendor": "AMD"
+    }
+  },
+  "built_models": {
+    "rocm-primus-llama4scout": {
+      "name": "primus_pyt_megatron_lm_train_llama-4-scout-17b-16e_overlay",
+      "url": "",
+      "dockerfile": "docker/primus_megatron_train_rccl_overlay.ubuntu.amd.Dockerfile",
+      "dockercontext": "./docker",
+      "scripts": "scripts/primus_megatron-lm/run.sh",
+      "n_gpus": "-1",
+      "owner": "mad.support@amd.com",
+      "training_precision": "",
+      "multiple_results": "perf_primus-megatron-Llama-4-Scout-17B-16E.csv",
+      "tags": ["pyt", "pretrain", "llama-4-scout", "moe", "training"],
+      "timeout": 14400,
+      "args": "--model_repo primus_pyt_megatron_lm_train_llama-4-scout-17b-16e",
+      "additional_docker_run_options": "--privileged --group-add render --shm-size 64G --device=/dev/infiniband --cap-add IPC_LOCK --ulimit memlock=-1 -v /sys:/sys:ro -v /run/udev:/run/udev:ro <FILL_AINIC_MOUNTS if fabric needs host ibverbs/ionic libs, e.g. -v /etc/libibverbs.d:/etc/libibverbs.d:ro -v /usr/lib/x86_64-linux-gnu/libionic.so:...:ro; delete if not needed, see references/cluster-types.md>"
+    }
+  },
+  "context": {
+    "docker_env_vars": {
+      "NCCL_DEBUG": "INFO",
+      "NCCL_DEBUG_SUBSYS": "INIT,NET",
+      "NCCL_IB_DISABLE": "0",
+      "NCCL_NET": "IB",
+      "NCCL_NET_PLUGIN": "none",
+      "NCCL_IB_HCA": "<FILL_NCCL_IB_HCA  data-plane HCA list, see references/cluster-types.md>",
+      "NCCL_IB_GID_INDEX": "<FILL_GID  RoCEv2 GID index, see references/cluster-types.md>",
+      "NCCL_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "GLOO_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "RDMAV_DRIVERS": "<FILL_DRIVER  see references/cluster-types.md>",
+      "IBV_DRIVERS": "<FILL_DRIVER  see references/cluster-types.md>",
+      "RCCL_AINIC_ROCE": "<FILL_RCCL_AINIC_ROCE  per archetype, see references/cluster-types.md; delete this key if not needed>",
+      "IBV_SHOW_WARNINGS": "1",
+      "NVTE_USE_CAST_TRANSPOSE_TRITON": "0"
+    },
+    "docker_mounts": {
+      "/dev/infiniband": "/dev/infiniband"
+    },
+    "docker_build_arg": {
+      "BASE_DOCKER": "rocm/primus:v26.3",
+      "BUILD_GPU_TARGETS": "<FILL_GPU_TARGETS  gfx942=MI300X/MI325X, gfx950=MI350X/MI355X>",
+      "RCCL_REPO": "https://github.com/ROCm/rocm-systems.git",
+      "RCCL_BRANCH": "",
+      "RCCL_COMMIT": "<FILL_RCCL_COMMIT  pinned RCCL commit sha; leave RCCL_BRANCH/RCCL_COMMIT empty to keep the base image RCCL>"
+    },
+    "gpu_vendor": "AMD",
+    "guest_os": "UBUNTU",
+    "docker_gpus": "0,1,2,3,4,5,6,7"
+  },
+  "credentials_required": [],
+  "summary": {
+    "successful_builds": [],
+    "failed_builds": [],
+    "total_build_time": 0,
+    "successful_pushes": [],
+    "failed_pushes": []
+  },
+  "deployment_config": {
+    "target": "slurm",
+    "slurm": {
+      "partition": "<FILL_PARTITION>",
+      "account": "<FILL_ACCOUNT or remove if cluster has none>",
+      "qos": "<FILL_QOS>",
+      "reservation": "<FILL_RESERVATION or remove if none>",
+      "nodes": 2,
+      "gpus_per_node": 8,
+      "time": "04:00:00",
+      "output_dir": "./slurm_output",
+      "exclusive": true,
+      "network_interface": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "nodelist": "<FILL_NODELIST optional: pin to specific nodes, e.g. node-a,node-b; delete this key to let SLURM schedule>"
+    },
+    "distributed": {
+      "launcher": "torchrun",
+      "backend": "nccl",
+      "port": 29500,
+      "nnodes": 2,
+      "nproc_per_node": 8
+    },
+    "env_vars": {
+      "HF_HOME": "${HF_HOME}",
+      "TORCH_HOME": "${TORCH_HOME}",
+      "XDG_CACHE_HOME": "${XDG_CACHE_HOME}",
+      "PIP_CACHE_DIR": "${PIP_CACHE_DIR}",
+      "MAD_DATAHOME": "${MAD_DATAHOME}",
+      "SCOUT_MOE_DISPATCHER": "alltoall",
+      "NCCL_DEBUG": "INFO",
+      "NCCL_DEBUG_SUBSYS": "INIT,NET",
+      "NCCL_IB_DISABLE": "0",
+      "NCCL_NET": "IB",
+      "NCCL_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "GLOO_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "NCCL_IB_GID_INDEX": "<FILL_GID  RoCEv2 GID index, see references/cluster-types.md>",
+      "NCCL_IB_HCA": "<FILL_NCCL_IB_HCA  same value as context.docker_env_vars>",
+      "RDMAV_DRIVERS": "<FILL_DRIVER  see references/cluster-types.md>",
+      "IBV_DRIVERS": "<FILL_DRIVER  see references/cluster-types.md>",
+      "RCCL_AINIC_ROCE": "<FILL_RCCL_AINIC_ROCE  per archetype, see references/cluster-types.md; delete this key if not needed>",
+      "NCCL_TIMEOUT": "900",
+      "TORCH_NCCL_ASYNC_ERROR_HANDLING": "1",
+      "TORCH_NCCL_HIGH_PRIORITY": "1",
+      "OMP_NUM_THREADS": "8",
+      "MIOPEN_FIND_MODE": "1",
+      "MIOPEN_USER_DB_PATH": "${XDG_CACHE_HOME}/miopen",
+      "NVTE_USE_CAST_TRANSPOSE_TRITON": "0"
+    },
+    "debug": false,
+    "docker_gpus": "0,1,2,3,4,5,6,7"
+  }
+}

--- a/.claude/skills/mad-slurm-multinode/assets/manifests/sglang_disagg_llama-4-scout.template.json
+++ b/.claude/skills/mad-slurm-multinode/assets/manifests/sglang_disagg_llama-4-scout.template.json
@@ -1,0 +1,153 @@
+{
+  "built_images": {
+    "sglang-disagg-llama-4-scout": {
+      "model": "sglang-disagg-llama-4-scout-overlay",
+      "docker_image": "<FILL_TAG  single full-overlay image tag, e.g. sglang-v0514-overlay:rccl-<sha>smifix-mori-<sha>-rixl-<sha>-mooncake<ver>-gfx942 (append -rdma62 when built with --build-arg ENABLE_RDMA62=1)>",
+      "dockerfile": "docker/sglang_disagg_inference_full_overlay.ubuntu.amd.Dockerfile",
+      "base_docker": "lmsysorg/sglang:v0.5.14-rocm720-mi30x",
+      "build_duration": 0,
+      "local_image": true,
+      "registry_image": null,
+      "registry": null,
+      "gpu_vendor": "AMD"
+    }
+  },
+  "built_models": {
+    "sglang-disagg-llama-4-scout": {
+      "name": "sglang-disagg-llama-4-scout-overlay",
+      "url": "",
+      "dockerfile": "docker/sglang_disagg_inference_full_overlay.ubuntu.amd.Dockerfile",
+      "scripts": "scripts/sglang_disagg/run.sh",
+      "data": "",
+      "n_gpus": "-1",
+      "owner": "mad.support@amd.com",
+      "training_precision": "",
+      "multiple_results": "perf_sglang-disagg-Llama-4-Scout-17B-16E-Instruct.csv",
+      "tags": ["pyt", "sglang", "disagg", "inference", "llama-4-scout"],
+      "timeout": 21600,
+      "args": "--model-name Llama-4-Scout-17B-16E-Instruct --model-path <FILL_MODEL_PATH  in-container absolute path to Llama-4-Scout-17B-16E-Instruct weights; if MODEL_PATH/config.json is absent run.sh rank-0 downloads from HF (MODEL_REPO override, else the non-gated unsloth mirror) and peers wait on MODEL_PATH/.stage_done> --run-mori 1 --dp-mode 0 --xp 2 --yd 2 --gpus-per-node 8 --kv-transfer-backend mori",
+      "additional_docker_run_options": "--privileged --group-add render --shm-size 64G --device=/dev/infiniband --cap-add IPC_LOCK --ulimit memlock=-1 --ulimit nofile=1048576:1048576 -v /sys:/sys:ro -v /sys/class/infiniband:/sys/class/infiniband:ro -v /run/udev:/run/udev:ro -v <FILL_MODEL_HOST_DIR  host NFS dir holding the weights>:<FILL_MODEL_CONTAINER_DIR  parent of --model-path> -v ${SLURM_SUBMIT_DIR}/slurm_output/run_logs:/run_logs -e SLURM_JOB_ID"
+    }
+  },
+  "context": {
+    "skip_perf_collection": false,
+    "docker_env_vars": {
+      "MODEL_NAME": "Llama-4-Scout-17B-16E-Instruct",
+      "MODEL_PATH": "<FILL_MODEL_PATH  same as built_models.args --model-path>",
+      "MODEL_REPO": "unsloth/Llama-4-Scout-17B-16E-Instruct",
+      "RUN_MORI": "1",
+      "DP_MODE": "0",
+      "xP": "2",
+      "yD": "2",
+      "GPUS_PER_NODE": "8",
+      "KV_TRANSFER_BACKEND": "mori",
+      "MORI_JIT_CACHE_DIR": "/tmp/mori_jit",
+      "MORI_SHMEM_HEAP_SIZE": "17179869184",
+      "RDMA_CORE_CACHE": "<FILL_RDMA_CORE_CACHE  shared-FS rdma-core build cache; only used when the image was built with --build-arg ENABLE_RDMA62=1>",
+      "NCCL_DEBUG": "WARN",
+      "NCCL_DEBUG_SUBSYS": "INIT,NET",
+      "NCCL_IB_DISABLE": "0",
+      "NCCL_IB_HCA": "<FILL_NCCL_IB_HCA  data-plane HCA list with ports, e.g. mlx5_0:1,...; see references/cluster-types.md>",
+      "IB_DEVICES": "<FILL_IB_DEVICES  data-plane HCA list without ports, e.g. mlx5_0,...>",
+      "MORI_RDMA_DEVICES": "<FILL_MORI_RDMA_DEVICES  same HCA list as IB_DEVICES; MoRI EP all-to-all transport>",
+      "NCCL_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "GLOO_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "MORI_SOCKET_IFNAME": "<FILL_IFNAME  management iface; MoRI bootstrap iface>",
+      "NCCL_IB_GID_INDEX": "<FILL_GID  RoCEv2 GID index, see references/cluster-types.md>",
+      "MORI_IB_GID_INDEX": "<FILL_GID  same GID index as NCCL_IB_GID_INDEX>",
+      "RDMAV_DRIVERS": "<FILL_DRIVER  e.g. mlx5; see references/cluster-types.md>",
+      "IBV_DRIVERS": "<FILL_DRIVER  e.g. mlx5; see references/cluster-types.md>",
+      "TORCH_NCCL_HIGH_PRIORITY": "1",
+      "GPU_MAX_HW_QUEUES": "2",
+      "TORCH_NCCL_ASYNC_ERROR_HANDLING": "1",
+      "NCCL_TIMEOUT": "900",
+      "HSA_ENABLE_SDMA": "0",
+      "HSA_FORCE_FINE_GRAIN_PCIE": "1",
+      "OMP_NUM_THREADS": "8",
+      "MIOPEN_FIND_MODE": "1",
+      "SMOKE": "0",
+      "BENCHMARK_ITR": "1",
+      "BENCHMARK_COMBINATIONS": "1024/1024 8192/1024",
+      "BENCHMARK_CONCURRENCY_LEVELS": "8 16 32 64",
+      "BENCHMARK_PRECHECK": "0",
+      "BENCHMARK_FAIL_FAST": "1"
+    },
+    "docker_mounts": {
+      "/dev/infiniband": "/dev/infiniband",
+      "/sys/class/infiniband": "/sys/class/infiniband",
+      "<FILL_MODEL_CONTAINER_DIR  parent of --model-path>": "<FILL_MODEL_HOST_DIR  host NFS dir containing Llama-4-Scout-17B-16E-Instruct>"
+    },
+    "docker_build_arg": {},
+    "gpu_vendor": "AMD",
+    "guest_os": "UBUNTU",
+    "docker_gpus": "0,1,2,3,4,5,6,7"
+  },
+  "credentials_required": [],
+  "summary": {
+    "successful_builds": [],
+    "failed_builds": [],
+    "total_build_time": 0,
+    "successful_pushes": [],
+    "failed_pushes": []
+  },
+  "deployment_config": {
+    "target": "slurm",
+    "slurm": {
+      "partition": "<FILL_PARTITION>",
+      "account": "<FILL_ACCOUNT or remove if cluster has none>",
+      "qos": "<FILL_QOS>",
+      "nodes": 4,
+      "gpus_per_node": 8,
+      "time": "02:30:00",
+      "output_dir": "./slurm_output",
+      "exclusive": true,
+      "network_interface": "<FILL_IFNAME  management iface, see references/cluster-types.md>"
+    },
+    "distributed": {
+      "launcher": "sglang-disagg",
+      "backend": "nccl",
+      "port": 29500,
+      "nnodes": 4,
+      "nproc_per_node": 8,
+      "sglang_disagg": {
+        "prefill_nodes": 2,
+        "decode_nodes": 2
+      }
+    },
+    "env_vars": {
+      "MODEL_NAME": "Llama-4-Scout-17B-16E-Instruct",
+      "MODEL_PATH": "<FILL_MODEL_PATH  same as context.docker_env_vars>",
+      "MODEL_REPO": "unsloth/Llama-4-Scout-17B-16E-Instruct",
+      "RUN_MORI": "1",
+      "DP_MODE": "0",
+      "xP": "2",
+      "yD": "2",
+      "GPUS_PER_NODE": "8",
+      "KV_TRANSFER_BACKEND": "mori",
+      "MORI_JIT_CACHE_DIR": "/tmp/mori_jit",
+      "MORI_SHMEM_HEAP_SIZE": "17179869184",
+      "RDMA_CORE_CACHE": "<FILL_RDMA_CORE_CACHE  same as context.docker_env_vars>",
+      "NCCL_DEBUG": "WARN",
+      "NCCL_IB_DISABLE": "0",
+      "NCCL_IB_HCA": "<FILL_NCCL_IB_HCA  same value as context.docker_env_vars>",
+      "IB_DEVICES": "<FILL_IB_DEVICES  same value as context.docker_env_vars>",
+      "MORI_RDMA_DEVICES": "<FILL_MORI_RDMA_DEVICES  same value as context.docker_env_vars>",
+      "NCCL_SOCKET_IFNAME": "<FILL_IFNAME  management iface>",
+      "GLOO_SOCKET_IFNAME": "<FILL_IFNAME  management iface>",
+      "MORI_SOCKET_IFNAME": "<FILL_IFNAME  management iface>",
+      "NCCL_IB_GID_INDEX": "<FILL_GID  RoCEv2 GID index>",
+      "MORI_IB_GID_INDEX": "<FILL_GID  same as NCCL_IB_GID_INDEX>",
+      "RDMAV_DRIVERS": "<FILL_DRIVER  e.g. mlx5>",
+      "IBV_DRIVERS": "<FILL_DRIVER  e.g. mlx5>",
+      "NCCL_TIMEOUT": "900",
+      "OMP_NUM_THREADS": "8",
+      "BENCHMARK_COMBINATIONS": "1024/1024 8192/1024",
+      "BENCHMARK_CONCURRENCY_LEVELS": "8 16 32 64",
+      "BENCHMARK_FAIL_FAST": "1"
+    },
+    "monitor": true,
+    "debug": false,
+    "docker_gpus": "0,1,2,3,4,5,6,7",
+    "gpus_per_node": 8
+  }
+}

--- a/.claude/skills/mad-slurm-multinode/assets/manifests/sglang_disagg_llama-4-scout.template.json
+++ b/.claude/skills/mad-slurm-multinode/assets/manifests/sglang_disagg_llama-4-scout.template.json
@@ -2,7 +2,7 @@
   "built_images": {
     "sglang-disagg-llama-4-scout": {
       "model": "sglang-disagg-llama-4-scout-overlay",
-      "docker_image": "<FILL_TAG  single full-overlay image tag, e.g. sglang-v0514-overlay:rccl-<sha>smifix-mori-<sha>-rixl-<sha>-mooncake<ver>-gfx942 (append -rdma62 when built with --build-arg ENABLE_RDMA62=1)>",
+      "docker_image": "<FILL_TAG  single full-overlay image tag naming the arch and rdma-core, e.g. sglang-v0514-overlay:rccl-78e8ba0smifix-mori-a14e6992-gfx942-rdma63>",
       "dockerfile": "docker/sglang_disagg_inference_full_overlay.ubuntu.amd.Dockerfile",
       "base_docker": "lmsysorg/sglang:v0.5.14-rocm720-mi30x",
       "build_duration": 0,

--- a/.claude/skills/mad-slurm-multinode/references/gotchas.md
+++ b/.claude/skills/mad-slurm-multinode/references/gotchas.md
@@ -313,7 +313,7 @@ print_rank_last throughput last global rank, multi-node perf collection rank-0.
   IB/RoCE net path directly. The primus template ships this key set to `none`.
 
 - **`rocm/primus:v26.5` can train fine and still report nothing — pin the base
-  the model was validated on.** Observed on Llama-4-Scout, 2 nodes / 16 GPU
+  that the model was validated on.** Observed on Llama-4-Scout, 2 nodes / 16 GPU
   gfx950: on `v26.5` the run completes all 50 iterations and logs
   `pretrain() completed successfully`, but every step also logs
   `[Patch:megatron.training_log] No token throughput`, the Primus summary prints

--- a/.claude/skills/mad-slurm-multinode/references/gotchas.md
+++ b/.claude/skills/mad-slurm-multinode/references/gotchas.md
@@ -312,6 +312,21 @@ print_rank_last throughput last global rank, multi-node perf collection rank-0.
   transport vars) to disable the plugin and let the bundled `librccl` drive the
   IB/RoCE net path directly. The primus template ships this key set to `none`.
 
+- **`rocm/primus:v26.5` can train fine and still report nothing — pin the base
+  the model was validated on.** Observed on Llama-4-Scout, 2 nodes / 16 GPU
+  gfx950: on `v26.5` the run completes all 50 iterations and logs
+  `pretrain() completed successfully`, but every step also logs
+  `[Patch:megatron.training_log] No token throughput`, the Primus summary prints
+  `Harmonic mean of TPS (excluding first 2 steps): N/A`, and
+  `primus_megatron-lm_benchmark_report.py` finds no `tokens/s/GPU` — so the perf
+  CSV comes out empty and madengine scores the run FAILED. The identical commit
+  on `rocm/primus:v26.3` gave 48/48 parsed iterations, 2749.5 tok/s/GPU and
+  276.8 TFLOP/s/GPU. This is easy to misread as a parser bug in MAD; it is not —
+  grep the training log for `No token throughput` before touching the parser.
+  The v26.5 run additionally SIGSEGVs at teardown
+  (`destroy_process_group() was not called before program exit`), which is a
+  second, independent reason it is scored as a failure.
+
 ## pyt_mlperf_training (MLPerf Llama-3.1)
 
 Keywords: mlperf training llama-3.1-8b nemo megatron-core version pairing,

--- a/.claude/skills/mad-slurm-multinode/references/manifests.md
+++ b/.claude/skills/mad-slurm-multinode/references/manifests.md
@@ -124,6 +124,26 @@ differ, the host path belongs on the value side.
   `timeout: 14400` (4h) — the CLI default (7200s/2h) times out on this model;
   keep the explicit 14400. `multiple_results` =
   `perf_primus-megatron-GPT-OSS-120B.csv`.
+- **Primus Llama-4-Scout-17B-16E**
+  (`primus_pyt_megatron_lm_train_llama-4-scout-17b-16e_overlay`): same
+  `rccl_overlay` Dockerfile / `torchrun` shape. MoE, BF16 only, seq 4096, MBS=1;
+  the shipped config runs EP=8 intra-node with TP=1/PP=1, so scaleout is pure
+  data parallelism and the global batch is renormalised to one micro-batch per
+  rank. Two knobs, both optional:
+  - `SCOUT_MOE_DISPATCHER` (default `alltoall`) — set `allgather` to route the
+    MoE dispatch around a RCCL build that hangs in `ALLTOALL_BASE`; the script
+    then also turns off `moe_shared_expert_overlap`, which is alltoall-only.
+  - `SCOUT_HF_TOKENIZER` (default `unsloth/Llama-4-Scout-17B-16E`) — a non-gated
+    mirror, so the run does not need a per-account Llama-4 license grant. Point
+    it at `meta-llama/Llama-4-Scout-17B-16E` once access is granted.
+  Reference point: 2 nodes / 16 GPU gfx950, BF16, `alltoall` → ~2734 tok/s/GPU,
+  ~275 TFLOP/s/GPU on `rocm/primus:v26.3` with RCCL develop `f1be5f14` (the
+  earlier `c67fbe4956` hung in the MoE all-to-all). Reproduced on this template:
+  2749.5 tok/s/GPU, 276.8 TFLOP/s/GPU, 48/48 parsed iterations, 0 RCCL errors.
+  The `v26.3` pin is deliberate — on `v26.5` the run trains to completion but
+  emits no throughput at all, see
+  [gotchas.md](gotchas.md#primus_megatron-training).
+  `multiple_results` = `perf_primus-megatron-Llama-4-Scout-17B-16E.csv`.
 - **sglang_disagg** (`sglang-disagg-deepseek-r1-overlay`): disaggregated
   prefill/decode serving of DeepSeek-R1 on SGLang.
   `launcher: sglang-disagg`, `scripts/sglang_disagg/run.sh` entrypoint,
@@ -173,6 +193,20 @@ differ, the host path belongs on the value side.
      (attention backend selection is CLI-driven, independent of this env
      var).
   `multiple_results` = `perf_sglang-disagg-GPT-OSS-120B.csv`.
+- **sglang_disagg Llama-4-Scout-17B-16E-Instruct**
+  (`sglang-disagg-llama-4-scout-overlay`): 17Bx16E MoE, bf16, same 4-node
+  xP=2/yD=2 shape. TP-only (`DP_MODE=0`) with `RUN_MORI=1` and `mori`
+  KV-transfer. The three flags that matter are already in
+  `scripts/sglang_disagg/models.yaml`, no manifest action needed:
+  `--attention-backend triton` and `--moe-runner-backend triton` (the AITER MoE
+  kernels segfault during Llama-4 warmup on gfx950 and are unnecessary on
+  gfx942), and `--disable-custom-all-reduce` (the custom all-reduce kernel
+  SIGSEGVs in the warmup embedding all-reduce; plain RCCL all-reduce is used
+  instead). Verified at 4 nodes on gfx942 (MI300X) / Mellanox CX7. This
+  registration is arch-agnostic: gfx950 needs further kernel workarounds that
+  are **not** part of it. Weights default to the non-gated
+  `unsloth/Llama-4-Scout-17B-16E-Instruct` mirror.
+  `multiple_results` = `perf_sglang-disagg-Llama-4-Scout-17B-16E-Instruct.csv`.
 - **MLPerf Training Llama-3.1-8B** (`pyt_mlperf_training_llama-3.1-8b`): the
   MLCommons `small_llm_pretraining/nemo` benchmark on the NeMo/Megatron/TE stack.
   `launcher: torchrun`, `scripts/pyt_mlperf_training/run.sh`, `nproc_per_node: 8`,

--- a/.claude/skills/mad-slurm-multinode/references/manifests.md
+++ b/.claude/skills/mad-slurm-multinode/references/manifests.md
@@ -202,10 +202,19 @@ differ, the host path belongs on the value side.
   kernels segfault during Llama-4 warmup on gfx950 and are unnecessary on
   gfx942), and `--disable-custom-all-reduce` (the custom all-reduce kernel
   SIGSEGVs in the warmup embedding all-reduce; plain RCCL all-reduce is used
-  instead). Verified at 4 nodes on gfx942 (MI300X) / Mellanox CX7. This
-  registration is arch-agnostic: gfx950 needs further kernel workarounds that
-  are **not** part of it. Weights default to the non-gated
-  `unsloth/Llama-4-Scout-17B-16E-Instruct` mirror.
+  instead). Verified at 4 nodes on gfx942 (MI300X) / Mellanox CX7, and
+  independently reproduced end-to-end at 4 nodes on gfx950 (MI355X) / Broadcom
+  Thor2 bnxt_re with this exact arch-agnostic registration (no gfx950-specific
+  kernel guards) — full 8-point benchmark sweep, all points returned real
+  completions, e.g. ISL/OSL 1024/1024 @ concurrency 64: 9622 tok/s total, TTFT
+  11497 ms. **Use `KV_TRANSFER_BACKEND=mori` (`RUN_MORI=1`), not `nixl`** — on
+  this cluster `nixl` never hung with an error, it just never completed a
+  request end-to-end (readiness probes retried indefinitely, no crash, no
+  timeout); switching to `mori` with everything else unchanged fixed it
+  immediately. This registration is arch-agnostic: gfx950 needs further kernel
+  workarounds for some models, but none were needed to reach this result here.
+  Weights default to the non-gated `unsloth/Llama-4-Scout-17B-16E-Instruct`
+  mirror.
   `multiple_results` = `perf_sglang-disagg-Llama-4-Scout-17B-16E-Instruct.csv`.
 - **MLPerf Training Llama-3.1-8B** (`pyt_mlperf_training_llama-3.1-8b`): the
   MLCommons `small_llm_pretraining/nemo` benchmark on the NeMo/Megatron/TE stack.

--- a/scripts/primus_megatron-lm/models.json
+++ b/scripts/primus_megatron-lm/models.json
@@ -3,6 +3,7 @@
     "name": "primus_pyt_megatron_lm_train_llama-3.1-8b_overlay",
     "url": "",
     "dockerfile": "../../docker/primus_megatron_train_rccl_overlay",
+    "dockercontext": "./docker",
     "scripts": "run.sh",
     "n_gpus": "-1",
     "owner": "mad.support@amd.com",
@@ -23,6 +24,7 @@
     "name": "primus_pyt_megatron_lm_train_llama-3.1-70b_overlay",
     "url": "",
     "dockerfile": "../../docker/primus_megatron_train_rccl_overlay",
+    "dockercontext": "./docker",
     "scripts": "run.sh",
     "n_gpus": "-1",
     "owner": "mad.support@amd.com",
@@ -43,6 +45,7 @@
     "name": "primus_pyt_megatron_lm_train_llama-3.1-405b_overlay",
     "url": "",
     "dockerfile": "../../docker/primus_megatron_train_rccl_overlay",
+    "dockercontext": "./docker",
     "scripts": "run.sh",
     "n_gpus": "-1",
     "owner": "mad.support@amd.com",
@@ -63,6 +66,7 @@
     "name": "primus_pyt_megatron_lm_train_gpt-oss-120b_overlay",
     "url": "",
     "dockerfile": "../../docker/primus_megatron_train_rccl_overlay",
+    "dockercontext": "./docker",
     "scripts": "run.sh",
     "n_gpus": "-1",
     "owner": "mad.support@amd.com",
@@ -77,5 +81,27 @@
     ],
     "timeout": -1,
     "args": "--model_repo primus_pyt_megatron_lm_train_gpt-oss-120b"
+  },
+  {
+    "name": "primus_pyt_megatron_lm_train_llama-4-scout-17b-16e_overlay",
+    "url": "",
+    "dockerfile": "../../docker/primus_megatron_train_rccl_overlay",
+    "dockercontext": "./docker",
+    "scripts": "run.sh",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "multiple_results": "perf_primus-megatron-Llama-4-Scout-17B-16E.csv",
+    "tags": [
+      "pyt",
+      "pretrain",
+      "llama4",
+      "moe",
+      "training",
+      "primus",
+      "scaleout"
+    ],
+    "timeout": -1,
+    "args": "--model_repo primus_pyt_megatron_lm_train_llama-4-scout-17b-16e"
   }
 ]

--- a/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.py
+++ b/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.py
@@ -156,6 +156,7 @@ if args.model == "Llama-3.1-8B" or args.model == "Llama-3.1-70B" or \
         args.model == "Mixtral-8x7B" or args.model == "Mixtral-8x22B-proxy" or \
         args.model == "DeepSeek-V2-lite" or args.model == "DeepSeek-V3-proxy" or \
         args.model == "Llama-3.1-70B-proxy" or args.model == "Llama-3.3-70B" or \
+        args.model == "Llama-4-Scout-17B-16E" or \
         args.model == "Qwen2.5-7B" or args.model == "Qwen2.5-72B" or \
         args.model == "Zebra-Llama-1B" or args.model == "Zebra-Llama-3B" or args.model == "Zebra-Llama-8B" or \
         args.model == "Qwen-3-32B" or args.model == "Mamba-370M" or \

--- a/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
+++ b/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
@@ -45,7 +45,7 @@ POSTTRAIN_TYPE="lora"
 usage() {
   echo "Usage: $0 -m <model_repo> -p <datatype> -t <mode> -f <posttrain_type>"
   echo "\nOptions:"
-  echo "  -m <model_repo>      Model repository (Llama-2-7B, Llama-2-70B, Llama-3.1-8B, Llama-3.1-70B, DeepSeek-V2-lite, DeepSeek-V3-proxy, Mixtral-8x7B, Mixtral-8x22B-proxy, Zebra-Llama-1B, Zebra-Llama-3B, Zebra-Llama-8B, Qwen-3-32B, GPT-OSS-20B, GPT-OSS-120B, Qwen-3-30B, Qwen-3-235B, Mamba-370M)"
+  echo "  -m <model_repo>      Model repository (Llama-2-7B, Llama-2-70B, Llama-3.1-8B, Llama-3.1-70B, Llama-4-Scout-17B-16E, DeepSeek-V2-lite, DeepSeek-V3-proxy, Mixtral-8x7B, Mixtral-8x22B-proxy, Zebra-Llama-1B, Zebra-Llama-3B, Zebra-Llama-8B, Qwen-3-32B, GPT-OSS-20B, GPT-OSS-120B, Qwen-3-30B, Qwen-3-235B, Mamba-370M)"
   echo "  -p <datatype>        Precision type (FP8, BF16, MXFP8, or MXFP4). MXFP8/MXFP4 only supported on MI355X/MI350X."
   echo "  -t <mode>            Training mode (pretrain or posttrain, default: pretrain)"
   echo "  -f <posttrain_type>  Post-training type (sft or lora, default: lora). Only used when mode is posttrain."
@@ -495,6 +495,53 @@ elif [ "$MODEL_REPO" == "Llama-2-70B" ]; then
         --log_file /tmp/primus_$MODEL_REPO.log \
         -- train pretrain \
         --config $EXP 2>&1 | tee -a $TRAIN_LOG
+    fi
+  fi
+  if [ -f "$TRAIN_LOG" ]; then
+    echo "[INFO] Benchmarking"
+    python3 $perf_script --model $MODEL_REPO --input $TRAIN_LOG --output $PERF_LOG --mode $MODE --precision $DATATYPE --batch_size $MBS --global_batch_size $GBS --seq_len $SEQ_LEN --device $DEVICE --num_gpus $NUM_GPUS
+    rm $TRAIN_LOG
+  else
+    echo "[INFO] Training log not found - configuration not supported."
+    echo "model,performance,metric,mode,precision,batch_size,global_batch_size,seq_len,device,num_gpus" > $PERF_LOG
+    echo "$MODEL_REPO,,tok_per_s_per_gpu,$MODE,$DATATYPE,$MBS,$GBS,$SEQ_LEN,$DEVICE,$NUM_GPUS" >> $PERF_LOG
+    echo "$MODEL_REPO,,TFLOPS_per_gpu,$MODE,$DATATYPE,$MBS,$GBS,$SEQ_LEN,$DEVICE,$NUM_GPUS" >> $PERF_LOG
+  fi
+
+elif [ "$MODEL_REPO" == "Llama-4-Scout-17B-16E" ]; then
+  echo "[INFO] $MODEL_REPO TRAINING"
+  # Llama-4-Scout-17B-16E MoE (48 layers, 16 experts). The shipped config uses
+  # EP=8 (intra-node experts) with TP=1/PP=1, so scaleout grows by pure data
+  # parallelism across nodes; tune via PRIMUS_TP/PRIMUS_PP/PRIMUS_EP if needed.
+  export EXP=examples/megatron/configs/$CONFIG_DEVICE/llama4_17B16E-$DATATYPE-pretrain.yaml
+  SEQ_LEN=4096
+  # One micro-batch per data-parallel rank. Set before the datatype switch so the
+  # fallback PERF_LOG (emitted when TRAIN_LOG is missing, e.g. FP8/unsupported
+  # device) still records a well-formed batch_size instead of an empty field.
+  MBS=1
+  GBS=$(normalize_global_batch_size "$MBS" "8" "$NUM_GPUS")
+  if [[ "$DEVICE" == "MI355X" || "$DEVICE" == "MI350X" || "$DEVICE" == "MI300X" || "$DEVICE" == "MI325X" ]]; then
+    if [ "$DATATYPE" == "FP8" ]; then
+      echo "Error: Datatype FP8 is not yet enabled for $MODEL_REPO. Only BF16 is supported."
+    elif [ "$DATATYPE" == "BF16" ]; then
+      # The shipped config points tokenizer_model at the gated meta-llama repo.
+      # Default to a non-gated mirror so the run does not depend on a per-account
+      # Llama-4 license grant; override with SCOUT_HF_TOKENIZER (e.g. the official
+      # meta-llama/Llama-4-Scout-17B-16E once access is granted).
+      SCOUT_HF_TOKENIZER="${SCOUT_HF_TOKENIZER:-unsloth/Llama-4-Scout-17B-16E}"
+      # MoE token dispatcher: the recommended 'alltoall' dispatcher works on RCCL
+      # develop f1be5f14; the earlier candidate build c67fbe4956 (2.29.7) hung in
+      # the MoE ALLTOALL_BASE collective (EXPERT_MODEL_PARALLEL_GROUP). Override
+      # with SCOUT_MOE_DISPATCHER=allgather to avoid all-to-all on a broken RCCL.
+      SCOUT_MOE_DISPATCHER="${SCOUT_MOE_DISPATCHER:-alltoall}"
+      # moe_shared_expert_overlap (on in the shipped config) overlaps shared-expert
+      # compute with the all-to-all dispatch and is only valid for the 'alltoall'
+      # dispatcher; disable it for any other dispatcher or Primus aborts.
+      SCOUT_DISPATCHER_ARGS=(--moe_token_dispatcher_type "$SCOUT_MOE_DISPATCHER")
+      [ "$SCOUT_MOE_DISPATCHER" != "alltoall" ] && SCOUT_DISPATCHER_ARGS+=(--moe_shared_expert_overlap false)
+      run_primus "$EXP" --micro_batch_size $MBS --global_batch_size $GBS \
+        --tokenizer_model "$SCOUT_HF_TOKENIZER" \
+        "${SCOUT_DISPATCHER_ARGS[@]}"
     fi
   fi
   if [ -f "$TRAIN_LOG" ]; then

--- a/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
+++ b/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
@@ -515,16 +515,19 @@ elif [ "$MODEL_REPO" == "Llama-4-Scout-17B-16E" ]; then
   # parallelism across nodes; tune via PRIMUS_TP/PRIMUS_PP/PRIMUS_EP if needed.
   export EXP=examples/megatron/configs/$CONFIG_DEVICE/llama4_17B16E-$DATATYPE-pretrain.yaml
   SEQ_LEN=4096
-  # MBS=1, GBS=8 matches the shipped single-node (8-GPU) config. Set before the
-  # datatype switch so the fallback PERF_LOG (emitted when TRAIN_LOG is
-  # missing, e.g. FP8/unsupported device) still records a well-formed
-  # batch_size instead of an empty field. TP=1/PP=1 here, so Megatron's own
-  # data-parallel size for the divisibility check in scaleout_gbs_override is
-  # NUM_GPUS itself -- EP shards experts within that same group and does not
-  # change it.
+  # MBS=1, GBS=8 matches the shipped single-node (8-GPU) config (verified
+  # directly against the base image) -- but always pass both flags explicitly
+  # rather than relying on that match: a future base-image bump could ship a
+  # different default, and an empty scaleout override at an unscaled node
+  # count would then silently fall back to that new default while $GBS (and
+  # the perf CSV) kept reporting 8. Set before the datatype switch so the
+  # fallback PERF_LOG (emitted when TRAIN_LOG is missing, e.g. FP8/unsupported
+  # device) still records a well-formed batch_size instead of an empty field.
+  # TP=1/PP=1 here, so Megatron's own data-parallel size for the divisibility
+  # check is NUM_GPUS itself -- EP shards experts within that same group and
+  # does not change it.
   MBS=1
   GBS=8
-  GBS_OVERRIDE=$(scaleout_gbs_override "$MBS" "$GBS")
   GBS=$(effective_global_batch_size "$MBS" "$GBS")
   if [[ "$DEVICE" == "MI355X" || "$DEVICE" == "MI350X" || "$DEVICE" == "MI300X" || "$DEVICE" == "MI325X" ]]; then
     if [ "$DATATYPE" == "FP8" ]; then
@@ -545,7 +548,7 @@ elif [ "$MODEL_REPO" == "Llama-4-Scout-17B-16E" ]; then
       # dispatcher; disable it for any other dispatcher or Primus aborts.
       SCOUT_DISPATCHER_ARGS=(--moe_token_dispatcher_type "$SCOUT_MOE_DISPATCHER")
       [ "$SCOUT_MOE_DISPATCHER" != "alltoall" ] && SCOUT_DISPATCHER_ARGS+=(--moe_shared_expert_overlap false)
-      run_primus "$EXP" --micro_batch_size $MBS $GBS_OVERRIDE \
+      run_primus "$EXP" --micro_batch_size $MBS --global_batch_size $GBS \
         --tokenizer_model "$SCOUT_HF_TOKENIZER" \
         "${SCOUT_DISPATCHER_ARGS[@]}"
     fi

--- a/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
+++ b/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
@@ -515,11 +515,17 @@ elif [ "$MODEL_REPO" == "Llama-4-Scout-17B-16E" ]; then
   # parallelism across nodes; tune via PRIMUS_TP/PRIMUS_PP/PRIMUS_EP if needed.
   export EXP=examples/megatron/configs/$CONFIG_DEVICE/llama4_17B16E-$DATATYPE-pretrain.yaml
   SEQ_LEN=4096
-  # One micro-batch per data-parallel rank. Set before the datatype switch so the
-  # fallback PERF_LOG (emitted when TRAIN_LOG is missing, e.g. FP8/unsupported
-  # device) still records a well-formed batch_size instead of an empty field.
+  # MBS=1, GBS=8 matches the shipped single-node (8-GPU) config. Set before the
+  # datatype switch so the fallback PERF_LOG (emitted when TRAIN_LOG is
+  # missing, e.g. FP8/unsupported device) still records a well-formed
+  # batch_size instead of an empty field. TP=1/PP=1 here, so Megatron's own
+  # data-parallel size for the divisibility check in scaleout_gbs_override is
+  # NUM_GPUS itself -- EP shards experts within that same group and does not
+  # change it.
   MBS=1
-  GBS=$(normalize_global_batch_size "$MBS" "8" "$NUM_GPUS")
+  GBS=8
+  GBS_OVERRIDE=$(scaleout_gbs_override "$MBS" "$GBS")
+  GBS=$(effective_global_batch_size "$MBS" "$GBS")
   if [[ "$DEVICE" == "MI355X" || "$DEVICE" == "MI350X" || "$DEVICE" == "MI300X" || "$DEVICE" == "MI325X" ]]; then
     if [ "$DATATYPE" == "FP8" ]; then
       echo "Error: Datatype FP8 is not yet enabled for $MODEL_REPO. Only BF16 is supported."
@@ -539,7 +545,7 @@ elif [ "$MODEL_REPO" == "Llama-4-Scout-17B-16E" ]; then
       # dispatcher; disable it for any other dispatcher or Primus aborts.
       SCOUT_DISPATCHER_ARGS=(--moe_token_dispatcher_type "$SCOUT_MOE_DISPATCHER")
       [ "$SCOUT_MOE_DISPATCHER" != "alltoall" ] && SCOUT_DISPATCHER_ARGS+=(--moe_shared_expert_overlap false)
-      run_primus "$EXP" --micro_batch_size $MBS --global_batch_size $GBS \
+      run_primus "$EXP" --micro_batch_size $MBS $GBS_OVERRIDE \
         --tokenizer_model "$SCOUT_HF_TOKENIZER" \
         "${SCOUT_DISPATCHER_ARGS[@]}"
     fi

--- a/scripts/primus_megatron-lm/run.sh
+++ b/scripts/primus_megatron-lm/run.sh
@@ -50,6 +50,8 @@ elif [[ "$MODEL_REPO" == "primus_pyt_megatron_lm_train_llama-2-7b" ]]; then
   model="Llama-2-7B"
 elif [[ "$MODEL_REPO" == "primus_pyt_megatron_lm_train_llama-2-70b" ]]; then
   model="Llama-2-70B"
+elif [[ "$MODEL_REPO" == "primus_pyt_megatron_lm_train_llama-4-scout-17b-16e" ]]; then
+  model="Llama-4-Scout-17B-16E"
 elif [[ "$MODEL_REPO" == "primus_pyt_megatron_lm_train_deepseek-v2-lite-16b" ]]; then
   model="DeepSeek-V2-lite"
 elif [[ "$MODEL_REPO" == "primus_pyt_megatron_lm_train_deepseek-v2" ]]; then

--- a/scripts/sglang_disagg/README.MD
+++ b/scripts/sglang_disagg/README.MD
@@ -3,6 +3,7 @@
 Dense Models
 - Qwen3-32B (https://huggingface.co/Qwen/Qwen3-32B)
 - meta-llama/Llama-3.1-8B-Instruct (https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct)
+- meta-llama/Llama-3.1-70B-Instruct (https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct)
 - amd/Llama-3.3-70B-Instruct-FP8-KV (https://huggingface.co/amd/Llama-3.3-70B-Instruct-FP8-KV)
 - amd/Llama-3.1-405B-Instruct-FP8-KV (https://huggingface.co/amd/Llama-3.1-405B-Instruct-FP8-KV)
 
@@ -10,6 +11,7 @@ MoE Models
 - DeepSeek-V3 (https://huggingface.co/deepseek-ai/DeepSeek-V3)
 - DeepSeek-R1 (https://huggingface.co/deepseek-ai/DeepSeek-R1)
 - Mixtral-8x7B-v0.1 (https://huggingface.co/mistralai/Mixtral-8x7B-v0.1)
+- Llama-4-Scout-17B-16E-Instruct (https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct) — staged from the non-gated `unsloth/Llama-4-Scout-17B-16E-Instruct` mirror by default
 
 This repository contains scripts and documentation to launch PD Disaggregation for above models. You will find setup instructions, node assignment details and benchmarking commands.
 

--- a/scripts/sglang_disagg/models.json
+++ b/scripts/sglang_disagg/models.json
@@ -554,5 +554,47 @@
         ],
         "timeout": 14400,
         "args": ""
+    },
+    {
+        "name": "sglang-disagg-llama-4-scout-overlay",
+        "url": "",
+        "dockerfile": "../../docker/sglang_disagg_inference_full_overlay",
+        "scripts": "run.sh",
+        "n_gpus": "8",
+        "owner": "mad.support@amd.com",
+        "training_precision": "",
+        "multiple_results": "perf_sglang-disagg-Llama-4-Scout-17B-16E-Instruct.csv",
+        "tags": [
+            "pyt",
+            "sglang",
+            "inference",
+            "disaggregated",
+            "llama4",
+            "moe",
+            "tp-only"
+        ],
+        "timeout": 21600,
+        "args": ""
+    },
+    {
+        "name": "sglang-disagg-llama-3.1-70b-overlay",
+        "url": "",
+        "dockerfile": "../../docker/sglang_disagg_inference_full_overlay",
+        "scripts": "run.sh",
+        "n_gpus": "8",
+        "owner": "mad.support@amd.com",
+        "training_precision": "",
+        "multiple_results": "perf_sglang-disagg-Llama-3.1-70B-Instruct.csv",
+        "tags": [
+            "pyt",
+            "sglang",
+            "inference",
+            "disaggregated",
+            "llama3",
+            "dense",
+            "tp-only"
+        ],
+        "timeout": 14400,
+        "args": ""
     }
 ]

--- a/scripts/sglang_disagg/models.yaml
+++ b/scripts/sglang_disagg/models.yaml
@@ -109,3 +109,16 @@ GPT-OSS-120B:
     tp: "--disable-cuda-graph"
   decode:
     tp: "--disable-radix-cache --cuda-graph-bs $(seq 1 512)"
+
+# Llama 4 Scout: 17Bx16E MoE, bf16. triton attention + triton moe-runner avoid the
+# AITER MoE kernels that segfault on gfx950 during warmup (harmless/generic on gfx942).
+# --disable-custom-all-reduce: the custom all-reduce kernel SIGSEGVs on gfx950 during
+# the embedding all-reduce in warmup; fall back to plain RCCL all-reduce. Context 131072.
+# Arch-agnostic registration only: validated on gfx942/Mellanox. The additional
+# gfx950 kernel and RDMA workarounds are not part of this entry.
+Llama-4-Scout-17B-16E-Instruct:
+  base_flags: "--attention-backend triton --moe-runner-backend triton --disable-custom-all-reduce --watchdog-timeout 1000000 --mem-fraction-static 0.8 --context-length 131072"
+  prefill:
+    tp: "--disable-cuda-graph"
+  decode:
+    tp: "--disable-radix-cache --cuda-graph-bs $(seq 1 512)"

--- a/scripts/sglang_disagg/models.yaml
+++ b/scripts/sglang_disagg/models.yaml
@@ -132,17 +132,31 @@ GPT-OSS-120B:
   decode:
     tp: "--disable-radix-cache --cuda-graph-bs $(seq 1 512)"
 
-# Llama 4 Scout: 17Bx16E MoE, bf16. triton attention + triton moe-runner avoid the
-# AITER MoE kernels that segfault on gfx950 during warmup (harmless/generic on gfx942).
-# --disable-custom-all-reduce: the custom all-reduce kernel SIGSEGVs on gfx950 during
-# the embedding all-reduce in warmup; fall back to plain RCCL all-reduce. Context 131072.
-# Arch-agnostic registration: no gfx950-specific kernel/RDMA guards. Verified
-# on gfx942 (MI300X)/Mellanox CX7 and independently reproduced end-to-end on
-# gfx950 (MI355X)/Broadcom Thor2 with this exact entry (full 8-point benchmark
-# sweep, 9622 tok/s @ concurrency 64, KV_TRANSFER_BACKEND=mori) -- see
-# manifests.md for the run details.
+# Llama 4 Scout: 17Bx16E MoE, bf16. --disable-custom-all-reduce: the custom
+# all-reduce kernel SIGSEGVs on gfx950 during the embedding all-reduce in warmup;
+# fall back to plain RCCL all-reduce. --attention-backend triton avoids the AITER
+# attention path that segfaults on gfx950 warmup and is harmless on gfx942 (verified
+# there: coherent completions). Context 131072.
+#
+# The two arches need opposite things here, so both live in arch_flags, not base_flags.
+#
+# gfx95 needs --moe-runner-backend triton: the AITER MoE kernels segfault during warmup.
+# gfx942 must NOT have it. There it silently corrupts output while every harness signal
+# stays green -- a 4-node 2P2D run produced a full 8/8 benchmark sweep at 2501 tok/s
+# while every generated token was id 0, and a single-node run with only this flag
+# returned multilingual gibberish ("iscentrouwd 의존해야傾 ocean...") where the same
+# server without it answers "Paris. Paris is known as the City of Light".
+# bench_serving counts tokens, not meaning, so nothing in the harness catches it.
+#
+# gfx942 then needs a higher --mem-fraction-static than the 0.8 that suits gfx95:
+# falling back to the AITER MoE runner costs more device memory, and on a 192 GB card
+# 0.8 leaves nothing for the KV cache ("Raise --mem-fraction-static above 0.854").
+# Appended after base_flags, so this overrides the base value.
 Llama-4-Scout-17B-16E-Instruct:
-  base_flags: "--attention-backend triton --moe-runner-backend triton --disable-custom-all-reduce --watchdog-timeout 1000000 --mem-fraction-static 0.8 --context-length 131072"
+  base_flags: "--attention-backend triton --disable-custom-all-reduce --watchdog-timeout 1000000 --mem-fraction-static 0.8 --context-length 131072"
+  arch_flags:
+    gfx95: "--moe-runner-backend triton"
+    gfx942: "--mem-fraction-static 0.9"
   prefill:
     tp: "--disable-cuda-graph"
   decode:

--- a/scripts/sglang_disagg/models.yaml
+++ b/scripts/sglang_disagg/models.yaml
@@ -114,8 +114,11 @@ GPT-OSS-120B:
 # AITER MoE kernels that segfault on gfx950 during warmup (harmless/generic on gfx942).
 # --disable-custom-all-reduce: the custom all-reduce kernel SIGSEGVs on gfx950 during
 # the embedding all-reduce in warmup; fall back to plain RCCL all-reduce. Context 131072.
-# Arch-agnostic registration only: validated on gfx942/Mellanox. The additional
-# gfx950 kernel and RDMA workarounds are not part of this entry.
+# Arch-agnostic registration: no gfx950-specific kernel/RDMA guards. Verified
+# on gfx942 (MI300X)/Mellanox CX7 and independently reproduced end-to-end on
+# gfx950 (MI355X)/Broadcom Thor2 with this exact entry (full 8-point benchmark
+# sweep, 9622 tok/s @ concurrency 64, KV_TRANSFER_BACKEND=mori) -- see
+# manifests.md for the run details.
 Llama-4-Scout-17B-16E-Instruct:
   base_flags: "--attention-backend triton --moe-runner-backend triton --disable-custom-all-reduce --watchdog-timeout 1000000 --mem-fraction-static 0.8 --context-length 131072"
   prefill:

--- a/scripts/sglang_disagg/run.sh
+++ b/scripts/sglang_disagg/run.sh
@@ -191,6 +191,9 @@ if ! _weights_complete; then
             Llama-3.1-70B-Instruct) _MODEL_REPO="meta-llama/Llama-3.1-70B-Instruct" ;;
             Qwen3-Next-80B) _MODEL_REPO="Qwen/Qwen3-Next-80B-A3B-Instruct" ;;
             GPT-OSS-120B)   _MODEL_REPO="openai/gpt-oss-120b" ;;
+            # Non-gated mirror: the official meta-llama Llama-4 repos need a
+            # per-account license grant, which an unattended run cannot obtain.
+            Llama-4-Scout-17B-16E-Instruct) _MODEL_REPO="unsloth/Llama-4-Scout-17B-16E-Instruct" ;;
             *) echo "ERROR: weights missing at ${MODEL_PATH}; set MODEL_REPO for ${MODEL_NAME}" >&2; exit 1 ;;
         esac
     fi

--- a/scripts/sglang_disagg/run_xPyD_models.slurm
+++ b/scripts/sglang_disagg/run_xPyD_models.slurm
@@ -53,6 +53,7 @@ MORI_EP_VALID_MODELS=( \
     "Qwen3-32B" \
     "Mixtral-8x7B-Instruct-v0.1" \
     "Llama-3.1-8B-Instruct" \
+    "Llama-3.1-70B-Instruct" \
     "Llama-3.1-405B-Instruct-FP8-KV" \
     "amd-Llama-3.3-70B-Instruct-FP8-KV" \
     "DeepSeek-V3" \
@@ -65,6 +66,7 @@ VALID_MODELS=( \
     "Qwen3-32B" \
     "Mixtral-8x7B-Instruct-v0.1" \
     "Llama-3.1-8B-Instruct" \
+    "Llama-3.1-70B-Instruct" \
     "Llama-3.1-405B-Instruct-FP8-KV" \
     "amd-Llama-3.3-70B-Instruct-FP8-KV" \
     "DeepSeek-V3" \

--- a/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
+++ b/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
@@ -407,13 +407,46 @@ echo "DECODE_ARGS: $DECODE_ARGS"
 # Container Synchronization
 # =============================================================================
 
-echo "Waiting at the container creation barrier on $host_name"
-python $MOONCAKE_COOKBOOK_PATH/socket_barrier.py \
+# Time-to-first-ready scales with checkpoint size, so the default is per model rather
+# than one number for every card. 4000s is fine for the ~600 GB class (DeepSeek-R1
+# reached ready in well under half of it), but Kimi-K2 is ~1 TB of FP8 weights: a
+# 4-node run measured 15m15s of weight load on an idle NFS and 24m48s on a busy one,
+# and the slow case blew past 4000s at 4003s -- run.sh then tore down healthy servers
+# that were still initialising. Give the 1 TB class 3h; an explicit
+# ROUTER_READY_TIMEOUT_SECONDS still overrides both.
+#
+# Computed here, before the per-rank branching, because every rank needs it: rank 0
+# polls the server logs with it, and the other ranks wait for rank 0's router with it.
+_router_ready_default=4000
+case "${MODEL_NAME:-}" in
+    *Kimi-K2*|*kimi-k2*) _router_ready_default=10800 ;;
+esac
+ROUTER_READY_TIMEOUT_SECONDS="${ROUTER_READY_TIMEOUT_SECONDS:-$_router_ready_default}"
+
+# The two barrier waits below are not the same kind of wait and must not share a
+# timeout. The container-creation barrier is peers starting a container: minutes.
+# The router wait further down is ranks 1..N waiting for rank 0 to finish loading
+# weights and bring every server up: hours. A single 3600s default for both killed a
+# healthy 4-node run at exactly 3600s ("barrier timed out ... 10.158.x:2322"), and
+# would also have killed the validated Kimi run, which took 72 minutes to reach ready.
+# So the router wait is bounded by the readiness timeout itself, plus a margin, and can
+# never fire before the thing it is waiting for has been given up on.
+BARRIER_TIMEOUT_SECONDS="${BARRIER_TIMEOUT_SECONDS:-3600}"
+ROUTER_BARRIER_TIMEOUT_SECONDS="${ROUTER_BARRIER_TIMEOUT_SECONDS:-$(( ROUTER_READY_TIMEOUT_SECONDS + 1800 ))}"
+
+echo "Waiting at the container creation barrier on $host_name (timeout ${BARRIER_TIMEOUT_SECONDS}s)"
+if ! python $MOONCAKE_COOKBOOK_PATH/socket_barrier.py \
     --local-ip ${host_ip} \
     --local-port ${BARRIER_PORT} \
     --enable-port \
     --node-ips ${IPADDRS} \
-    --node-ports ${BARRIER_PORT}
+    --node-ports ${BARRIER_PORT} \
+    --timeout "${BARRIER_TIMEOUT_SECONDS}"; then
+    # Checked, unlike before: an unchecked barrier turns a hard failure into
+    # "Script completed successfully" and madengine then reports the run as passed.
+    echo "ERROR: container-creation barrier failed on ${host_name}; aborting this rank" >&2
+    exit 1
+fi
 
 
 # =============================================================================
@@ -588,18 +621,6 @@ if [[ "$NODE_RANK" -eq 0 ]]; then
     # DP_MODE=1: wait for master prefill NODE 0 + master decode NODE xP only.
     # Requires shared /run_logs across nodes.
     SEARCH_SIGNAL="${SEARCH_SIGNAL:-The server is fired up and ready to roll!}"
-    # Time-to-first-ready scales with checkpoint size, so the default is per model
-    # rather than one number for every card. 4000s is fine for the ~600 GB class
-    # (DeepSeek-R1 reached ready in well under half of it), but Kimi-K2 is ~1 TB of
-    # FP8 weights: a 4-node run measured 15m15s of weight load on an idle NFS and
-    # 24m48s on a busy one, and the slow case blew past 4000s at 4003s -- run.sh
-    # then tore down healthy servers that were still initialising. Give the 1 TB
-    # class 3h; an explicit ROUTER_READY_TIMEOUT_SECONDS still overrides both.
-    _router_ready_default=4000
-    case "${MODEL_NAME:-}" in
-        *Kimi-K2*|*kimi-k2*) _router_ready_default=10800 ;;
-    esac
-    ROUTER_READY_TIMEOUT_SECONDS="${ROUTER_READY_TIMEOUT_SECONDS:-$_router_ready_default}"
     ROUTER_POLL_SLEEP_SECONDS="${ROUTER_POLL_SLEEP_SECONDS:-10}"
     _wait_start_ts=$(date +%s)
     _runlog="/run_logs/${SLURM_JOB_ID:-0}"
@@ -832,10 +853,15 @@ elif [[ "$NODE_RANK" -ge 1 && "$NODE_RANK" -lt "$xP" ]]; then
     _dbg "prefill server started pid=${prefill_pid}"
 
     _dbg "waiting for proxy server to be up (MASTER_ADDR=${MASTER_ADDR}:2322) ..."
-    echo "Waiting for proxy server to be up..."
-    python "$MOONCAKE_COOKBOOK_PATH/socket_barrier.py" \
+    echo "Waiting for proxy server to be up (timeout ${ROUTER_BARRIER_TIMEOUT_SECONDS}s)..."
+    if ! python "$MOONCAKE_COOKBOOK_PATH/socket_barrier.py" \
         --node-ips "${MASTER_ADDR}" \
-        --node-ports 2322
+        --node-ports 2322 \
+        --timeout "${ROUTER_BARRIER_TIMEOUT_SECONDS}"; then
+        echo "ERROR: proxy on ${MASTER_ADDR}:2322 never came up within ${ROUTER_BARRIER_TIMEOUT_SECONDS}s" >&2
+        _shutdown_server "${prefill_pid}" "prefill NODE${NODE_RANK}"
+        exit 1
+    fi
 
     echo "Waiting until proxy server closes..."
     python "$MOONCAKE_COOKBOOK_PATH/socket_wait.py" \
@@ -913,10 +939,15 @@ elif [[ "$NODE_RANK" -ge $xP && "$NODE_RANK" -le $((xP + yD - 1)) ]]; then
     _dbg "decode server started pid=${decode_pid}"
 
     _dbg "waiting for proxy server to be up (MASTER_ADDR=${MASTER_ADDR}:2322) ..."
-    echo "Waiting for proxy server to be up..."
-    python "$MOONCAKE_COOKBOOK_PATH/socket_barrier.py" \
+    echo "Waiting for proxy server to be up (timeout ${ROUTER_BARRIER_TIMEOUT_SECONDS}s)..."
+    if ! python "$MOONCAKE_COOKBOOK_PATH/socket_barrier.py" \
         --node-ips "${MASTER_ADDR}" \
-        --node-ports 2322
+        --node-ports 2322 \
+        --timeout "${ROUTER_BARRIER_TIMEOUT_SECONDS}"; then
+        echo "ERROR: proxy on ${MASTER_ADDR}:2322 never came up within ${ROUTER_BARRIER_TIMEOUT_SECONDS}s" >&2
+        _shutdown_server "${decode_pid}" "decode NODE${NODE_RANK}"
+        exit 1
+    fi
 
     echo "Waiting until proxy server closes..."
     python "$MOONCAKE_COOKBOOK_PATH/socket_wait.py" \

--- a/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
+++ b/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
@@ -145,6 +145,21 @@ exports = {
     "MODEL_EXPERIMENTAL_FLAGS": cfg.get("experimental_flags", ""),
 }
 
+# Optional `arch_flags:` map, keyed by GPU-arch prefix, applied by the launcher's
+# arch gate below (longest matching prefix wins). Keys must be valid shell
+# identifiers because they become variable-name suffixes.
+arch_flags = cfg.get("arch_flags", {}) or {}
+if not isinstance(arch_flags, dict):
+    print(f"echo {q(f'ERROR: arch_flags for {model_name} must be a mapping of arch-prefix to flags')}; exit 1")
+    sys.exit(0)
+for key in arch_flags:
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", str(key)):
+        print(f"echo {q(f'ERROR: arch_flags key {key!r} is not a valid identifier')}; exit 1")
+        sys.exit(0)
+exports["MODEL_ARCH_FLAG_KEYS"] = " ".join(str(k) for k in arch_flags)
+for key, value in arch_flags.items():
+    exports[f"MODEL_ARCH_FLAGS__{key}"] = value or ""
+
 for key, value in exports.items():
     print(f"{key}={q(value)}")
 PY
@@ -193,8 +208,54 @@ export PREFILL_TP_SIZE DECODE_TP_SIZE
 # =============================================================================
 
 
-PREFILL_MODEL_CONFIG="${MODEL_BASE_FLAGS} ${MODEL_MODE_FLAGS} ${MODEL_PREFILL_FLAGS} ${MODEL_EXPERIMENTAL_FLAGS}"
-DECODE_MODEL_CONFIG="${MODEL_BASE_FLAGS} ${MODEL_MODE_FLAGS} ${MODEL_DECODE_FLAGS} ${MODEL_EXPERIMENTAL_FLAGS}"
+# --- arch-specific flags ----------------------------------------------------
+# Some settings are correct on one GPU generation and actively harmful on another, so
+# models.yaml can carry an optional `arch_flags:` map keyed by GPU-arch prefix. The
+# launcher detects the arch and appends the entry whose key is the LONGEST matching
+# prefix, so `gfx95:` covers the whole gfx95x family while `gfx942:` can still say
+# something different. Appended after base_flags, so an arch entry can also override a
+# base value (sglang parses with argparse: the last occurrence of a flag wins).
+#
+# Motivating case, Llama-4-Scout, where the two arches need opposite things:
+#   gfx95  needs --moe-runner-backend triton (AITER MoE segfaults during warmup),
+#   gfx942 must NOT have it -- it corrupts generation while every harness signal stays
+#          green (a 4-node sweep reported 8/8 points at 2501 tok/s emitting only token
+#          id 0), and then needs a higher --mem-fraction-static than gfx95, because the
+#          AITER MoE runner it falls back to needs more device memory on a 192 GB card.
+#
+# Set SGLANG_GFX_ARCH to override detection (e.g. to exercise another arch's path).
+# When the arch cannot be detected, NO arch flags are applied -- deliberately, because
+# the failure modes are not symmetric: missing a kernel workaround fails loudly at
+# warmup, while applying one on the wrong arch fails silently with corrupted output
+# that benchmarks still score as a pass. Prefer the loud failure.
+_detect_gfx_arch() {
+    local a="${SGLANG_GFX_ARCH:-${MAD_SYSTEM_GPU_ARCHITECTURE:-}}"
+    [[ -n "$a" ]] && { echo "$a"; return; }
+    a="$(rocminfo 2>/dev/null | grep -m1 -oE 'gfx[0-9a-f]+' || true)"
+    [[ -z "$a" ]] && a="$(python3 -c 'import torch;print(torch.cuda.get_device_properties(0).gcnArchName)' 2>/dev/null | cut -d: -f1 || true)"
+    echo "$a"
+}
+GFX_ARCH="$(_detect_gfx_arch)"
+MODEL_ARCH_FLAGS=""
+if [[ -n "${MODEL_ARCH_FLAG_KEYS:-}" ]]; then
+    if [[ -z "$GFX_ARCH" ]]; then
+        echo "WARNING: GPU arch not detected; NOT applying any arch_flags (keys: ${MODEL_ARCH_FLAG_KEYS}). Set SGLANG_GFX_ARCH to force." >&2
+    else
+        _arch_key=""
+        for _k in ${MODEL_ARCH_FLAG_KEYS}; do
+            if [[ "$GFX_ARCH" == "${_k}"* ]] && (( ${#_k} > ${#_arch_key} )); then _arch_key="$_k"; fi
+        done
+        if [[ -n "$_arch_key" ]]; then
+            _v="MODEL_ARCH_FLAGS__${_arch_key}"; MODEL_ARCH_FLAGS="${!_v}"
+            echo "Arch gate: ${GFX_ARCH} matches arch_flags[${_arch_key}] -> applying: ${MODEL_ARCH_FLAGS}"
+        else
+            echo "Arch gate: ${GFX_ARCH} matches no arch_flags key (${MODEL_ARCH_FLAG_KEYS}) -> applying none"
+        fi
+    fi
+fi
+
+PREFILL_MODEL_CONFIG="${MODEL_BASE_FLAGS} ${MODEL_ARCH_FLAGS} ${MODEL_MODE_FLAGS} ${MODEL_PREFILL_FLAGS} ${MODEL_EXPERIMENTAL_FLAGS}"
+DECODE_MODEL_CONFIG="${MODEL_BASE_FLAGS} ${MODEL_ARCH_FLAGS} ${MODEL_MODE_FLAGS} ${MODEL_DECODE_FLAGS} ${MODEL_EXPERIMENTAL_FLAGS}"
 echo "Using model-specific configuration for: $MODEL_NAME (mode=${PARALLEL_MODE})"
 
 export PREFILL_MODEL_CONFIG DECODE_MODEL_CONFIG MODEL_EXPERIMENTAL_FLAGS


### PR DESCRIPTION
Port Llama-4-Scout-17B-16E onto current `mad-rccl`, and make Llama-3.1-70B-Instruct launchable.

**Primus training** (`primus_pyt_megatron_lm_train_llama-4-scout-17b-16e_overlay`): BF16, EP=8/TP=1/PP=1. `SCOUT_MOE_DISPATCHER` (default `alltoall`) falls back to `allgather` for RCCL builds that hang in `ALLTOALL_BASE`. `SCOUT_HF_TOKENIZER` defaults to a non-gated mirror.

**SGLang inference** (`sglang-disagg-llama-4-scout-overlay`): `--disable-custom-all-reduce` and `triton` attention avoid SIGSEGVs during Llama-4 warmup. `--moe-runner-backend triton` is needed on gfx950 but corrupts output on gfx942, so it moves into a new optional `arch_flags:` map in `models.yaml` that the launcher applies per detected GPU; gfx942 also needs a higher `--mem-fraction-static` there. gfx95 behaviour is unchanged.

**Llama-3.1-70B-Instruct**: the `models.yaml` and `run.sh` entries already existed; adds the missing model card and `run_xPyD_models.slurm` allow-list entries so it can actually be launched.

All five `primus_megatron-lm` cards now pin `"dockercontext": "./docker"` — `DockerBuilder.get_context_path` otherwise gives repo-root context to any dockerfile path containing "primus", which disagrees with what the manifest templates already used.

Also fixes a barrier regression from #223: `socket_barrier.py` was given one timeout for two waits of very different length, and its exit status was never checked, so a slow-starting run died at 3600 s and reported success. The router wait is now bounded by `ROUTER_READY_TIMEOUT_SECONDS + 1800` and all three call sites check their status.

A pre-existing build blocker in `sglang_disagg_inference_full_overlay` found along the way is fixed separately in #225.

## Validation

**Training** — 2 nodes x 8 GPU, gfx950, `rocm/primus:v26.3` + RCCL `f1be5f14`: **2749.5 tok/s/GPU, 276.8 TFLOP/s/GPU**, 48/48 iterations, exit 0, 0 RCCL errors — within 0.6% of the 2734.3/275.3 reference. The template pins `v26.3` deliberately: on `v26.5` the same run completes but emits no throughput at all.

**Inference, gfx950 / Broadcom Thor2** — 4 nodes: full 8-point sweep, every point returned real completions, e.g. ISL/OSL 1024/1024 @ concurrency 64: **9622 tok/s, TTFT 11497 ms**. Use `KV_TRANSFER_BACKEND=mori` (`RUN_MORI=1`), not `nixl` — on this cluster `nixl` never completes a request and gives no error to debug from.

**Inference, gfx942 (MI300X) / Mellanox CX7** — 4 nodes, rebased on the merged #223 + #225: COMPLETED 0:0, 4/4 servers ready, 8/8 sweep points, perf CSV 56/56 `SUCCESS`, peak **25329 tok/s** @ ISL 8192 / concurrency 64. Checked the smoke output, not just the metrics: *"Lisa Su is the President and CEO of AMD. She has been in this role"*.
