### PR TITLE
Kimi-K2: Primus training and SGLang inference

### DIFF
--- a/.claude/skills/mad-slurm-multinode/assets/manifests/primus_kimi-k2-thinking.template.json
+++ b/.claude/skills/mad-slurm-multinode/assets/manifests/primus_kimi-k2-thinking.template.json
@@ -23,7 +23,12 @@
       "owner": "mad.support@amd.com",
       "training_precision": "",
       "multiple_results": "perf_primus-megatron-Kimi-K2-Thinking.csv",
-      "tags": ["pyt", "pretrain", "kimi-k2-thinking", "training"],
+      "tags": [
+        "pyt",
+        "pretrain",
+        "kimi-k2-thinking",
+        "training"
+      ],
       "timeout": -1,
       "args": "--model_repo primus_pyt_megatron_lm_train_kimi-k2-thinking",
       "additional_docker_run_options": "--privileged --group-add render --shm-size 64G --device=/dev/infiniband --cap-add IPC_LOCK --ulimit memlock=-1 -v /sys:/sys:ro -v /run/udev:/run/udev:ro <FILL_AINIC_MOUNTS if fabric needs host ibverbs/ionic libs, e.g. -v /etc/libibverbs.d:/etc/libibverbs.d:ro -v /usr/lib/x86_64-linux-gnu/libionic.so:...:ro; delete if not needed, see references/cluster-types.md>",
@@ -64,7 +69,11 @@
       "NCCL_GDR_FLUSH_DISABLE": "1",
       "NCCL_DMABUF_ENABLE": "0",
       "NCCL_IGNORE_CPU_AFFINITY": "1",
-      "NCCL_IB_QPS_PER_CONNECTION": "1"
+      "NCCL_IB_QPS_PER_CONNECTION": "1",
+      "PRIMUS_EP": "192",
+      "PRIMUS_TP": "1",
+      "PYTORCH_HIP_ALLOC_CONF": "expandable_segments:True",
+      "PYTORCH_ALLOC_CONF": "expandable_segments:True"
     },
     "docker_mounts": {
       "/dev/infiniband": "/dev/infiniband"
@@ -95,7 +104,7 @@
       "account": "<FILL_ACCOUNT or remove if cluster has none>",
       "qos": "<FILL_QOS>",
       "reservation": "<FILL_RESERVATION or remove if none>",
-      "nodes": 2,
+      "nodes": 24,
       "gpus_per_node": 8,
       "time": "08:00:00",
       "output_dir": "./slurm_output",
@@ -106,7 +115,7 @@
       "launcher": "torchrun",
       "backend": "nccl",
       "port": 29500,
-      "nnodes": 2,
+      "nnodes": 24,
       "nproc_per_node": 8
     },
     "env_vars": {
@@ -132,7 +141,11 @@
       "TORCH_NCCL_HIGH_PRIORITY": "1",
       "OMP_NUM_THREADS": "8",
       "MIOPEN_FIND_MODE": "1",
-      "MIOPEN_USER_DB_PATH": "${XDG_CACHE_HOME}/miopen"
+      "MIOPEN_USER_DB_PATH": "${XDG_CACHE_HOME}/miopen",
+      "PRIMUS_EP": "192",
+      "PRIMUS_TP": "1",
+      "PYTORCH_HIP_ALLOC_CONF": "expandable_segments:True",
+      "PYTORCH_ALLOC_CONF": "expandable_segments:True"
     },
     "debug": false,
     "docker_gpus": "0,1,2,3,4,5,6,7"

--- a/.claude/skills/mad-slurm-multinode/assets/manifests/primus_kimi-k2-thinking.template.json
+++ b/.claude/skills/mad-slurm-multinode/assets/manifests/primus_kimi-k2-thinking.template.json
@@ -1,0 +1,142 @@
+{
+  "built_images": {
+    "rocm-primus-kimi-k2-thinking": {
+      "model": "primus_pyt_megatron_lm_train_kimi-k2-thinking_overlay",
+      "docker_image": "rocm/primus:v26.3-<FILL_RCCL_TAG e.g. kimi-k2-rccl-develop-<sha7>>",
+      "dockerfile": "docker/primus_megatron_train_rccl_overlay.ubuntu.amd.Dockerfile",
+      "base_docker": "rocm/primus:v26.3",
+      "build_duration": 0,
+      "local_image": true,
+      "registry_image": null,
+      "registry": null,
+      "gpu_vendor": "AMD"
+    }
+  },
+  "built_models": {
+    "rocm-primus-kimi-k2-thinking": {
+      "name": "primus_pyt_megatron_lm_train_kimi-k2-thinking_overlay",
+      "url": "",
+      "dockerfile": "docker/primus_megatron_train_rccl_overlay.ubuntu.amd.Dockerfile",
+      "dockercontext": "./docker",
+      "scripts": "scripts/primus_megatron-lm/run.sh",
+      "n_gpus": "-1",
+      "owner": "mad.support@amd.com",
+      "training_precision": "",
+      "multiple_results": "perf_primus-megatron-Kimi-K2-Thinking.csv",
+      "tags": ["pyt", "pretrain", "kimi-k2-thinking", "training"],
+      "timeout": -1,
+      "args": "--model_repo primus_pyt_megatron_lm_train_kimi-k2-thinking",
+      "additional_docker_run_options": "--privileged --group-add render --shm-size 64G --device=/dev/infiniband --cap-add IPC_LOCK --ulimit memlock=-1 -v /sys:/sys:ro -v /run/udev:/run/udev:ro <FILL_AINIC_MOUNTS if fabric needs host ibverbs/ionic libs, e.g. -v /etc/libibverbs.d:/etc/libibverbs.d:ro -v /usr/lib/x86_64-linux-gnu/libionic.so:...:ro; delete if not needed, see references/cluster-types.md>",
+      "log_error_patterns": [
+        "OutOfMemoryError",
+        "HIP out of memory",
+        "CUDA out of memory",
+        "AssertionError:",
+        "ValueError:",
+        "SystemExit",
+        "ImportError:",
+        "ModuleNotFoundError:"
+      ]
+    }
+  },
+  "context": {
+    "docker_env_vars": {
+      "MAD_SYSTEM_GPU_ARCHITECTURE": "<FILL_GPU_ARCH  gfx942 or gfx950; only needed when rocminfo cannot report the device>",
+      "NCCL_DEBUG": "INFO",
+      "NCCL_DEBUG_SUBSYS": "INIT,NET",
+      "NCCL_IB_DISABLE": "0",
+      "NCCL_NET": "IB",
+      "NCCL_IB_HCA": "<FILL_NCCL_IB_HCA  data-plane HCA list, see references/cluster-types.md>",
+      "NCCL_IB_GID_INDEX": "<FILL_GID  RoCEv2 GID index, see references/cluster-types.md>",
+      "NCCL_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "GLOO_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "RDMAV_DRIVERS": "<FILL_DRIVER  see references/cluster-types.md>",
+      "IBV_DRIVERS": "<FILL_DRIVER  see references/cluster-types.md>",
+      "RCCL_AINIC_ROCE": "<FILL_RCCL_AINIC_ROCE  per archetype, see references/cluster-types.md; delete this key if not needed>",
+      "IBV_SHOW_WARNINGS": "1",
+      "LIBIBVERBS_DRIVER_PATH": "<FILL_or_delete  e.g. /usr/lib/x86_64-linux-gnu/libibverbs for ionic hosts>",
+      "NCCL_IB_ROCE_VERSION_NUM": "2",
+      "NCCL_IB_TC": "104",
+      "NCCL_IB_FIFO_TC": "184",
+      "NCCL_MAX_P2P_CHANNELS": "56",
+      "NET_OPTIONAL_RECV_COMPLETION": "1",
+      "NCCL_IB_USE_INLINE": "1",
+      "NCCL_GDR_FLUSH_DISABLE": "1",
+      "NCCL_DMABUF_ENABLE": "0",
+      "NCCL_IGNORE_CPU_AFFINITY": "1",
+      "NCCL_IB_QPS_PER_CONNECTION": "1",
+      "PRIMUS_SANITY_TRAIN_ITERS": "50",
+      "PRIMUS_SANITY_DATATYPE": "BF16"
+    },
+    "docker_mounts": {
+      "/dev/infiniband": "/dev/infiniband"
+    },
+    "docker_build_arg": {
+      "BASE_DOCKER": "rocm/primus:v26.3",
+      "BUILD_GPU_TARGETS": "<FILL_GPU_TARGETS  gfx942=MI300X/MI325X, gfx950=MI350X/MI355X>",
+      "RCCL_REPO": "https://github.com/ROCm/rocm-systems.git",
+      "RCCL_BRANCH": "",
+      "RCCL_COMMIT": "<FILL_RCCL_COMMIT  full SHA of the RCCL commit to build, e.g. 86f60f9...; leave RCCL_BRANCH/RCCL_COMMIT empty to keep the base image RCCL>"
+    },
+    "gpu_vendor": "AMD",
+    "guest_os": "UBUNTU",
+    "docker_gpus": "0,1,2,3,4,5,6,7"
+  },
+  "credentials_required": [],
+  "summary": {
+    "successful_builds": [],
+    "failed_builds": [],
+    "total_build_time": 0,
+    "successful_pushes": [],
+    "failed_pushes": []
+  },
+  "deployment_config": {
+    "target": "slurm",
+    "slurm": {
+      "partition": "<FILL_PARTITION>",
+      "account": "<FILL_ACCOUNT or remove if cluster has none>",
+      "qos": "<FILL_QOS>",
+      "reservation": "<FILL_RESERVATION or remove if none>",
+      "nodes": 2,
+      "gpus_per_node": 8,
+      "time": "08:00:00",
+      "output_dir": "./slurm_output",
+      "exclusive": true,
+      "network_interface": "<FILL_IFNAME  management iface, see references/cluster-types.md>"
+    },
+    "distributed": {
+      "launcher": "torchrun",
+      "backend": "nccl",
+      "port": 29500,
+      "nnodes": 2,
+      "nproc_per_node": 8
+    },
+    "env_vars": {
+      "HF_HOME": "${HF_HOME}",
+      "TORCH_HOME": "${TORCH_HOME}",
+      "XDG_CACHE_HOME": "${XDG_CACHE_HOME}",
+      "PIP_CACHE_DIR": "${PIP_CACHE_DIR}",
+      "MAD_DATAHOME": "${MAD_DATAHOME}",
+      "MAD_DOCKER_BUILDS": "${MAD_DOCKER_BUILDS}",
+      "NCCL_DEBUG": "INFO",
+      "NCCL_DEBUG_SUBSYS": "INIT,NET",
+      "NCCL_IB_DISABLE": "0",
+      "NCCL_NET": "IB",
+      "NCCL_SOCKET_IFNAME": "<FILL_IFNAME>",
+      "GLOO_SOCKET_IFNAME": "<FILL_IFNAME>",
+      "NCCL_IB_GID_INDEX": "<FILL_GID>",
+      "NCCL_IB_HCA": "<FILL_NCCL_IB_HCA>",
+      "RDMAV_DRIVERS": "<FILL_DRIVER>",
+      "IBV_DRIVERS": "<FILL_DRIVER>",
+      "RCCL_AINIC_ROCE": "<FILL_RCCL_AINIC_ROCE  or delete>",
+      "NCCL_TIMEOUT": "14400",
+      "TORCH_NCCL_ASYNC_ERROR_HANDLING": "1",
+      "TORCH_NCCL_HIGH_PRIORITY": "1",
+      "OMP_NUM_THREADS": "8",
+      "MIOPEN_FIND_MODE": "1",
+      "MIOPEN_USER_DB_PATH": "${XDG_CACHE_HOME}/miopen"
+    },
+    "debug": false,
+    "docker_gpus": "0,1,2,3,4,5,6,7"
+  }
+}

--- a/.claude/skills/mad-slurm-multinode/assets/manifests/primus_kimi-k2-thinking.template.json
+++ b/.claude/skills/mad-slurm-multinode/assets/manifests/primus_kimi-k2-thinking.template.json
@@ -64,9 +64,7 @@
       "NCCL_GDR_FLUSH_DISABLE": "1",
       "NCCL_DMABUF_ENABLE": "0",
       "NCCL_IGNORE_CPU_AFFINITY": "1",
-      "NCCL_IB_QPS_PER_CONNECTION": "1",
-      "PRIMUS_SANITY_TRAIN_ITERS": "50",
-      "PRIMUS_SANITY_DATATYPE": "BF16"
+      "NCCL_IB_QPS_PER_CONNECTION": "1"
     },
     "docker_mounts": {
       "/dev/infiniband": "/dev/infiniband"

--- a/.claude/skills/mad-slurm-multinode/assets/manifests/sglang_disagg_kimi-k2-instruct.template.json
+++ b/.claude/skills/mad-slurm-multinode/assets/manifests/sglang_disagg_kimi-k2-instruct.template.json
@@ -1,0 +1,163 @@
+{
+  "built_images": {
+    "sglang-disagg-kimi-k2-instruct-overlay": {
+      "model": "sglang-disagg-kimi-k2-instruct-overlay",
+      "docker_image": "<FILL_TAG  single full-overlay image tag, e.g. sgldev0516-overlay:mi30x-20260807-rdma63-gfx942; name the arch and the rdma-core in the tag since RDMA_CORE_VERSION defaults to 63.0>",
+      "dockerfile": "docker/sglang_disagg_inference_full_overlay.ubuntu.amd.Dockerfile",
+      "base_docker": "<FILL_BASE_DOCKER  rocm/sgl-dev tag whose suffix names the GPU: -mi30x=gfx942, -mi35x=gfx950. Must agree with BUILD_GPU_TARGETS>",
+      "build_duration": 0,
+      "local_image": true,
+      "registry_image": null,
+      "registry": null,
+      "gpu_vendor": "AMD"
+    }
+  },
+  "built_models": {
+    "sglang-disagg-kimi-k2-instruct-overlay": {
+      "name": "sglang-disagg-kimi-k2-instruct-overlay",
+      "url": "",
+      "dockerfile": "docker/sglang_disagg_inference_full_overlay.ubuntu.amd.Dockerfile",
+      "scripts": "scripts/sglang_disagg/run.sh",
+      "data": "",
+      "n_gpus": "-1",
+      "owner": "mad.support@amd.com",
+      "training_precision": "",
+      "multiple_results": "perf_sglang-disagg-Kimi-K2-Instruct.csv",
+      "tags": [
+        "pyt",
+        "sglang",
+        "inference",
+        "disaggregated",
+        "kimi-k2",
+        "moe",
+        "ep-internode",
+        "rccl-tp",
+        "mori-a2a"
+      ],
+      "timeout": 21600,
+      "args": "--model-name Kimi-K2-Instruct --model-path <FILL_MODEL_PATH  in-container absolute path to the Kimi-K2-Instruct-0905 weights (~1 TB, FP8). If MODEL_PATH/config.json is absent, run.sh rank-0 downloads moonshotai/Kimi-K2-Instruct-0905 and peers wait on MODEL_PATH/.stage_done> --run-mori 1 --dp-mode 1 --xp 2 --yd 2 --gpus-per-node 8 --kv-transfer-backend mori",
+      "additional_docker_run_options": "--privileged --group-add render --shm-size 64G --device=/dev/infiniband --cap-add IPC_LOCK --ulimit memlock=-1 --ulimit nofile=1048576:1048576 -v /sys:/sys:ro -v /sys/class/infiniband:/sys/class/infiniband:ro -v /run/udev:/run/udev:ro -v <FILL_MODEL_HOST_DIR  host NFS dir holding the weights>:<FILL_MODEL_CONTAINER_DIR  parent of --model-path> -v ${SLURM_SUBMIT_DIR}/slurm_output/run_logs:/run_logs -e SLURM_JOB_ID"
+    }
+  },
+  "context": {
+    "skip_perf_collection": false,
+    "docker_env_vars": {
+      "MODEL_NAME": "Kimi-K2-Instruct",
+      "MODEL_PATH": "<FILL_MODEL_PATH  in-container absolute path to the Kimi-K2-Instruct-0905 weights (~1 TB, FP8). If MODEL_PATH/config.json is absent, run.sh rank-0 downloads moonshotai/Kimi-K2-Instruct-0905 and peers wait on MODEL_PATH/.stage_done>",
+      "RUN_MORI": "1",
+      "DP_MODE": "1",
+      "xP": "2",
+      "yD": "2",
+      "GPUS_PER_NODE": "8",
+      "KV_TRANSFER_BACKEND": "mori",
+      "MORI_JIT_CACHE_DIR": "/tmp/mori_jit",
+      "MORI_SHMEM_HEAP_SIZE": "17179869184",
+      "NCCL_DEBUG": "WARN",
+      "NCCL_DEBUG_SUBSYS": "INIT,NET",
+      "NCCL_IB_DISABLE": "0",
+      "NCCL_IB_HCA": "<FILL_NCCL_IB_HCA  data-plane HCA list with ports, e.g. mlx5_0:1,...; see references/cluster-types.md>",
+      "IB_DEVICES": "<FILL_IB_DEVICES  same list without ports>",
+      "MORI_RDMA_DEVICES": "<FILL_MORI_RDMA_DEVICES  same list as IB_DEVICES; MoRI EP all-to-all transport>",
+      "NCCL_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "GLOO_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "MORI_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "NCCL_IB_GID_INDEX": "<FILL_GID  RoCEv2 GID index>",
+      "MORI_IB_GID_INDEX": "<FILL_GID  RoCEv2 GID index>",
+      "RDMAV_DRIVERS": "<FILL_DRIVER  e.g. mlx5>",
+      "IBV_DRIVERS": "<FILL_DRIVER  e.g. mlx5>",
+      "TORCH_NCCL_HIGH_PRIORITY": "1",
+      "GPU_MAX_HW_QUEUES": "2",
+      "TORCH_NCCL_ASYNC_ERROR_HANDLING": "1",
+      "NCCL_TIMEOUT": "900",
+      "HSA_ENABLE_SDMA": "0",
+      "HSA_FORCE_FINE_GRAIN_PCIE": "1",
+      "OMP_NUM_THREADS": "8",
+      "MIOPEN_FIND_MODE": "1",
+      "SMOKE": "0",
+      "BENCHMARK_ITR": "1",
+      "BENCHMARK_COMBINATIONS": "1024/1024 8192/1024",
+      "BENCHMARK_CONCURRENCY_LEVELS": "8 16 32 64",
+      "BENCHMARK_PRECHECK": "0",
+      "BENCHMARK_FAIL_FAST": "1"
+    },
+    "docker_mounts": {
+      "/dev/infiniband": "/dev/infiniband",
+      "/sys/class/infiniband": "/sys/class/infiniband",
+      "<FILL_MODEL_CONTAINER_DIR  parent of --model-path>": "<FILL_MODEL_HOST_DIR  host NFS dir holding the weights>"
+    },
+    "docker_build_arg": {
+      "BASE_DOCKER": "<FILL_BASE_DOCKER  rocm/sgl-dev tag whose suffix names the GPU: -mi30x=gfx942, -mi35x=gfx950. Must agree with BUILD_GPU_TARGETS>",
+      "BUILD_GPU_TARGETS": "<FILL_GPU_TARGETS  gfx942=MI300X/MI325X, gfx950=MI350X/MI355X>"
+    },
+    "gpu_vendor": "AMD",
+    "guest_os": "UBUNTU",
+    "docker_gpus": "0,1,2,3,4,5,6,7"
+  },
+  "credentials_required": [],
+  "summary": {
+    "successful_builds": [],
+    "failed_builds": [],
+    "total_build_time": 0,
+    "successful_pushes": [],
+    "failed_pushes": []
+  },
+  "deployment_config": {
+    "target": "slurm",
+    "slurm": {
+      "partition": "<FILL_PARTITION>",
+      "nodes": 4,
+      "gpus_per_node": 8,
+      "time": "06:00:00",
+      "output_dir": "./slurm_output",
+      "exclusive": true,
+      "network_interface": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "nodelist": "<FILL_NODELIST or remove to let SLURM choose>",
+      "account": "<FILL_ACCOUNT or remove if cluster has none>",
+      "qos": "<FILL_QOS or remove>"
+    },
+    "distributed": {
+      "launcher": "sglang-disagg",
+      "backend": "nccl",
+      "port": 29500,
+      "nnodes": 4,
+      "nproc_per_node": 8,
+      "sglang_disagg": {
+        "prefill_nodes": 2,
+        "decode_nodes": 2
+      }
+    },
+    "env_vars": {
+      "MODEL_NAME": "Kimi-K2-Instruct",
+      "MODEL_PATH": "<FILL_MODEL_PATH  in-container absolute path to the Kimi-K2-Instruct-0905 weights (~1 TB, FP8). If MODEL_PATH/config.json is absent, run.sh rank-0 downloads moonshotai/Kimi-K2-Instruct-0905 and peers wait on MODEL_PATH/.stage_done>",
+      "RUN_MORI": "1",
+      "DP_MODE": "1",
+      "xP": "2",
+      "yD": "2",
+      "GPUS_PER_NODE": "8",
+      "KV_TRANSFER_BACKEND": "mori",
+      "MORI_JIT_CACHE_DIR": "/tmp/mori_jit",
+      "MORI_SHMEM_HEAP_SIZE": "17179869184",
+      "NCCL_DEBUG": "WARN",
+      "NCCL_IB_DISABLE": "0",
+      "NCCL_IB_HCA": "<FILL_NCCL_IB_HCA  data-plane HCA list with ports, e.g. mlx5_0:1,...; see references/cluster-types.md>",
+      "IB_DEVICES": "<FILL_IB_DEVICES  same list without ports>",
+      "MORI_RDMA_DEVICES": "<FILL_MORI_RDMA_DEVICES  same list as IB_DEVICES; MoRI EP all-to-all transport>",
+      "NCCL_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "GLOO_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "MORI_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "NCCL_IB_GID_INDEX": "<FILL_GID  RoCEv2 GID index>",
+      "MORI_IB_GID_INDEX": "<FILL_GID  RoCEv2 GID index>",
+      "RDMAV_DRIVERS": "<FILL_DRIVER  e.g. mlx5>",
+      "IBV_DRIVERS": "<FILL_DRIVER  e.g. mlx5>",
+      "NCCL_TIMEOUT": "900",
+      "OMP_NUM_THREADS": "8",
+      "BENCHMARK_COMBINATIONS": "1024/1024 8192/1024",
+      "BENCHMARK_CONCURRENCY_LEVELS": "8 16 32 64",
+      "BENCHMARK_FAIL_FAST": "1"
+    },
+    "monitor": true,
+    "debug": false,
+    "docker_gpus": "0,1,2,3,4,5,6,7",
+    "gpus_per_node": 8
+  }
+}

--- a/.claude/skills/mad-slurm-multinode/references/gotchas.md
+++ b/.claude/skills/mad-slurm-multinode/references/gotchas.md
@@ -332,15 +332,25 @@ moe_router_num_groups null no group routing.
   `"dockercontext": "./docker"` — without it madengine gives any dockerfile whose
   path contains `primus` a repo-root context and the build fails at the `COPY`.
 
-- **Set `PRIMUS_SANITY_TRAIN_ITERS` for CI/build sanity, leave it unset for a real
-  measurement.** With all 61 layers and 384 experts, `torch.compile` workers
-  saturate every CPU during NCCL bootstrap and the rendezvous times out
-  (`DistStoreError: Timed out`) before the first training step. Setting
-  `PRIMUS_SANITY_TRAIN_ITERS` selects the 3-layer proxy path
-  (`--num_layers 3 --moe_layer_freq 1`) in `benchmark_report.sh`, which finishes
-  in ~30 min on 2 x MI355X nodes. The template sets it in
-  `context.docker_env_vars` (the local build-sanity run) but **not** in
-  `deployment_config.env_vars`, so the deployed SLURM run measures full depth.
+- **`context.docker_env_vars` reaches every deployment, not just a local
+  build-time sanity pass — `PRIMUS_SANITY_TRAIN_ITERS` must not live there by
+  default.** madengine renders `context.docker_env_vars` as `--env` on the
+  actual `docker run`/`torchrun` invocation on every node, SLURM-deployed runs
+  included (verified directly: grepping a real 2-node SLURM job's container
+  launch line shows `PRIMUS_SANITY_TRAIN_ITERS=50` passed to the container even
+  though the manifest's `deployment_config.env_vars` never set it). An earlier
+  version of this template shipped `PRIMUS_SANITY_TRAIN_ITERS`/
+  `PRIMUS_SANITY_DATATYPE` unconditionally in `context.docker_env_vars`, on the
+  mistaken assumption that block was build-time-only — the effect was that
+  *every* deployment of the template, including the "real" SLURM run, silently
+  took the 3-layer proxy path and never measured full depth. Fixed: the
+  shipped template no longer sets either key. Add `PRIMUS_SANITY_TRAIN_ITERS`
+  to `context.docker_env_vars` yourself only when you deliberately want the
+  fast 3-layer CI/build-sanity path (`--num_layers 3 --moe_layer_freq 1` in
+  `benchmark_report.sh`, ~30 min on 2×MI355X); leave it absent for a real
+  measurement — at full depth, `torch.compile` workers can saturate every CPU
+  during NCCL bootstrap and the rendezvous can time out (`DistStoreError:
+  Timed out`) before the first training step without the rdzv fix below.
 
 - **The torchrun rdzv timeout must be 7200s.** The 600s default is too short for
   MIOpen kernel compilation on a first run with 384 experts, and the job dies at

--- a/.claude/skills/mad-slurm-multinode/references/gotchas.md
+++ b/.claude/skills/mad-slurm-multinode/references/gotchas.md
@@ -312,6 +312,55 @@ print_rank_last throughput last global rank, multi-node perf collection rank-0.
   transport vars) to disable the plugin and let the bundled `librccl` drive the
   IB/RoCE net path directly. The primus template ships this key set to `none`.
 
+Keywords: Kimi-K2-Thinking 384 experts MoE, rdzv timeout DistStoreError MIOpen,
+PRIMUS_SANITY_TRAIN_ITERS proxy 3-layer, log_error_patterns torchrun SIGSEGV Traceback,
+moe_router_num_groups null no group routing.
+
+- **Kimi-K2-Thinking is a mock-data throughput benchmark, not a training run.**
+  `docker/kimi_k2_configs/kimi_k2_thinking-BF16-pretrain.yaml` sets `mock_data:
+  true`, `train_iters: 50` and `disable_last_saving: true` unconditionally. The
+  architecture is the real 61-layer / 384-expert one, so the tok/s and TFLOP/s
+  figures are representative, but no dataset is read and no checkpoint is
+  written. Do not quote it as a 1T-parameter pretraining result.
+
+- **The two Kimi YAMLs are injected by the Dockerfile, not shipped in the base
+  image.** Unlike every other Primus model here,
+  `kimi_k2_thinking.yaml` and `kimi_k2_thinking-BF16-pretrain.yaml` live in this
+  repo under `docker/kimi_k2_configs/` and are copied into the Primus tree by
+  `docker/primus_megatron_train_rccl_overlay.ubuntu.amd.Dockerfile`. That `COPY`
+  is relative to the build context, so the manifest must keep
+  `"dockercontext": "./docker"` — without it madengine gives any dockerfile whose
+  path contains `primus` a repo-root context and the build fails at the `COPY`.
+
+- **Set `PRIMUS_SANITY_TRAIN_ITERS` for CI/build sanity, leave it unset for a real
+  measurement.** With all 61 layers and 384 experts, `torch.compile` workers
+  saturate every CPU during NCCL bootstrap and the rendezvous times out
+  (`DistStoreError: Timed out`) before the first training step. Setting
+  `PRIMUS_SANITY_TRAIN_ITERS` selects the 3-layer proxy path
+  (`--num_layers 3 --moe_layer_freq 1`) in `benchmark_report.sh`, which finishes
+  in ~30 min on 2 x MI355X nodes. The template sets it in
+  `context.docker_env_vars` (the local build-sanity run) but **not** in
+  `deployment_config.env_vars`, so the deployed SLURM run measures full depth.
+
+- **The torchrun rdzv timeout must be 7200s.** The 600s default is too short for
+  MIOpen kernel compilation on a first run with 384 experts, and the job dies at
+  `DistStoreError` during NCCL init — this looks like a network fault but is not.
+  The `rccl_overlay` Dockerfile patches `run_pretrain.sh` and
+  `primus-cli-direct.sh` to `--rdzv-conf timeout=7200`. Rebuild without that
+  patch and the failure comes back.
+
+- **`log_error_patterns` must be overridden.** torchrun prints `Traceback (most
+  recent call last)` to stdout when a worker is SIGTERMed at cleanup, even after
+  all 50 iterations complete cleanly. madengine's default error scan treats any
+  `Traceback` as a failure and returns exit code 3, discarding a perfectly valid
+  perf CSV. The template's `log_error_patterns` list drops `Traceback`,
+  `RuntimeError:`, `Exception:`, `FAILED` and `failed (exitcode:` — keep it.
+
+- **Architecture difference from DeepSeek-V3 that shows up in manifests:** Kimi K2
+  uses `n_group=1`, so `moe_router_num_groups` is `null` (no group routing), and
+  there are no MTP layers. Both are handled inside `kimi_k2_thinking.yaml`; no
+  env overrides are needed.
+
 ## pyt_mlperf_training (MLPerf Llama-3.1)
 
 Keywords: mlperf training llama-3.1-8b nemo megatron-core version pairing,

--- a/.claude/skills/mad-slurm-multinode/references/gotchas.md
+++ b/.claude/skills/mad-slurm-multinode/references/gotchas.md
@@ -316,6 +316,39 @@ Keywords: Kimi-K2-Thinking 384 experts MoE, rdzv timeout DistStoreError MIOpen,
 PRIMUS_SANITY_TRAIN_ITERS proxy 3-layer, log_error_patterns torchrun SIGSEGV Traceback,
 moe_router_num_groups null no group routing.
 
+- **Kimi-K2-Thinking needs >= 24 nodes (192 GPUs, EP=192). Smaller is
+  arithmetically impossible, and the failure is invisible.** At 1T total params
+  the per-GPU budget is weights (bf16) + grads (fp32, `grad_reduce_in_fp32`) +
+  Adam state (12 B/param). Expert optimizer state is only sharded across
+  expert-DP = `world_size / EP`, so when `EP == world_size` it is not sharded at
+  all. At the original EP=8 / 2-node shape that totals ~1126 GiB/GPU against
+  252 GiB usable on MI355X. Measured working point: 24 nodes, `PRIMUS_EP=192`,
+  `micro_batch_size=1`, full recompute -> ~188 GiB resident, ~236 tok/s/GPU
+  steady state (61 layers, seq 4096).
+  Three separate walls hit in order, each masking the next: DDP `param_data`
+  allocation, then forward activations (fixed by recompute), then the MoE
+  permutation buffers in backward (fixed by MBS=1).
+
+- **Set `PYTORCH_HIP_ALLOC_CONF=expandable_segments:True` for this model.** With
+  the previous `garbage_collection_threshold:0.8`, once occupancy approaches the
+  ceiling the caching allocator re-runs a full GC on *every* allocation and
+  spins for many minutes instead of raising `OutOfMemoryError`. That looks
+  exactly like a collective deadlock -- GPUs pinned at 100%, an unchanging
+  `py-spy` frame, a frozen log -- and it cost a long detour blaming RCCL and the
+  MoE all-to-all. The give-away is that the stuck frame is a plain
+  `torch.empty(...)`, not a kernel launch or a collective.
+
+- **A "silent" worker death here is almost never silent -- it is a hidden
+  `OutOfMemoryError`.** `primus/cli/main.py` wraps every worker exception in
+  `except Exception: ... raise SystemExit(1)`; CPython deliberately prints no
+  traceback for `SystemExit`; and torchrun's `--local-ranks-filter 0` hides the
+  stderr of whichever rank actually failed. Net effect: `exitcode 1`,
+  `error_file: <N/A>`, no traceback anywhere. To recover the real exception
+  without rebuilding the image, inject a `sitecustomize.py` via `PYTHONPATH`
+  that hooks `sys.exit` and PEP 669 `sys.monitoring` RAISE, and dump
+  `SystemExit.__context__` to a per-rank file (a per-rank file also dodges the
+  rank filter).
+
 - **Kimi-K2-Thinking is a mock-data throughput benchmark, not a training run.**
   `docker/kimi_k2_configs/kimi_k2_thinking-BF16-pretrain.yaml` sets `mock_data:
   true`, `train_iters: 50` and `disable_last_saving: true` unconditionally. The

--- a/.claude/skills/mad-slurm-multinode/references/gotchas.md
+++ b/.claude/skills/mad-slurm-multinode/references/gotchas.md
@@ -316,38 +316,10 @@ Keywords: Kimi-K2-Thinking 384 experts MoE, rdzv timeout DistStoreError MIOpen,
 PRIMUS_SANITY_TRAIN_ITERS proxy 3-layer, log_error_patterns torchrun SIGSEGV Traceback,
 moe_router_num_groups null no group routing.
 
-- **Kimi-K2-Thinking needs >= 24 nodes (192 GPUs, EP=192). Smaller is
-  arithmetically impossible, and the failure is invisible.** At 1T total params
-  the per-GPU budget is weights (bf16) + grads (fp32, `grad_reduce_in_fp32`) +
-  Adam state (12 B/param). Expert optimizer state is only sharded across
-  expert-DP = `world_size / EP`, so when `EP == world_size` it is not sharded at
-  all. At the original EP=8 / 2-node shape that totals ~1126 GiB/GPU against
-  252 GiB usable on MI355X. Measured working point: 24 nodes, `PRIMUS_EP=192`,
-  `micro_batch_size=1`, full recompute -> ~188 GiB resident, ~236 tok/s/GPU
-  steady state (61 layers, seq 4096).
-  Three separate walls hit in order, each masking the next: DDP `param_data`
-  allocation, then forward activations (fixed by recompute), then the MoE
-  permutation buffers in backward (fixed by MBS=1).
-
-- **Set `PYTORCH_HIP_ALLOC_CONF=expandable_segments:True` for this model.** With
-  the previous `garbage_collection_threshold:0.8`, once occupancy approaches the
-  ceiling the caching allocator re-runs a full GC on *every* allocation and
-  spins for many minutes instead of raising `OutOfMemoryError`. That looks
-  exactly like a collective deadlock -- GPUs pinned at 100%, an unchanging
-  `py-spy` frame, a frozen log -- and it cost a long detour blaming RCCL and the
-  MoE all-to-all. The give-away is that the stuck frame is a plain
-  `torch.empty(...)`, not a kernel launch or a collective.
-
-- **A "silent" worker death here is almost never silent -- it is a hidden
-  `OutOfMemoryError`.** `primus/cli/main.py` wraps every worker exception in
-  `except Exception: ... raise SystemExit(1)`; CPython deliberately prints no
-  traceback for `SystemExit`; and torchrun's `--local-ranks-filter 0` hides the
-  stderr of whichever rank actually failed. Net effect: `exitcode 1`,
-  `error_file: <N/A>`, no traceback anywhere. To recover the real exception
-  without rebuilding the image, inject a `sitecustomize.py` via `PYTHONPATH`
-  that hooks `sys.exit` and PEP 669 `sys.monitoring` RAISE, and dump
-  `SystemExit.__context__` to a per-rank file (a per-rank file also dodges the
-  rank filter).
+- **Kimi-K2-Thinking needs 24 nodes (192 GPUs) with `PRIMUS_EP=192`,
+  `micro_batch_size=1` and full recompute.** At 1T params it does not fit in
+  less; all three are requirements, not tuning. Set
+  `PYTORCH_HIP_ALLOC_CONF=expandable_segments:True` alongside them.
 
 - **Kimi-K2-Thinking is a mock-data throughput benchmark, not a training run.**
   `docker/kimi_k2_configs/kimi_k2_thinking-BF16-pretrain.yaml` sets `mock_data:

--- a/.claude/skills/mad-slurm-multinode/references/manifests.md
+++ b/.claude/skills/mad-slurm-multinode/references/manifests.md
@@ -126,8 +126,13 @@ differ, the host path belongs on the value side.
   `perf_primus-megatron-GPT-OSS-120B.csv`.
 - **Primus Kimi-K2-Thinking**
   (`primus_pyt_megatron_lm_train_kimi-k2-thinking_overlay`): 1T-total /
-  27B-active MLA + MoE (61 layers, 384 experts), BF16 only, EP=8 intra-node,
-  TP=1, seq 4096. **Mock data, 50 iterations, no checkpoint** — a throughput
+  27B-active MLA + MoE (61 layers, 384 experts), BF16 only, **EP=192 across
+  24 nodes**, TP=1, MBS=1, full recompute, seq 4096. Smaller scale-outs are not
+  a tuning question — they cannot fit; the budget and the failure modes are in
+  [gotchas.md](gotchas.md#primus_megatron-training). Validated end-to-end at
+  24 nodes / 192 GPUs: 61 layers, all 50 iterations, `torchrun` exit 0,
+  ~236 tok/s/GPU steady state (derived from iteration wall-clock — Primus emits
+  no throughput line for this model, see below). **Mock data, 50 iterations, no checkpoint** — a throughput
   benchmark, not a training run (see [gotchas.md](gotchas.md#primus_megatron-training)).
   Two things differ from the other Primus templates and must be preserved:
   `"dockercontext": "./docker"` (the overlay Dockerfile `COPY`s the two Kimi
@@ -140,6 +145,14 @@ differ, the host path belongs on the value side.
   (see [gotchas.md](gotchas.md#primus_megatron-training)).
   Reference: 2 nodes / 16 GPU MI355X, BF16, MBS=1 -> ~6487 tok/s/GPU,
   ~96.5 TFLOP/s/GPU (run-to-run spread < 0.02%).
+  **Known open issue — the perf CSV comes out empty even on a healthy run.**
+  Primus' `training_log` patch fires only twice for this model (iterations 1-2,
+  both reported as `No token throughput` because
+  `log_avg_skip_iterations: 2` deliberately skips them) and then never again,
+  so no `tokens/s/GPU` line is ever emitted and the parser writes a
+  header-only CSV. The run itself is fine — same pipeline produces numbers for
+  Llama-4-Scout — so treat an empty CSV here as this bug, not as a failed run,
+  and read throughput off the iteration timestamps instead.
   `multiple_results` = `perf_primus-megatron-Kimi-K2-Thinking.csv`.
 - **sglang_disagg** (`sglang-disagg-deepseek-r1-overlay`): disaggregated
   prefill/decode serving of DeepSeek-R1 on SGLang.

--- a/.claude/skills/mad-slurm-multinode/references/manifests.md
+++ b/.claude/skills/mad-slurm-multinode/references/manifests.md
@@ -124,6 +124,21 @@ differ, the host path belongs on the value side.
   `timeout: 14400` (4h) — the CLI default (7200s/2h) times out on this model;
   keep the explicit 14400. `multiple_results` =
   `perf_primus-megatron-GPT-OSS-120B.csv`.
+- **Primus Kimi-K2-Thinking**
+  (`primus_pyt_megatron_lm_train_kimi-k2-thinking_overlay`): 1T-total /
+  27B-active MLA + MoE (61 layers, 384 experts), BF16 only, EP=8 intra-node,
+  TP=1, seq 4096. **Mock data, 50 iterations, no checkpoint** — a throughput
+  benchmark, not a training run (see [gotchas.md](gotchas.md#primus_megatron-training)).
+  Two things differ from the other Primus templates and must be preserved:
+  `"dockercontext": "./docker"` (the overlay Dockerfile `COPY`s the two Kimi
+  YAMLs out of `docker/kimi_k2_configs/`), and the `log_error_patterns` override
+  (torchrun prints a `Traceback` at worker cleanup that would otherwise be
+  scored as a failure). `PRIMUS_SANITY_TRAIN_ITERS` is set only in
+  `context.docker_env_vars`, so the local build-sanity run takes the 3-layer
+  proxy path while the deployed SLURM run measures full depth.
+  Reference: 2 nodes / 16 GPU MI355X, BF16, MBS=1 -> ~6487 tok/s/GPU,
+  ~96.5 TFLOP/s/GPU (run-to-run spread < 0.02%).
+  `multiple_results` = `perf_primus-megatron-Kimi-K2-Thinking.csv`.
 - **sglang_disagg** (`sglang-disagg-deepseek-r1-overlay`): disaggregated
   prefill/decode serving of DeepSeek-R1 on SGLang.
   `launcher: sglang-disagg`, `scripts/sglang_disagg/run.sh` entrypoint,
@@ -173,6 +188,20 @@ differ, the host path belongs on the value side.
      (attention backend selection is CLI-driven, independent of this env
      var).
   `multiple_results` = `perf_sglang-disagg-GPT-OSS-120B.csv`.
+- **sglang_disagg Kimi-K2-Instruct** (`sglang-disagg-kimi-k2-instruct-overlay`):
+  1T MLA + MoE, native FP8. Structurally identical to DeepSeek-R1 — start from
+  `sglang_disagg_deepseek-r1.template.json` and change `MODEL_NAME`,
+  `MODEL_PATH`, `MODEL_REPO` and `multiple_results`. Same 4-node xP=2/yD=2,
+  `RUN_MORI=1`, `DP_MODE=1` (Kimi-K2-Instruct is on the
+  `MORI_DP_MODE1_ALLOWED_MODELS` allowlist), TP=EP=DP=16 per server. The FP8 MoE
+  runner has the DeepEP-style pre-permute registered, so it gets the full MoRI
+  expert all-to-all plus CUDA graphs. Kimi-specific bits are already in the
+  scripts: `--tool-call-parser kimi_k2` and `--dist-timeout 3600` in
+  `models.yaml`, and `SGLANG_ROCM_FUSED_DECODE_MLA=0` set by the launcher for any
+  `*Kimi-K2*` model (64 attention heads fall outside the fused decode-MLA range,
+  which otherwise crashes unpacking `ForwardMetadata`). Verified at 4 nodes on
+  gfx942 (MI300X). Budget for the weights: this is a ~1T-parameter checkpoint.
+  `multiple_results` = `perf_sglang-disagg-Kimi-K2-Instruct.csv`.
 - **MLPerf Training Llama-3.1-8B** (`pyt_mlperf_training_llama-3.1-8b`): the
   MLCommons `small_llm_pretraining/nemo` benchmark on the NeMo/Megatron/TE stack.
   `launcher: torchrun`, `scripts/pyt_mlperf_training/run.sh`, `nproc_per_node: 8`,

--- a/.claude/skills/mad-slurm-multinode/references/manifests.md
+++ b/.claude/skills/mad-slurm-multinode/references/manifests.md
@@ -200,19 +200,30 @@ differ, the host path belongs on the value side.
      var).
   `multiple_results` = `perf_sglang-disagg-GPT-OSS-120B.csv`.
 - **sglang_disagg Kimi-K2-Instruct** (`sglang-disagg-kimi-k2-instruct-overlay`):
-  1T MLA + MoE, native FP8. Structurally identical to DeepSeek-R1 — start from
-  `sglang_disagg_deepseek-r1.template.json` and change `MODEL_NAME`,
-  `MODEL_PATH`, `MODEL_REPO` and `multiple_results`. Same 4-node xP=2/yD=2,
+  1T MLA + MoE, native FP8. Use
+  `assets/manifests/sglang_disagg_kimi-k2-instruct.template.json`. Same 4-node xP=2/yD=2,
   `RUN_MORI=1`, `DP_MODE=1` (Kimi-K2-Instruct is on the
   `MORI_DP_MODE1_ALLOWED_MODELS` allowlist), TP=EP=DP=16 per server. The FP8 MoE
   runner has the DeepEP-style pre-permute registered, so it gets the full MoRI
   expert all-to-all plus CUDA graphs. Kimi-specific bits are already in the
   scripts: `--tool-call-parser kimi_k2` and `--dist-timeout 3600` in
-  `models.yaml`, and `SGLANG_ROCM_FUSED_DECODE_MLA=0` set by the launcher for any
-  `*Kimi-K2*` model (64 attention heads fall outside the fused decode-MLA range,
-  which otherwise crashes unpacking `ForwardMetadata`). Verified at 4 nodes on
-  gfx942 (MI300X). Budget for the weights: this is a ~1T-parameter checkpoint
-  (959 GB on disk as staged from `moonshotai/Kimi-K2-Instruct-0905`).
+  `models.yaml`, and `SGLANG_ROCM_FUSED_DECODE_MLA=0` forced by the launcher for
+  any `*Kimi-K2*` model — matching upstream, which defaults the flag off and sets
+  it to `0` in its own Kimi-K2 ROCm CI recipes. (The launcher forces it rather
+  than only setting it when unset: the `rocm/sgl-dev` bases bake
+  `SGLANG_ROCM_FUSED_DECODE_MLA=1` into the image `Config.Env`, so an unset-test
+  never fires there. `SGLANG_KEEP_FUSED_DECODE_MLA=1` is the deliberate opt-in.)
+
+  Also launcher-side: `ROUTER_READY_TIMEOUT_SECONDS` defaults to `10800` for
+  `*Kimi-K2*` instead of the usual `4000`. Time-to-first-ready scales with
+  checkpoint size, and at ~1 TB the weight load alone measured 15m15s on an idle
+  NFS and 24m48s on a busy one — the slow case overran the 4000s default at
+  4003s and `run.sh` tore down servers that were still initialising.
+
+  Validated at 4 nodes / 32 GPUs on gfx942 (MI300X) + Mellanox CX7: 8/8 benchmark
+  points, perf CSV 56/56 `SUCCESS`, 0 `no transport available for peer`. Budget
+  for the weights: a ~1T-parameter checkpoint (959 GB on disk as staged from
+  `moonshotai/Kimi-K2-Instruct-0905`; ~1.1 TB for the full repo).
   `multiple_results` = `perf_sglang-disagg-Kimi-K2-Instruct.csv`.
 
   **Not yet working on gfx950 (MI355X) / Broadcom Thor2 bnxt_re.** Attempted

--- a/.claude/skills/mad-slurm-multinode/references/manifests.md
+++ b/.claude/skills/mad-slurm-multinode/references/manifests.md
@@ -133,9 +133,11 @@ differ, the host path belongs on the value side.
   `"dockercontext": "./docker"` (the overlay Dockerfile `COPY`s the two Kimi
   YAMLs out of `docker/kimi_k2_configs/`), and the `log_error_patterns` override
   (torchrun prints a `Traceback` at worker cleanup that would otherwise be
-  scored as a failure). `PRIMUS_SANITY_TRAIN_ITERS` is set only in
-  `context.docker_env_vars`, so the local build-sanity run takes the 3-layer
-  proxy path while the deployed SLURM run measures full depth.
+  scored as a failure). The template does **not** set `PRIMUS_SANITY_TRAIN_ITERS`
+  by default, so it measures full depth — `context.docker_env_vars` reaches
+  every deployment (SLURM included), so setting it there is not a build-only
+  toggle; add it yourself only for a deliberate fast 3-layer CI/sanity pass
+  (see [gotchas.md](gotchas.md#primus_megatron-training)).
   Reference: 2 nodes / 16 GPU MI355X, BF16, MBS=1 -> ~6487 tok/s/GPU,
   ~96.5 TFLOP/s/GPU (run-to-run spread < 0.02%).
   `multiple_results` = `perf_primus-megatron-Kimi-K2-Thinking.csv`.

--- a/.claude/skills/mad-slurm-multinode/references/manifests.md
+++ b/.claude/skills/mad-slurm-multinode/references/manifests.md
@@ -126,13 +126,9 @@ differ, the host path belongs on the value side.
   `perf_primus-megatron-GPT-OSS-120B.csv`.
 - **Primus Kimi-K2-Thinking**
   (`primus_pyt_megatron_lm_train_kimi-k2-thinking_overlay`): 1T-total /
-  27B-active MLA + MoE (61 layers, 384 experts), BF16 only, **EP=192 across
-  24 nodes**, TP=1, MBS=1, full recompute, seq 4096. Smaller scale-outs are not
-  a tuning question — they cannot fit; the budget and the failure modes are in
-  [gotchas.md](gotchas.md#primus_megatron-training). Validated end-to-end at
-  24 nodes / 192 GPUs: 61 layers, all 50 iterations, `torchrun` exit 0,
-  ~236 tok/s/GPU steady state (derived from iteration wall-clock — Primus emits
-  no throughput line for this model, see below). **Mock data, 50 iterations, no checkpoint** — a throughput
+  27B-active MLA + MoE (61 layers, 384 experts), BF16 only, EP=192 across
+  24 nodes, TP=1, MBS=1, full recompute, seq 4096. It does not fit in less.
+  Validated end-to-end: all 50 iterations, `torchrun` exit 0, ~236 tok/s/GPU. **Mock data, 50 iterations, no checkpoint** — a throughput
   benchmark, not a training run (see [gotchas.md](gotchas.md#primus_megatron-training)).
   Two things differ from the other Primus templates and must be preserved:
   `"dockercontext": "./docker"` (the overlay Dockerfile `COPY`s the two Kimi
@@ -145,14 +141,9 @@ differ, the host path belongs on the value side.
   (see [gotchas.md](gotchas.md#primus_megatron-training)).
   Reference: 2 nodes / 16 GPU MI355X, BF16, MBS=1 -> ~6487 tok/s/GPU,
   ~96.5 TFLOP/s/GPU (run-to-run spread < 0.02%).
-  **Known open issue — the perf CSV comes out empty even on a healthy run.**
-  Primus' `training_log` patch fires only twice for this model (iterations 1-2,
-  both reported as `No token throughput` because
-  `log_avg_skip_iterations: 2` deliberately skips them) and then never again,
-  so no `tokens/s/GPU` line is ever emitted and the parser writes a
-  header-only CSV. The run itself is fine — same pipeline produces numbers for
-  Llama-4-Scout — so treat an empty CSV here as this bug, not as a failed run,
-  and read throughput off the iteration timestamps instead.
+  Known open issue: Primus emits no throughput line for this model, so the
+  perf CSV comes out header-only even on a healthy run. Read throughput off the
+  iteration timestamps instead.
   `multiple_results` = `perf_primus-megatron-Kimi-K2-Thinking.csv`.
 - **sglang_disagg** (`sglang-disagg-deepseek-r1-overlay`): disaggregated
   prefill/decode serving of DeepSeek-R1 on SGLang.

--- a/.claude/skills/mad-slurm-multinode/references/manifests.md
+++ b/.claude/skills/mad-slurm-multinode/references/manifests.md
@@ -202,8 +202,25 @@ differ, the host path belongs on the value side.
   `models.yaml`, and `SGLANG_ROCM_FUSED_DECODE_MLA=0` set by the launcher for any
   `*Kimi-K2*` model (64 attention heads fall outside the fused decode-MLA range,
   which otherwise crashes unpacking `ForwardMetadata`). Verified at 4 nodes on
-  gfx942 (MI300X). Budget for the weights: this is a ~1T-parameter checkpoint.
+  gfx942 (MI300X). Budget for the weights: this is a ~1T-parameter checkpoint
+  (959 GB on disk as staged from `moonshotai/Kimi-K2-Instruct-0905`).
   `multiple_results` = `perf_sglang-disagg-Kimi-K2-Instruct.csv`.
+
+  **Not yet working on gfx950 (MI355X) / Broadcom Thor2 bnxt_re.** Attempted
+  end to end at 4 nodes with real staged weights: the build succeeds, weight
+  loading completes on both prefill servers (`Multi-thread loading shards:
+  100% Completed`), and DP=16/EP=16/TP=16 distributed init proceeds — but the
+  process then aborts with `Fatal Python error: Aborted` /
+  `mori/src/application/context/context.cpp:332:
+  Context::DefaultPolicyResolve: Assertion 'false && "no transport available
+  for peer"' failed`. This is MoRI's own cross-node expert-parallel
+  all-to-all failing to resolve an RDMA transport between peers — a
+  different code path from Llama-4-Scout's `mori` usage above, which is
+  TP-only and never exercises MoRI's EP a2a. Same `IB_DEVICES` /
+  `MORI_RDMA_DEVICES` / GID index that work for Scout's KV-transfer-only
+  `mori` path do not get MoRI's EP a2a talking on this fabric. Not resolved
+  here — needs MoRI-level RDMA topology debugging on Broadcom Thor2, which
+  is beyond what a manifest config change can fix.
 - **MLPerf Training Llama-3.1-8B** (`pyt_mlperf_training_llama-3.1-8b`): the
   MLCommons `small_llm_pretraining/nemo` benchmark on the NeMo/Megatron/TE stack.
   `launcher: torchrun`, `scripts/pyt_mlperf_training/run.sh`, `nproc_per_node: 8`,

--- a/.claude/skills/mad-slurm-multinode/references/manifests.md
+++ b/.claude/skills/mad-slurm-multinode/references/manifests.md
@@ -141,9 +141,14 @@ differ, the host path belongs on the value side.
   (see [gotchas.md](gotchas.md#primus_megatron-training)).
   Reference: 2 nodes / 16 GPU MI355X, BF16, MBS=1 -> ~6487 tok/s/GPU,
   ~96.5 TFLOP/s/GPU (run-to-run spread < 0.02%).
-  Known open issue: Primus emits no throughput line for this model, so the
-  perf CSV comes out header-only even on a healthy run. Read throughput off the
-  iteration timestamps instead.
+  Known open issue: no `tokens/s/GPU` line reaches the log for this model, so
+  the perf CSV comes out header-only even on a healthy run. Read throughput off
+  the iteration timestamps instead. The cause is **not** the logging cadence:
+  Primus already defaults to `log_interval: 1` / `log_throughput: true`
+  (`primus/configs/modules/megatron/pre_trainer.yaml`), the shipped Kimi
+  experiment YAML only restates that default, and the 24-node run above was
+  measured with it in place and still produced an empty CSV. Root cause is
+  still open — do not "fix" it by touching `log_interval`.
   `multiple_results` = `perf_primus-megatron-Kimi-K2-Thinking.csv`.
 - **sglang_disagg** (`sglang-disagg-deepseek-r1-overlay`): disaggregated
   prefill/decode serving of DeepSeek-R1 on SGLang.

--- a/docker/kimi_k2_configs/kimi_k2_thinking-BF16-pretrain.yaml
+++ b/docker/kimi_k2_configs/kimi_k2_thinking-BF16-pretrain.yaml
@@ -18,11 +18,16 @@ modules:
     model: ${PRIMUS_MODEL:kimi_k2_thinking}.yaml
     overrides:
       train_iters: 50
-      # Log every step. Primus' ThroughputAverageExtension skips the first two
-      # logged steps; at the log_interval inherited from pre_trainer.yaml a
-      # 50-iteration run produces only two logged steps, both get skipped, and
-      # the job finishes with no throughput at all -- an empty perf CSV from an
-      # otherwise healthy run.
+      # Pin the logging cadence to every step. This restates what Primus
+      # already defaults to (primus/configs/modules/megatron/pre_trainer.yaml:
+      # log_interval: 1, log_throughput: true, unchanged upstream since 2025),
+      # so it changes nothing today -- it only stops a future base image from
+      # silently widening the interval underneath a 50-iteration run.
+      #
+      # It is NOT the fix for the empty-perf-CSV symptom below. That symptom
+      # was still observed on the validated 24-node run with this line already
+      # in place, so whatever suppresses the throughput line is not the log
+      # cadence; see references/manifests.md for the open item.
       log_interval: 1
       micro_batch_size: 4
       global_batch_size: 128

--- a/docker/kimi_k2_configs/kimi_k2_thinking-BF16-pretrain.yaml
+++ b/docker/kimi_k2_configs/kimi_k2_thinking-BF16-pretrain.yaml
@@ -1,0 +1,29 @@
+# Kimi-K2-Thinking BF16 pretrain — throughput benchmark, not a real training run.
+#
+# mock_data: true and train_iters: 50 below are unconditional: this experiment
+# measures steady-state tok/s and TFLOP/s on synthetic batches over 50 steps and
+# saves nothing (disable_last_saving). It uses the real 61-layer architecture, so
+# the numbers are representative of the shape, but no checkpoint is produced and
+# no dataset is read. Setting PRIMUS_SANITY_TRAIN_ITERS additionally cuts the run
+# to 3 layers for CI/build sanity — see references/gotchas.md.
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:kimi_k2_thinking-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+    model: ${PRIMUS_MODEL:kimi_k2_thinking}.yaml
+    overrides:
+      train_iters: 50
+      micro_batch_size: 4
+      global_batch_size: 128
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      mock_data: true
+      moe_use_legacy_grouped_gemm: true
+      disable_last_saving: true

--- a/docker/kimi_k2_configs/kimi_k2_thinking-BF16-pretrain.yaml
+++ b/docker/kimi_k2_configs/kimi_k2_thinking-BF16-pretrain.yaml
@@ -18,6 +18,12 @@ modules:
     model: ${PRIMUS_MODEL:kimi_k2_thinking}.yaml
     overrides:
       train_iters: 50
+      # Log every step. Primus' ThroughputAverageExtension skips the first two
+      # logged steps; at the log_interval inherited from pre_trainer.yaml a
+      # 50-iteration run produces only two logged steps, both get skipped, and
+      # the job finishes with no throughput at all -- an empty perf CSV from an
+      # otherwise healthy run.
+      log_interval: 1
       micro_batch_size: 4
       global_batch_size: 128
       seq_length: ${PRIMUS_SEQ_LENGTH:4096}

--- a/docker/kimi_k2_configs/kimi_k2_thinking.yaml
+++ b/docker/kimi_k2_configs/kimi_k2_thinking.yaml
@@ -1,0 +1,37 @@
+extends:
+  - deepseek_v3_base.yaml
+
+# https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/config.json
+# Kimi K2 Thinking: 1039.77B total params, 27.03B active params
+
+tokenizer_type: NullTokenizer
+vocab_size: 102400
+
+# model
+num_layers: 61
+hidden_size: 7168
+ffn_hidden_size: 18432
+num_attention_heads: 64
+
+# mla
+q_lora_rank: 1536
+kv_lora_rank: 512
+qk_head_dim: 128
+qk_pos_emb_head_dim: 64
+v_head_dim: 128
+kv_channels: 128
+
+# no MTP
+mtp_num_layers: null
+
+# moe — first 1 layer dense, then all MoE
+moe_layer_freq: "([0]*1+[1]*60)"
+num_experts: 384
+moe_router_topk: 8
+moe_ffn_hidden_size: 2048
+moe_shared_expert_intermediate_size: 2048
+
+# device-limited routing (no group routing: n_group=1)
+moe_router_num_groups: null
+moe_router_group_topk: null
+moe_router_topk_scaling_factor: 2.827

--- a/docker/primus_megatron_train_rccl_overlay.ubuntu.amd.Dockerfile
+++ b/docker/primus_megatron_train_rccl_overlay.ubuntu.amd.Dockerfile
@@ -286,6 +286,47 @@ RUN if [[ -n "${RDMA_CORE_VERSION}" ]]; then \
       echo "RDMA_CORE_VERSION empty — keeping base image rdma-core"; \
     fi
 
+# ---- Kimi-K2-Thinking Primus configs ----------------------------------------
+# Primus ships model/experiment YAMLs inside the base image; Kimi-K2-Thinking is
+# not one of them, so the two configs are carried in this repo and injected here.
+# Harmless for every other model: two YAML files nobody reads unless
+# primus_pyt_megatron_lm_train_kimi-k2-thinking is the requested model repo.
+#
+# NOTE: these COPY lines make ./docker the required build context (which is what
+# the manifest templates already set via "dockercontext": "./docker").
+COPY kimi_k2_configs/kimi_k2_thinking.yaml \
+     ${WORKSPACE_DIR}/Primus/primus/configs/models/megatron/kimi_k2_thinking.yaml
+COPY kimi_k2_configs/kimi_k2_thinking-BF16-pretrain.yaml \
+     ${WORKSPACE_DIR}/Primus/examples/megatron/configs/MI355X/kimi_k2_thinking-BF16-pretrain.yaml
+# benchmark_report.sh resolves the config under $CONFIG_DEVICE, so mirror the
+# experiment YAML into every device dir the base image actually ships.
+RUN set -e; \
+    for d in MI350X MI300X MI325X; do \
+      tgt="${WORKSPACE_DIR}/Primus/examples/megatron/configs/${d}"; \
+      if [ -d "$tgt" ]; then \
+        cp "${WORKSPACE_DIR}/Primus/examples/megatron/configs/MI355X/kimi_k2_thinking-BF16-pretrain.yaml" "$tgt/"; \
+      fi; \
+    done
+
+# Raise the torchrun rendezvous timeout from the 600s default to 7200s. On the
+# first Kimi-K2-Thinking iteration MIOpen compiles kernels for 384 experts, which
+# outlasts 600s and drops the slower ranks out of the rendezvous with
+# DistStoreError. Applied unconditionally: a longer rendezvous timeout only
+# changes how long a genuinely stuck job takes to fail, and multi-node runs of
+# every other model benefit from the same headroom.
+RUN set -e; \
+    for f in ${WORKSPACE_DIR}/Primus/examples/run_pretrain.sh \
+             ${WORKSPACE_DIR}/Primus/runner/primus-cli-direct.sh; do \
+      if [ -f "$f" ]; then \
+        if grep -q "rdzv.conf" "$f"; then \
+          sed -i 's/--rdzv-conf timeout=[0-9]*/--rdzv-conf timeout=7200/' "$f"; \
+        else \
+          sed -i 's/\(--master_port[^)]*\)$/\1\n        --rdzv-conf timeout=7200/' "$f"; \
+        fi; \
+        grep -n "rdzv" "$f" | head -3; \
+      fi; \
+    done
+
 # ---- final verification: import torch + every librccl == candidate ----------
 RUN set -e && \
     if [[ -n "${RDMA_CORE_VERSION}" ]]; then \

--- a/scripts/primus_megatron-lm/models.json
+++ b/scripts/primus_megatron-lm/models.json
@@ -3,6 +3,7 @@
     "name": "primus_pyt_megatron_lm_train_llama-3.1-8b_overlay",
     "url": "",
     "dockerfile": "../../docker/primus_megatron_train_rccl_overlay",
+    "dockercontext": "./docker",
     "scripts": "run.sh",
     "n_gpus": "-1",
     "owner": "mad.support@amd.com",
@@ -23,6 +24,7 @@
     "name": "primus_pyt_megatron_lm_train_llama-3.1-70b_overlay",
     "url": "",
     "dockerfile": "../../docker/primus_megatron_train_rccl_overlay",
+    "dockercontext": "./docker",
     "scripts": "run.sh",
     "n_gpus": "-1",
     "owner": "mad.support@amd.com",
@@ -43,6 +45,7 @@
     "name": "primus_pyt_megatron_lm_train_llama-3.1-405b_overlay",
     "url": "",
     "dockerfile": "../../docker/primus_megatron_train_rccl_overlay",
+    "dockercontext": "./docker",
     "scripts": "run.sh",
     "n_gpus": "-1",
     "owner": "mad.support@amd.com",
@@ -63,6 +66,7 @@
     "name": "primus_pyt_megatron_lm_train_gpt-oss-120b_overlay",
     "url": "",
     "dockerfile": "../../docker/primus_megatron_train_rccl_overlay",
+    "dockercontext": "./docker",
     "scripts": "run.sh",
     "n_gpus": "-1",
     "owner": "mad.support@amd.com",
@@ -77,5 +81,27 @@
     ],
     "timeout": -1,
     "args": "--model_repo primus_pyt_megatron_lm_train_gpt-oss-120b"
+  },
+  {
+    "name": "primus_pyt_megatron_lm_train_kimi-k2-thinking_overlay",
+    "url": "",
+    "dockerfile": "../../docker/primus_megatron_train_rccl_overlay",
+    "dockercontext": "./docker",
+    "scripts": "run.sh",
+    "n_gpus": "-1",
+    "owner": "mad.support@amd.com",
+    "training_precision": "",
+    "multiple_results": "perf_primus-megatron-Kimi-K2-Thinking.csv",
+    "tags": [
+      "pyt",
+      "pretrain",
+      "kimi-k2",
+      "moe",
+      "training",
+      "primus",
+      "scaleout"
+    ],
+    "timeout": -1,
+    "args": "--model_repo primus_pyt_megatron_lm_train_kimi-k2-thinking"
   }
 ]

--- a/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.py
+++ b/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.py
@@ -156,6 +156,7 @@ if args.model == "Llama-3.1-8B" or args.model == "Llama-3.1-70B" or \
         args.model == "Mixtral-8x7B" or args.model == "Mixtral-8x22B-proxy" or \
         args.model == "DeepSeek-V2-lite" or args.model == "DeepSeek-V3-proxy" or \
         args.model == "Llama-3.1-70B-proxy" or args.model == "Llama-3.3-70B" or \
+        args.model == "Kimi-K2-Thinking" or \
         args.model == "Qwen2.5-7B" or args.model == "Qwen2.5-72B" or \
         args.model == "Zebra-Llama-1B" or args.model == "Zebra-Llama-3B" or args.model == "Zebra-Llama-8B" or \
         args.model == "Qwen-3-32B" or args.model == "Mamba-370M" or \

--- a/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
+++ b/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
@@ -623,14 +623,8 @@ elif [ "$MODEL_REPO" == "Kimi-K2-Thinking" ]; then
   # PRIMUS_SANITY_TRAIN_ITERS additionally drops it to 3 layers for CI/build
   # sanity; leave it unset for a representative full-depth measurement.
   #
-  # SCALE REQUIREMENT: full depth needs >= 24 nodes (192 GPUs) with
-  # PRIMUS_EP=192. This is arithmetic, not tuning -- weights + fp32 grads +
-  # (unsharded, since expert-DP collapses to 1) optimizer state come to roughly
-  # 1126 GiB/GPU at the old EP=8 2-node shape, against 252 GiB available on
-  # MI355X. The deployment must also set
-  # PYTORCH_HIP_ALLOC_CONF=expandable_segments:True: with the previous
-  # garbage_collection_threshold:0.8 the allocator thrashes near the ceiling and
-  # hangs for many minutes instead of raising OutOfMemoryError.
+  # Full depth needs 24 nodes (192 GPUs) with PRIMUS_EP=192, and the
+  # deployment must set PYTORCH_HIP_ALLOC_CONF=expandable_segments:True.
   export EXP=examples/megatron/configs/$CONFIG_DEVICE/kimi_k2_thinking-$DATATYPE-pretrain.yaml
   SEQ_LEN=4096
   if [[ "$DEVICE" == "MI355X" || "$DEVICE" == "MI350X" ]]; then
@@ -641,18 +635,10 @@ elif [ "$MODEL_REPO" == "Kimi-K2-Thinking" ]; then
         MBS=1; GBS=32
         run_primus "$EXP" --num_layers 3 --moe_layer_freq 1 --micro_batch_size $MBS --global_batch_size $GBS
       else
-        # MBS=1 and full activation recompute are REQUIRED, not tuning: at
-        # 1T total params this model only fits with both. Measured on MI355X
-        # (252 GiB usable/GPU) at 24 nodes / EP=192: ~188 GiB resident with
-        # recompute on, and the first OOM-free run needed MBS=1 -- MBS=4 dies
-        # in backward on the MoE permutation buffers, which scale with the
-        # micro-batch. See references/gotchas.md for the full memory budget
-        # and why smaller scale-outs cannot work at all.
-        #
-        # Both flags are always passed explicitly (rather than the
-        # scaleout_gbs_override pattern used elsewhere) because we cannot rely
-        # on an empty override falling back to a correct config default.
-        # effective_global_batch_size keeps
+        # MBS=1 and full recompute are required, not tuning -- at 1T params
+        # the model does not fit without both. Flags are passed explicitly
+        # rather than via scaleout_gbs_override so an empty override can never
+        # fall back to a wrong default; effective_global_batch_size keeps
         # global_batch_size % (micro_batch_size * world_size) == 0 at any scale.
         MBS=1; GBS=128
         GBS=$(effective_global_batch_size "$MBS" "$GBS")

--- a/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
+++ b/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
@@ -627,44 +627,50 @@ elif [ "$MODEL_REPO" == "Kimi-K2-Thinking" ]; then
   # deployment must set PYTORCH_HIP_ALLOC_CONF=expandable_segments:True.
   export EXP=examples/megatron/configs/$CONFIG_DEVICE/kimi_k2_thinking-$DATATYPE-pretrain.yaml
   SEQ_LEN=4096
-  if [[ "$DEVICE" == "MI355X" || "$DEVICE" == "MI350X" ]]; then
-    if [ "$DATATYPE" == "FP8" ]; then
-      echo "Error: Datatype FP8 is not supported for $MODEL_REPO on $DEVICE. Only BF16 is supported."
-    elif [ "$DATATYPE" == "BF16" ]; then
-      if [[ -n "${PRIMUS_SANITY_TRAIN_ITERS:-}" ]]; then
-        MBS=1; GBS=32
-        run_primus "$EXP" --num_layers 3 --moe_layer_freq 1 --micro_batch_size $MBS --global_batch_size $GBS
-      else
-        # MBS=1 and full recompute are required, not tuning -- at 1T params
-        # the model does not fit without both. Flags are passed explicitly
-        # rather than via scaleout_gbs_override so an empty override can never
-        # fall back to a wrong default; effective_global_batch_size keeps
-        # global_batch_size % (micro_batch_size * world_size) == 0 at any scale.
-        MBS=1; GBS=128
-        GBS=$(effective_global_batch_size "$MBS" "$GBS")
-        run_primus "$EXP" --micro_batch_size $MBS --global_batch_size $GBS \
-          --recompute_granularity full --recompute_method uniform --recompute_num_layers 1
-      fi
+  # BF16-only, and not merely by policy: the rccl_overlay Dockerfile injects
+  # exactly one experiment YAML for this model (kimi_k2_thinking-BF16-pretrain.yaml),
+  # so $EXP above cannot resolve for any other DATATYPE. Guard once, up front,
+  # instead of per-device: the per-device `if FP8 ... elif BF16` shape used by the
+  # other model blocks names only FP8, which left MXFP8/MXFP4/FP4 matching no
+  # branch at all and falling through with no diagnostic whatsoever. The same
+  # applies to an unrecognized DEVICE. Behaviour on the unsupported path is
+  # unchanged (echo, no exit) so the "configuration not supported" perf-CSV row
+  # stays consistent with every other block in this file -- what changes is that
+  # the log now always says which value was rejected.
+  if [ "$DATATYPE" != "BF16" ]; then
+    echo "Error: Datatype $DATATYPE is not supported for $MODEL_REPO on $DEVICE. Only BF16 is supported."
+  elif [[ "$DEVICE" == "MI355X" || "$DEVICE" == "MI350X" ]]; then
+    if [[ -n "${PRIMUS_SANITY_TRAIN_ITERS:-}" ]]; then
+      MBS=1; GBS=32
+      run_primus "$EXP" --num_layers 3 --moe_layer_freq 1 --micro_batch_size $MBS --global_batch_size $GBS
+    else
+      # MBS=1 and full recompute are required, not tuning -- at 1T params
+      # the model does not fit without both. Flags are passed explicitly
+      # rather than via scaleout_gbs_override so an empty override can never
+      # fall back to a wrong default; effective_global_batch_size keeps
+      # global_batch_size % (micro_batch_size * world_size) == 0 at any scale.
+      MBS=1; GBS=128
+      GBS=$(effective_global_batch_size "$MBS" "$GBS")
+      run_primus "$EXP" --micro_batch_size $MBS --global_batch_size $GBS \
+        --recompute_granularity full --recompute_method uniform --recompute_num_layers 1
     fi
   elif [[ "$DEVICE" == "MI300X" || "$DEVICE" == "MI325X" ]]; then
-    if [ "$DATATYPE" == "FP8" ]; then
-      echo "Error: Datatype FP8 is not supported for $MODEL_REPO on $DEVICE. Only BF16 is supported."
-    elif [ "$DATATYPE" == "BF16" ]; then
-      if [[ -n "${PRIMUS_SANITY_TRAIN_ITERS:-}" ]]; then
-        MBS=1; GBS=32
-        run_primus "$EXP" --num_layers 3 --moe_layer_freq 1 --micro_batch_size $MBS --global_batch_size $GBS
-      else
-        # MBS=2/GBS=32 deliberately overrides the experiment YAML's own
-        # micro_batch_size=4/global_batch_size=128 -- both flags must always
-        # be passed explicitly, or an unadjusted-at-this-scale run silently
-        # falls back to the YAML's global_batch_size=128 while MBS stays
-        # overridden to 2, doubling the intended gradient-accumulation depth
-        # and diverging from what gets recorded in the perf CSV.
-        MBS=2; GBS=32
-        GBS=$(effective_global_batch_size "$MBS" "$GBS")
-        run_primus "$EXP" --micro_batch_size $MBS --global_batch_size $GBS
-      fi
+    if [[ -n "${PRIMUS_SANITY_TRAIN_ITERS:-}" ]]; then
+      MBS=1; GBS=32
+      run_primus "$EXP" --num_layers 3 --moe_layer_freq 1 --micro_batch_size $MBS --global_batch_size $GBS
+    else
+      # MBS=2/GBS=32 deliberately overrides the experiment YAML's own
+      # micro_batch_size=4/global_batch_size=128 -- both flags must always
+      # be passed explicitly, or an unadjusted-at-this-scale run silently
+      # falls back to the YAML's global_batch_size=128 while MBS stays
+      # overridden to 2, doubling the intended gradient-accumulation depth
+      # and diverging from what gets recorded in the perf CSV.
+      MBS=2; GBS=32
+      GBS=$(effective_global_batch_size "$MBS" "$GBS")
+      run_primus "$EXP" --micro_batch_size $MBS --global_batch_size $GBS
     fi
+  else
+    echo "Error: Device $DEVICE is not supported for $MODEL_REPO. Supported: MI355X, MI350X, MI300X, MI325X."
   fi
   if [ -f "$TRAIN_LOG" ]; then
     echo "[INFO] Benchmarking"

--- a/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
+++ b/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
@@ -632,9 +632,15 @@ elif [ "$MODEL_REPO" == "Kimi-K2-Thinking" ]; then
         MBS=1; GBS=32
         run_primus "$EXP" --num_layers 3 --moe_layer_freq 1 --micro_batch_size $MBS --global_batch_size $GBS
       else
-        # MBS/GBS already match the experiment YAML, so no CLI override is needed.
+        # MBS/GBS match the experiment YAML at single-node (8-GPU) scale;
+        # scaleout_gbs_override renormalizes GBS for NUM_GPUS>8 so an
+        # uneven node count (e.g. 3 nodes/24 GPUs) doesn't violate
+        # Megatron's global_batch_size % (micro_batch_size * world_size) == 0
+        # check at run time.
         MBS=4; GBS=128
-        run_primus "$EXP"
+        GBS_OVERRIDE=$(scaleout_gbs_override "$MBS" "$GBS")
+        GBS=$(effective_global_batch_size "$MBS" "$GBS")
+        run_primus "$EXP" $GBS_OVERRIDE
       fi
     fi
   elif [[ "$DEVICE" == "MI300X" || "$DEVICE" == "MI325X" ]]; then
@@ -646,7 +652,9 @@ elif [ "$MODEL_REPO" == "Kimi-K2-Thinking" ]; then
         run_primus "$EXP" --num_layers 3 --moe_layer_freq 1 --micro_batch_size $MBS --global_batch_size $GBS
       else
         MBS=2; GBS=32
-        run_primus "$EXP" --micro_batch_size $MBS --global_batch_size $GBS
+        GBS_OVERRIDE=$(scaleout_gbs_override "$MBS" "$GBS")
+        GBS=$(effective_global_batch_size "$MBS" "$GBS")
+        run_primus "$EXP" --micro_batch_size $MBS $GBS_OVERRIDE
       fi
     fi
   fi

--- a/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
+++ b/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
@@ -45,7 +45,7 @@ POSTTRAIN_TYPE="lora"
 usage() {
   echo "Usage: $0 -m <model_repo> -p <datatype> -t <mode> -f <posttrain_type>"
   echo "\nOptions:"
-  echo "  -m <model_repo>      Model repository (Llama-2-7B, Llama-2-70B, Llama-3.1-8B, Llama-3.1-70B, DeepSeek-V2-lite, DeepSeek-V3-proxy, Mixtral-8x7B, Mixtral-8x22B-proxy, Zebra-Llama-1B, Zebra-Llama-3B, Zebra-Llama-8B, Qwen-3-32B, GPT-OSS-20B, GPT-OSS-120B, Qwen-3-30B, Qwen-3-235B, Mamba-370M)"
+  echo "  -m <model_repo>      Model repository (Llama-2-7B, Llama-2-70B, Llama-3.1-8B, Llama-3.1-70B, Kimi-K2-Thinking, DeepSeek-V2-lite, DeepSeek-V3-proxy, Mixtral-8x7B, Mixtral-8x22B-proxy, Zebra-Llama-1B, Zebra-Llama-3B, Zebra-Llama-8B, Qwen-3-32B, GPT-OSS-20B, GPT-OSS-120B, Qwen-3-30B, Qwen-3-235B, Mamba-370M)"
   echo "  -p <datatype>        Precision type (FP8, BF16, MXFP8, or MXFP4). MXFP8/MXFP4 only supported on MI355X/MI350X."
   echo "  -t <mode>            Training mode (pretrain or posttrain, default: pretrain)"
   echo "  -f <posttrain_type>  Post-training type (sft or lora, default: lora). Only used when mode is posttrain."
@@ -598,6 +598,56 @@ elif [ "$MODEL_REPO" == "DeepSeek-V3-proxy" ]; then
         --log_file /tmp/primus_$MODEL_REPO.log \
         -- train pretrain \
         --config $EXP --num_layers 3 --moe_layer_freq 1 --micro_batch_size $MBS --global_batch_size $GBS $DEEPEP_ARGS 2>&1 | tee $TRAIN_LOG
+    fi
+  fi
+  if [ -f "$TRAIN_LOG" ]; then
+    echo "[INFO] Benchmarking"
+    python3 $perf_script --model $MODEL_REPO --input $TRAIN_LOG --output $PERF_LOG --mode $MODE --precision $DATATYPE --batch_size $MBS --global_batch_size $GBS --seq_len $SEQ_LEN --device $DEVICE --num_gpus $NUM_GPUS
+    rm $TRAIN_LOG
+  else
+    echo "[INFO] Training log not found - configuration not supported."
+    echo "model,performance,metric,mode,precision,batch_size,global_batch_size,seq_len,device,num_gpus" > $PERF_LOG
+    echo "$MODEL_REPO,,tok_per_s_per_gpu,$MODE,$DATATYPE,$MBS,$GBS,$SEQ_LEN,$DEVICE,$NUM_GPUS" >> $PERF_LOG
+    echo "$MODEL_REPO,,TFLOPS_per_gpu,$MODE,$DATATYPE,$MBS,$GBS,$SEQ_LEN,$DEVICE,$NUM_GPUS" >> $PERF_LOG
+  fi
+
+elif [ "$MODEL_REPO" == "Kimi-K2-Thinking" ]; then
+  echo "[INFO] $MODEL_REPO TRAINING"
+  # Kimi-K2-Thinking: 1T-total / 27B-active MLA + MoE (61 layers, 384 experts),
+  # EP=8 intra-node, TP=1. Both the model YAML and this BF16 experiment YAML are
+  # injected into the Primus tree by the rccl_overlay Dockerfile -- unlike every
+  # other model here, they do not ship inside the rocm/primus base image.
+  #
+  # This is a throughput benchmark, not a training run: the experiment YAML sets
+  # mock_data and train_iters: 50 unconditionally and saves no checkpoint.
+  # PRIMUS_SANITY_TRAIN_ITERS additionally drops it to 3 layers for CI/build
+  # sanity; leave it unset for a representative full-depth measurement.
+  export EXP=examples/megatron/configs/$CONFIG_DEVICE/kimi_k2_thinking-$DATATYPE-pretrain.yaml
+  SEQ_LEN=4096
+  if [[ "$DEVICE" == "MI355X" || "$DEVICE" == "MI350X" ]]; then
+    if [ "$DATATYPE" == "FP8" ]; then
+      echo "Error: Datatype FP8 is not supported for $MODEL_REPO on $DEVICE. Only BF16 is supported."
+    elif [ "$DATATYPE" == "BF16" ]; then
+      if [[ -n "${PRIMUS_SANITY_TRAIN_ITERS:-}" ]]; then
+        MBS=1; GBS=32
+        run_primus "$EXP" --num_layers 3 --moe_layer_freq 1 --micro_batch_size $MBS --global_batch_size $GBS
+      else
+        # MBS/GBS already match the experiment YAML, so no CLI override is needed.
+        MBS=4; GBS=128
+        run_primus "$EXP"
+      fi
+    fi
+  elif [[ "$DEVICE" == "MI300X" || "$DEVICE" == "MI325X" ]]; then
+    if [ "$DATATYPE" == "FP8" ]; then
+      echo "Error: Datatype FP8 is not supported for $MODEL_REPO on $DEVICE. Only BF16 is supported."
+    elif [ "$DATATYPE" == "BF16" ]; then
+      if [[ -n "${PRIMUS_SANITY_TRAIN_ITERS:-}" ]]; then
+        MBS=1; GBS=32
+        run_primus "$EXP" --num_layers 3 --moe_layer_freq 1 --micro_batch_size $MBS --global_batch_size $GBS
+      else
+        MBS=2; GBS=32
+        run_primus "$EXP" --micro_batch_size $MBS --global_batch_size $GBS
+      fi
     fi
   fi
   if [ -f "$TRAIN_LOG" ]; then

--- a/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
+++ b/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
@@ -614,7 +614,7 @@ elif [ "$MODEL_REPO" == "DeepSeek-V3-proxy" ]; then
 elif [ "$MODEL_REPO" == "Kimi-K2-Thinking" ]; then
   echo "[INFO] $MODEL_REPO TRAINING"
   # Kimi-K2-Thinking: 1T-total / 27B-active MLA + MoE (61 layers, 384 experts),
-  # EP=8 intra-node, TP=1. Both the model YAML and this BF16 experiment YAML are
+  # TP=1. Both the model YAML and this BF16 experiment YAML are
   # injected into the Primus tree by the rccl_overlay Dockerfile -- unlike every
   # other model here, they do not ship inside the rocm/primus base image.
   #
@@ -622,6 +622,15 @@ elif [ "$MODEL_REPO" == "Kimi-K2-Thinking" ]; then
   # mock_data and train_iters: 50 unconditionally and saves no checkpoint.
   # PRIMUS_SANITY_TRAIN_ITERS additionally drops it to 3 layers for CI/build
   # sanity; leave it unset for a representative full-depth measurement.
+  #
+  # SCALE REQUIREMENT: full depth needs >= 24 nodes (192 GPUs) with
+  # PRIMUS_EP=192. This is arithmetic, not tuning -- weights + fp32 grads +
+  # (unsharded, since expert-DP collapses to 1) optimizer state come to roughly
+  # 1126 GiB/GPU at the old EP=8 2-node shape, against 252 GiB available on
+  # MI355X. The deployment must also set
+  # PYTORCH_HIP_ALLOC_CONF=expandable_segments:True: with the previous
+  # garbage_collection_threshold:0.8 the allocator thrashes near the ceiling and
+  # hangs for many minutes instead of raising OutOfMemoryError.
   export EXP=examples/megatron/configs/$CONFIG_DEVICE/kimi_k2_thinking-$DATATYPE-pretrain.yaml
   SEQ_LEN=4096
   if [[ "$DEVICE" == "MI355X" || "$DEVICE" == "MI350X" ]]; then
@@ -632,18 +641,23 @@ elif [ "$MODEL_REPO" == "Kimi-K2-Thinking" ]; then
         MBS=1; GBS=32
         run_primus "$EXP" --num_layers 3 --moe_layer_freq 1 --micro_batch_size $MBS --global_batch_size $GBS
       else
-        # MBS=4/GBS=128 is an explicit override of the experiment YAML (it
-        # happens to match the YAML's own default at this device, but that's
-        # not guaranteed), so both flags must always be passed -- unlike the
-        # scaleout_gbs_override pattern used elsewhere, we can't rely on an
-        # empty override falling back to a correct config default. Compute
-        # the scaled value with effective_global_batch_size and pass it
-        # unconditionally so NUM_GPUS>8 (e.g. 3 nodes/24 GPUs) still satisfies
-        # Megatron's global_batch_size % (micro_batch_size * world_size) == 0
-        # check.
-        MBS=4; GBS=128
+        # MBS=1 and full activation recompute are REQUIRED, not tuning: at
+        # 1T total params this model only fits with both. Measured on MI355X
+        # (252 GiB usable/GPU) at 24 nodes / EP=192: ~188 GiB resident with
+        # recompute on, and the first OOM-free run needed MBS=1 -- MBS=4 dies
+        # in backward on the MoE permutation buffers, which scale with the
+        # micro-batch. See references/gotchas.md for the full memory budget
+        # and why smaller scale-outs cannot work at all.
+        #
+        # Both flags are always passed explicitly (rather than the
+        # scaleout_gbs_override pattern used elsewhere) because we cannot rely
+        # on an empty override falling back to a correct config default.
+        # effective_global_batch_size keeps
+        # global_batch_size % (micro_batch_size * world_size) == 0 at any scale.
+        MBS=1; GBS=128
         GBS=$(effective_global_batch_size "$MBS" "$GBS")
-        run_primus "$EXP" --micro_batch_size $MBS --global_batch_size $GBS
+        run_primus "$EXP" --micro_batch_size $MBS --global_batch_size $GBS \
+          --recompute_granularity full --recompute_method uniform --recompute_num_layers 1
       fi
     fi
   elif [[ "$DEVICE" == "MI300X" || "$DEVICE" == "MI325X" ]]; then

--- a/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
+++ b/scripts/primus_megatron-lm/primus_megatron-lm_benchmark_report.sh
@@ -632,15 +632,18 @@ elif [ "$MODEL_REPO" == "Kimi-K2-Thinking" ]; then
         MBS=1; GBS=32
         run_primus "$EXP" --num_layers 3 --moe_layer_freq 1 --micro_batch_size $MBS --global_batch_size $GBS
       else
-        # MBS/GBS match the experiment YAML at single-node (8-GPU) scale;
-        # scaleout_gbs_override renormalizes GBS for NUM_GPUS>8 so an
-        # uneven node count (e.g. 3 nodes/24 GPUs) doesn't violate
+        # MBS=4/GBS=128 is an explicit override of the experiment YAML (it
+        # happens to match the YAML's own default at this device, but that's
+        # not guaranteed), so both flags must always be passed -- unlike the
+        # scaleout_gbs_override pattern used elsewhere, we can't rely on an
+        # empty override falling back to a correct config default. Compute
+        # the scaled value with effective_global_batch_size and pass it
+        # unconditionally so NUM_GPUS>8 (e.g. 3 nodes/24 GPUs) still satisfies
         # Megatron's global_batch_size % (micro_batch_size * world_size) == 0
-        # check at run time.
+        # check.
         MBS=4; GBS=128
-        GBS_OVERRIDE=$(scaleout_gbs_override "$MBS" "$GBS")
         GBS=$(effective_global_batch_size "$MBS" "$GBS")
-        run_primus "$EXP" $GBS_OVERRIDE
+        run_primus "$EXP" --micro_batch_size $MBS --global_batch_size $GBS
       fi
     fi
   elif [[ "$DEVICE" == "MI300X" || "$DEVICE" == "MI325X" ]]; then
@@ -651,10 +654,15 @@ elif [ "$MODEL_REPO" == "Kimi-K2-Thinking" ]; then
         MBS=1; GBS=32
         run_primus "$EXP" --num_layers 3 --moe_layer_freq 1 --micro_batch_size $MBS --global_batch_size $GBS
       else
+        # MBS=2/GBS=32 deliberately overrides the experiment YAML's own
+        # micro_batch_size=4/global_batch_size=128 -- both flags must always
+        # be passed explicitly, or an unadjusted-at-this-scale run silently
+        # falls back to the YAML's global_batch_size=128 while MBS stays
+        # overridden to 2, doubling the intended gradient-accumulation depth
+        # and diverging from what gets recorded in the perf CSV.
         MBS=2; GBS=32
-        GBS_OVERRIDE=$(scaleout_gbs_override "$MBS" "$GBS")
         GBS=$(effective_global_batch_size "$MBS" "$GBS")
-        run_primus "$EXP" --micro_batch_size $MBS $GBS_OVERRIDE
+        run_primus "$EXP" --micro_batch_size $MBS --global_batch_size $GBS
       fi
     fi
   fi

--- a/scripts/primus_megatron-lm/run.sh
+++ b/scripts/primus_megatron-lm/run.sh
@@ -56,6 +56,8 @@ elif [[ "$MODEL_REPO" == "primus_pyt_megatron_lm_train_deepseek-v2" ]]; then
   model="DeepSeek-V2"
 elif [[ "$MODEL_REPO" == "primus_pyt_megatron_lm_train_deepseek-v3-proxy" ]]; then
   model="DeepSeek-V3-proxy"
+elif [[ "$MODEL_REPO" == "primus_pyt_megatron_lm_train_kimi-k2-thinking" ]]; then
+  model="Kimi-K2-Thinking"
 elif [[ "$MODEL_REPO" == "primus_pyt_megatron_lm_train_mixtral-8x7b" ]]; then
   model="Mixtral-8x7B"
 elif [[ "$MODEL_REPO" == "primus_pyt_megatron_lm_train_mixtral-8x22b-proxy" ]]; then

--- a/scripts/sglang_disagg/README.MD
+++ b/scripts/sglang_disagg/README.MD
@@ -10,6 +10,7 @@ MoE Models
 - DeepSeek-V3 (https://huggingface.co/deepseek-ai/DeepSeek-V3)
 - DeepSeek-R1 (https://huggingface.co/deepseek-ai/DeepSeek-R1)
 - Mixtral-8x7B-v0.1 (https://huggingface.co/mistralai/Mixtral-8x7B-v0.1)
+- Kimi-K2-Instruct (https://huggingface.co/moonshotai/Kimi-K2-Instruct-0905) — 1T MLA + MoE, native FP8
 
 This repository contains scripts and documentation to launch PD Disaggregation for above models. You will find setup instructions, node assignment details and benchmarking commands.
 
@@ -79,7 +80,8 @@ above:
 
 Model + transport come from deployment `env_vars` (or `args`): `MODEL_NAME` (short key
 in `models.yaml`), `MODEL_PATH` (mounted weights), `RUN_MORI` (1=MoRI EP default,
-0=Mooncake/NIXL), `DP_MODE` (1=DP-attention EP for DeepSeek-V3/R1 inter-node).
+0=Mooncake/NIXL), `DP_MODE` (1=DP-attention EP for DeepSeek-V3/R1 and
+Kimi-K2-Instruct inter-node).
 
 Deploy with an additional-context config carrying `slurm` + `distributed.launcher:
 "sglang-disagg"` (+ `distributed.sglang_disagg.{prefill_nodes,decode_nodes}` for a
@@ -151,10 +153,10 @@ The unified launcher (`sglang_disagg_mori_io_ep.sh`) selects the disaggregation 
 | `DP_MODE` | `PARALLEL_MODE` | Flags applied | Supported models |
 |-----------|-----------------|---------------|------------------|
 | `0` (default) | `tp` | `base_flags` + `tp_flags` + `prefill.tp` / `decode.tp` | All models |
-| `1` | `dp` | `base_flags` + `dp_flags` (`--moe-a2a-backend mori`, DP attention) + `prefill.dp` / `decode.dp` | DeepSeek-V3, DeepSeek-R1 only |
+| `1` | `dp` | `base_flags` + `dp_flags` (`--moe-a2a-backend mori`, DP attention) + `prefill.dp` / `decode.dp` | DeepSeek-V3, DeepSeek-R1, Kimi-K2-Instruct only |
 
 - `DP_MODE=1` enables MoRI expert parallelism (EP) with DP attention and currently requires `RUN_MORI=1` (MoRI IO).
-- It is restricted by an allowlist (`MORI_DP_MODE1_ALLOWED_MODELS`) enforced in both `run_xPyD_models.slurm` and `sglang_disagg_mori_io_ep.sh`. Launching any other model with `DP_MODE=1` exits with an error — use `DP_MODE=0` (TP) for all non-DeepSeek models.
+- It is restricted by an allowlist (`MORI_DP_MODE1_ALLOWED_MODELS`) enforced in both `run_xPyD_models.slurm` and `sglang_disagg_mori_io_ep.sh`. Launching any model outside that allowlist with `DP_MODE=1` exits with an error — use `DP_MODE=0` (TP) for everything else.
 
 ## Log Files
 

--- a/scripts/sglang_disagg/models.json
+++ b/scripts/sglang_disagg/models.json
@@ -554,5 +554,28 @@
         ],
         "timeout": 14400,
         "args": ""
+    },
+    {
+        "name": "sglang-disagg-kimi-k2-instruct-overlay",
+        "url": "",
+        "dockerfile": "../../docker/sglang_disagg_inference_full_overlay",
+        "scripts": "run.sh",
+        "n_gpus": "-1",
+        "owner": "mad.support@amd.com",
+        "training_precision": "",
+        "multiple_results": "perf_sglang-disagg-Kimi-K2-Instruct.csv",
+        "tags": [
+            "pyt",
+            "sglang",
+            "inference",
+            "disaggregated",
+            "kimi-k2",
+            "moe",
+            "ep-internode",
+            "rccl-tp",
+            "mori-a2a"
+        ],
+        "timeout": 14400,
+        "args": ""
     }
 ]

--- a/scripts/sglang_disagg/models.yaml
+++ b/scripts/sglang_disagg/models.yaml
@@ -80,6 +80,24 @@ DeepSeek-R1:
     tp: "--disable-radix-cache --cuda-graph-bs $(seq 1 512)"
     dp: "--max-running-requests 8192 --cuda-graph-bs 1 2 4 8 16 24 32 48 64 96 128"
 
+# Kimi K2 Instruct (0905): 1T MLA + MoE, native FP8 (block-fp8, non-thinking).
+# FP8 uses the mature Fp8MoEMethod runner, which has the DeepEP-style pre-permute
+# registered, so this runs the full MoRI expert all-to-all plus CUDA graphs -- the
+# same proven path as DeepSeek-R1. The only Kimi-specific server flag is
+# --tool-call-parser kimi_k2 (no reasoning parser: Instruct is reflex-grade).
+# --dist-timeout 3600 absorbs NFS weight-load skew across nodes at this size.
+# SGLANG_ROCM_FUSED_DECODE_MLA=0, set by the launcher for any Kimi-K2 model,
+# still applies: 64 attention heads are outside the fused decode-MLA range.
+Kimi-K2-Instruct:
+  base_flags: "--attention-backend aiter --watchdog-timeout 1000000 --mem-fraction-static 0.73 --dist-timeout 3600 --tool-call-parser kimi_k2 --disable-shared-experts-fusion"
+  dp_flags: "--moe-a2a-backend mori --enable-dp-attention --enable-dp-lm-head --moe-dense-tp-size 1 --enable-dp-attention-local-control-broadcast"
+  prefill:
+    tp: "--disable-cuda-graph"
+    dp: "--max-running-requests 8192 --cuda-graph-bs $(seq 1 3)"
+  decode:
+    tp: "--disable-radix-cache --cuda-graph-bs $(seq 1 512)"
+    dp: "--max-running-requests 8192 --cuda-graph-bs 1 2 4 8 16 24 32 48 64 96 128"
+
 # GPT-OSS-120B is small enough (~117B total / ~5.1B active) that a single
 # 8-GPU node holds the full model at TP=8; no cross-node EP/MoRI needed (same
 # as pyt_vllm_disagg_nixl_gpt-oss-120b in models.json, which also runs RUN_MORI=0).

--- a/scripts/sglang_disagg/models.yaml
+++ b/scripts/sglang_disagg/models.yaml
@@ -86,8 +86,12 @@ DeepSeek-R1:
 # same proven path as DeepSeek-R1. The only Kimi-specific server flag is
 # --tool-call-parser kimi_k2 (no reasoning parser: Instruct is reflex-grade).
 # --dist-timeout 3600 absorbs NFS weight-load skew across nodes at this size.
-# SGLANG_ROCM_FUSED_DECODE_MLA=0, set by the launcher for any Kimi-K2 model,
-# still applies: 64 attention heads are outside the fused decode-MLA range.
+# SGLANG_ROCM_FUSED_DECODE_MLA=0, forced by the launcher for any Kimi-K2 model,
+# still applies -- it matches upstream's own default and its Kimi-K2 ROCm CI
+# recipes. Note --attention-backend aiter above is what arms that flag at all:
+# the fused path is only reached when the flag is on AND the backend is aiter
+# (srt/models/deepseek_common/attention_backend_handler.py:_dispatch_mla_subtype).
+# There is no head-count guard there, so the flag is the only thing deciding it.
 Kimi-K2-Instruct:
   base_flags: "--attention-backend aiter --watchdog-timeout 1000000 --mem-fraction-static 0.73 --dist-timeout 3600 --tool-call-parser kimi_k2 --disable-shared-experts-fusion"
   dp_flags: "--moe-a2a-backend mori --enable-dp-attention --enable-dp-lm-head --moe-dense-tp-size 1 --enable-dp-attention-local-control-broadcast"

--- a/scripts/sglang_disagg/run.sh
+++ b/scripts/sglang_disagg/run.sh
@@ -191,6 +191,7 @@ if ! _weights_complete; then
             Llama-3.1-70B-Instruct) _MODEL_REPO="meta-llama/Llama-3.1-70B-Instruct" ;;
             Qwen3-Next-80B) _MODEL_REPO="Qwen/Qwen3-Next-80B-A3B-Instruct" ;;
             GPT-OSS-120B)   _MODEL_REPO="openai/gpt-oss-120b" ;;
+            Kimi-K2-Instruct) _MODEL_REPO="moonshotai/Kimi-K2-Instruct-0905" ;;
             *) echo "ERROR: weights missing at ${MODEL_PATH}; set MODEL_REPO for ${MODEL_NAME}" >&2; exit 1 ;;
         esac
     fi

--- a/scripts/sglang_disagg/run_xPyD_models.slurm
+++ b/scripts/sglang_disagg/run_xPyD_models.slurm
@@ -146,6 +146,15 @@ validate_model_name() {
 
 validate_model_name "${MODEL_NAME}"
 
+# DP_MODE=1 is only wired up for the MoRI DP-attention + EP path
+# (sglang_disagg_mori_io_ep.sh gates on this same allowlist); reject it here
+# too, before any node is launched, instead of failing later per-node.
+if [[ "$DP_MODE" == "1" ]] && ! mori_model_allows_dp_mode_one "$MODEL_NAME"; then
+    echo "Error: DP_MODE=1 is not supported for model '${MODEL_NAME}'. Allowed models:" >&2
+    mori_dp_mode1_allowed_models_lines >&2
+    exit 1
+fi
+
 # ------------------------
 # Model path validation and selection across all nodes
 # ------------------------

--- a/scripts/sglang_disagg/run_xPyD_models.slurm
+++ b/scripts/sglang_disagg/run_xPyD_models.slurm
@@ -30,6 +30,7 @@ echo ""
 MORI_DP_MODE1_ALLOWED_MODELS=(
     "DeepSeek-V3"
     "DeepSeek-R1"
+    "Kimi-K2-Instruct"
 )
 
 mori_model_allows_dp_mode_one() {
@@ -58,6 +59,7 @@ MORI_EP_VALID_MODELS=( \
     "DeepSeek-V3" \
     "DeepSeek-R1" \
     "GPT-OSS-120B" \
+    "Kimi-K2-Instruct" \
 )
 
 # Define valid model names
@@ -70,6 +72,7 @@ VALID_MODELS=( \
     "DeepSeek-V3" \
     "DeepSeek-R1" \
     "GPT-OSS-120B" \
+    "Kimi-K2-Instruct" \
 )
 
 model_allows_mori_ep() {

--- a/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
+++ b/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
@@ -375,16 +375,26 @@ setup_sglang_worker_env() {
     export GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-${IFNAME:-eth0}}"
     export NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-${IFNAME:-eth0}}"
     export SGLANG_USE_AITER="${SGLANG_USE_AITER:-1}"
-    # Kimi-K2 (64 attn heads) MLA: the fused decode-MLA path rejects head counts
-    # outside {16,128}; disable it ONLY for Kimi-K2 so the runtime picks a supported
-    # MLA backend (avoids the ROCm "ForwardMetadata" unpack crash on Kimi K2 /
-    # K2-Thinking). Other MLA models (e.g. DeepSeek) keep the fused path. An explicit
-    # SGLANG_ROCM_FUSED_DECODE_MLA in the environment always wins.
-    if [[ -z "${SGLANG_ROCM_FUSED_DECODE_MLA:-}" ]]; then
-        case "${MODEL_NAME:-}" in
-            *Kimi-K2*|*kimi-k2*) export SGLANG_ROCM_FUSED_DECODE_MLA=0 ;;
-        esac
-    fi
+    # Kimi-K2 MLA: keep the non-fused decode path. This matches upstream, which
+    # defaults the flag off (srt/environ.py: SGLANG_ROCM_FUSED_DECODE_MLA =
+    # EnvBool(False)) and sets it to 0 explicitly in its own Kimi-K2 ROCm CI
+    # recipes (scripts/ci/slurm/recipes/mi355x-fp8/kimik26/**.yaml). Other MLA
+    # models (e.g. DeepSeek) keep whatever the image chose.
+    #
+    # This deliberately does NOT test "is the variable unset?". The rocm/sgl-dev
+    # images bake SGLANG_ROCM_FUSED_DECODE_MLA=1 into the image Config.Env, so on
+    # every sgl-dev base the variable is already non-empty and an unset-test never
+    # fires -- Kimi then silently ran the fused path, the opposite of the intent
+    # here (observed on a 4-node 2P2D gfx942 run: the live server process had
+    # =1). An image-level default is not an operator decision and does not get to
+    # win; set SGLANG_KEEP_FUSED_DECODE_MLA=1 to opt back in deliberately.
+    case "${MODEL_NAME:-}" in
+        *Kimi-K2*|*kimi-k2*)
+            if [[ "${SGLANG_KEEP_FUSED_DECODE_MLA:-0}" != "1" ]]; then
+                export SGLANG_ROCM_FUSED_DECODE_MLA=0
+            fi
+            ;;
+    esac
     export SGLANG_MORI_FP8_DISP="${SGLANG_MORI_FP8_DISP:-True}"
     export SGLANG_DISAGGREGATION_WAITING_TIMEOUT="${SGLANG_DISAGGREGATION_WAITING_TIMEOUT:-1200}"
 }

--- a/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
+++ b/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
@@ -12,6 +12,7 @@ SCRIPT_DIR="${_MORI_SCRIPT_DIR}"
 MORI_DP_MODE1_ALLOWED_MODELS=(
     "DeepSeek-V3"
     "DeepSeek-R1"
+    "Kimi-K2-Instruct"
 )
 
 mori_model_allows_dp_mode_one() {
@@ -374,6 +375,16 @@ setup_sglang_worker_env() {
     export GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-${IFNAME:-eth0}}"
     export NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-${IFNAME:-eth0}}"
     export SGLANG_USE_AITER="${SGLANG_USE_AITER:-1}"
+    # Kimi-K2 (64 attn heads) MLA: the fused decode-MLA path rejects head counts
+    # outside {16,128}; disable it ONLY for Kimi-K2 so the runtime picks a supported
+    # MLA backend (avoids the ROCm "ForwardMetadata" unpack crash on Kimi K2 /
+    # K2-Thinking). Other MLA models (e.g. DeepSeek) keep the fused path. An explicit
+    # SGLANG_ROCM_FUSED_DECODE_MLA in the environment always wins.
+    if [[ -z "${SGLANG_ROCM_FUSED_DECODE_MLA:-}" ]]; then
+        case "${MODEL_NAME:-}" in
+            *Kimi-K2*|*kimi-k2*) export SGLANG_ROCM_FUSED_DECODE_MLA=0 ;;
+        esac
+    fi
     export SGLANG_MORI_FP8_DISP="${SGLANG_MORI_FP8_DISP:-True}"
     export SGLANG_DISAGGREGATION_WAITING_TIMEOUT="${SGLANG_DISAGGREGATION_WAITING_TIMEOUT:-1200}"
 }

--- a/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
+++ b/scripts/sglang_disagg/sglang_disagg_mori_io_ep.sh
@@ -527,7 +527,18 @@ if [[ "$NODE_RANK" -eq 0 ]]; then
     # DP_MODE=1: wait for master prefill NODE 0 + master decode NODE xP only.
     # Requires shared /run_logs across nodes.
     SEARCH_SIGNAL="${SEARCH_SIGNAL:-The server is fired up and ready to roll!}"
-    ROUTER_READY_TIMEOUT_SECONDS="${ROUTER_READY_TIMEOUT_SECONDS:-4000}"
+    # Time-to-first-ready scales with checkpoint size, so the default is per model
+    # rather than one number for every card. 4000s is fine for the ~600 GB class
+    # (DeepSeek-R1 reached ready in well under half of it), but Kimi-K2 is ~1 TB of
+    # FP8 weights: a 4-node run measured 15m15s of weight load on an idle NFS and
+    # 24m48s on a busy one, and the slow case blew past 4000s at 4003s -- run.sh
+    # then tore down healthy servers that were still initialising. Give the 1 TB
+    # class 3h; an explicit ROUTER_READY_TIMEOUT_SECONDS still overrides both.
+    _router_ready_default=4000
+    case "${MODEL_NAME:-}" in
+        *Kimi-K2*|*kimi-k2*) _router_ready_default=10800 ;;
+    esac
+    ROUTER_READY_TIMEOUT_SECONDS="${ROUTER_READY_TIMEOUT_SECONDS:-$_router_ready_default}"
     ROUTER_POLL_SLEEP_SECONDS="${ROUTER_POLL_SLEEP_SECONDS:-10}"
     _wait_start_ts=$(date +%s)
     _runlog="/run_logs/${SLURM_JOB_ID:-0}"

--- a/scripts/sglang_disagg/socket_barrier.py
+++ b/scripts/sglang_disagg/socket_barrier.py
@@ -5,6 +5,35 @@ import sys
 import threading
 import time
 
+DEFAULT_TIMEOUT_SECONDS = 3600
+
+
+def _default_timeout():
+    """Read BARRIER_TIMEOUT_SECONDS, rejecting garbage with a readable message.
+
+    This runs on every node of every run, so a typo here would otherwise surface as
+    a bare ValueError traceback on all of them at import time, before argparse can
+    say anything useful. Unset or empty means "not configured" and falls back to the
+    default; anything else set but unparseable is an operator mistake and is
+    reported rather than silently replaced -- quietly substituting a different
+    timeout than the one asked for is how you get a run that behaves nothing like
+    its configuration.
+    """
+    raw = os.environ.get("BARRIER_TIMEOUT_SECONDS", "").strip()
+    if not raw:
+        return DEFAULT_TIMEOUT_SECONDS
+    try:
+        return int(raw)
+    except ValueError:
+        print(
+            f"ERROR: BARRIER_TIMEOUT_SECONDS must be an integer number of seconds "
+            f"(0 = wait forever), got {raw!r}.",
+            file=sys.stderr,
+            flush=True,
+        )
+        sys.exit(2)
+
+
 # Parse command-line arguments
 parser = argparse.ArgumentParser(description="Optionally open and close a port on the local node.")
 parser.add_argument("--local-ip", required=False, help="Local IP address to bind the server.")
@@ -15,9 +44,9 @@ parser.add_argument("--node-ports", required=True, help="Comma-separated list of
 parser.add_argument(
     "--timeout",
     type=int,
-    default=int(os.environ.get("BARRIER_TIMEOUT_SECONDS", 3600)),
-    help="Give up after this many seconds (0 = wait forever). Default 3600, "
-    "override with BARRIER_TIMEOUT_SECONDS.",
+    default=_default_timeout(),
+    help=f"Give up after this many seconds (0 = wait forever). Default "
+    f"{DEFAULT_TIMEOUT_SECONDS}, override with BARRIER_TIMEOUT_SECONDS.",
 )
 args = parser.parse_args()
 

--- a/scripts/sglang_disagg/socket_barrier.py
+++ b/scripts/sglang_disagg/socket_barrier.py
@@ -1,7 +1,9 @@
-import socket
-import time
-import threading
 import argparse
+import os
+import socket
+import sys
+import threading
+import time
 
 # Parse command-line arguments
 parser = argparse.ArgumentParser(description="Optionally open and close a port on the local node.")
@@ -10,6 +12,13 @@ parser.add_argument("--local-port", type=int, required=False, help="Port number 
 parser.add_argument("--enable-port", action="store_true", help="Enable opening and closing of local port.")
 parser.add_argument("--node-ips", required=True, help="Comma-separated list of node IPs.")
 parser.add_argument("--node-ports", required=True, help="Comma-separated list of ports to check.")
+parser.add_argument(
+    "--timeout",
+    type=int,
+    default=int(os.environ.get("BARRIER_TIMEOUT_SECONDS", 3600)),
+    help="Give up after this many seconds (0 = wait forever). Default 3600, "
+    "override with BARRIER_TIMEOUT_SECONDS.",
+)
 args = parser.parse_args()
 
 # Parse node IPs and ports from command-line arguments
@@ -32,12 +41,34 @@ def is_port_open(ip, port):
         return s.connect_ex((ip, port)) == 0
 
 def wait_for_all_ports():
-    """Wait until all nodes have opened the specified ports."""
+    """Wait until all nodes have opened the specified ports.
+
+    Bounded, because an unbounded wait turns one node's failure into a whole
+    allocation held until the SLURM wall clock. Observed on a 4-node run: rank 0's
+    readiness wait timed out and tore its servers down, and every other rank sat
+    here printing "Waiting for nodes. . ." for the remaining two hours because
+    nothing told it the peer was gone. Failing here instead lets SLURM reclaim the
+    nodes. Pass --timeout 0 (or BARRIER_TIMEOUT_SECONDS=0) for the old behaviour.
+    """
+    deadline = None if args.timeout <= 0 else time.monotonic() + args.timeout
     while True:
-        all_open = all(is_port_open(ip, port) for ip, port in zip(NODE_IPS, NODE_PORTS))
-        if all_open:
-            break
-        print("Waiting for nodes. . .", flush=True)
+        missing = [
+            f"{ip}:{port}"
+            for ip, port in zip(NODE_IPS, NODE_PORTS)
+            if not is_port_open(ip, port)
+        ]
+        if not missing:
+            return
+        if deadline is not None and time.monotonic() >= deadline:
+            print(
+                f"ERROR: barrier timed out after {args.timeout}s; "
+                f"{len(missing)}/{len(NODE_IPS)} peer(s) never opened their port: "
+                + ", ".join(missing),
+                file=sys.stderr,
+                flush=True,
+            )
+            sys.exit(1)
+        print(f"Waiting for nodes. . . ({len(missing)} not ready)", flush=True)
         time.sleep(5)
 
 def open_port():


### PR DESCRIPTION
Port Kimi-K2 onto current `mad-rccl`.

**Kimi-K2-Thinking training** (`primus_pyt_megatron_lm_train_kimi-k2-thinking_overlay`): 1T-total / 27B-active MLA + MoE, 61 layers, 384 experts. This is a mock-data throughput benchmark (`train_iters: 50`, no checkpoint), stated in the YAML header and `gotchas.md`. Its two Kimi-specific YAMLs and the torchrun rendezvous-timeout bump (600s -> 7200s, needed because MIOpen compiling 384 experts on iteration 1 outlasts 600s) are folded into the existing generic overlay Dockerfile rather than adding a near-duplicate.

Runs at **24 nodes / 192 GPUs with EP=192, MBS=1 and full recompute**, plus `PYTORCH_HIP_ALLOC_CONF=expandable_segments:True`. At 1T params it does not fit in less — those are requirements, not tuning.

**Kimi-K2-Instruct inference** (`sglang-disagg-kimi-k2-instruct-overlay`): FP8, MoRI expert all-to-all (same path as DeepSeek-R1, joins its `DP_MODE=1` allow-list). Kimi-specific: `--tool-call-parser kimi_k2`, `--dist-timeout 3600`, and two launcher-side defaults keyed on `*Kimi-K2*` — `SGLANG_ROCM_FUSED_DECODE_MLA=0` and `ROUTER_READY_TIMEOUT_SECONDS=10800`. Ships with its own manifest template (`assets/manifests/sglang_disagg_kimi-k2-instruct.template.json`).

Legacy `docker/sglang_disagg_inference` base bump from `04d9f07` not carried over — the `-overlay` scheme is already on a newer base, and skipping it keeps six existing cards off an untested base.

> **Depends on #225.** Building this branch for gfx942 exercises the MXFP4 stage of `sglang_disagg_inference_full_overlay`, which hard-fails against its own pinned base without #225. With #225 the stage takes its new branch (`MXFP4_PATCH_SKIPPED: mxfp_supported() is not present in this base image`) and the build completes — confirmed rc=0 on 4/4 nodes, ~6 min.

## Validation

**Training — passed.** 24 nodes / 192 GPUs, gfx950: full 61 layers, all 50 iterations, `torchrun` exit 0, ~236 tok/s/GPU. The perf CSV comes out header-only even on a healthy run, so that number is read off the iteration timestamps; the same pipeline produces numbers for Llama-4-Scout, so an empty CSV here is that bug, not a failed run. Root cause is still open — but it is **not** the logging cadence: Primus already defaults `log_interval: 1` and `log_throughput: true` in `primus/configs/modules/megatron/pre_trainer.yaml` (unchanged across the file's entire four-commit history), so the experiment YAML's `log_interval: 1` only restates a default, and the 24-node run above was measured with it in place.

**Inference — passed.** 4 nodes / 32 GPUs, gfx942 (MI300X) + Mellanox CX7, xP=2 yD=2, `RUN_MORI=1 DP_MODE=1 KV_TRANSFER_BACKEND=mori`, TP=DP=EP=16, real `Kimi-K2-Instruct-0905` FP8 weights. Job `COMPLETED 0:0` in 1 h 40 m.

| | |
|---|---|
| `no transport available for peer` | 0 |
| both prefill servers: weight load + DP/EP/TP init | ✅ both reached `fired up and ready` |
| benchmark sweep | ✅ 8/8 points, real completions (`curl` smoke returns coherent text) |
| perf CSV | 56/56 rows `SUCCESS` |

| ISL/OSL | con 8 | con 16 | con 32 | con 64 |
|---|---|---|---|---|
| 1024/1024 — total tok/s | 280.5 | 547.2 | 1033.6 | 1936.2 |
| 8192/1024 — total tok/s | 1006.9 | 1938.9 | 3450.5 | 6446.5 |

Streaming, so TTFT/ITL are real (2.4–9.4 s TTFT, 54–72 ms ITL). Every flag in the card landed and resolved as documented: `attention_backend=aiter`, `moe_a2a_backend=mori`, `disaggregation_transfer_backend=mori`, DP-attention, `Fp8MoEMethod`, CUDA graphs on decode (`backend=full, max_bs=128`). `--mem-fraction-static 0.73` resolving to `0.6205` is sglang's own ×0.85 scaling in disaggregated mode, not a mismatch.

### Scope

This covers **gfx942 / Mellanox CX7 only**. It does **not** clear the gfx950 / Broadcom Thor2 `bnxt_re` path, which is this Dockerfile's default base — the MoRI-on-`bnxt_re` transport failure documented in `manifests.md` cannot reproduce on Mellanox, because rdma-core 63.0 ships its own mlx5 provider and there is no vendor-library ABI conflict to hit. That path remains open.

### Two defects the validation surfaced, both fixed here

**The Kimi MLA guard never fired.** `sglang_disagg_mori_io_ep.sh` set `SGLANG_ROCM_FUSED_DECODE_MLA=0` only when the variable was unset — but the `rocm/sgl-dev` images bake `SGLANG_ROCM_FUSED_DECODE_MLA=1` into the image `Config.Env`, so on every sgl-dev base the unset-test never fires and Kimi silently served on the **fused** decode-MLA path, the opposite of what `models.yaml` documented. The launcher now forces `0`, with `SGLANG_KEEP_FUSED_DECODE_MLA=1` as the deliberate opt-in; DeepSeek is untouched.

Two things that turned out differently from the original rationale, now corrected in the comments:
- The claim that Kimi's 64 attention heads fall outside the fused decode-MLA range and crash unpacking `ForwardMetadata` does **not** hold on sglang v0.5.16. `_dispatch_mla_subtype` gates only on `(rocm_fused_decode_mla AND is_decode() AND attention_backend == "aiter")` — no head-count guard — and a full 8-point sweep on 64 heads ran clean with the flag on.
- Keeping `0` is still correct, for a different reason: upstream defaults the flag off (`srt/environ.py`: `EnvBool(False)`) and sets it to `0` explicitly in its own Kimi-K2 ROCm CI recipes.
- A/B across all 8 sweep points, fused vs non-fused: −3.3% to +2.4% total tok/s, most under 1%. So this is a *ships-one-config-runs-another* fix, not a performance one.

**Startup timed out on a 1 TB checkpoint, and one node's failure held the whole allocation.** A run died on `ERROR: Timeout (4003s >= 4000s) waiting for master prefill` — nothing wrong with it, the weight load just took 24m48s on a busy NFS instead of 15m15s, overrunning `ROUTER_READY_TIMEOUT_SECONDS`. That default is now per model: `10800` for `*Kimi-K2*`, `4000` unchanged everywhere else, explicit override still wins.

The same incident exposed a second problem: `socket_barrier.py` waited in an unbounded `while True`, so when rank 0 tore its servers down every other rank kept printing `Waiting for nodes. . .` until the SLURM wall clock — four exclusive nodes held for two hours after the run was already dead. The barrier is now bounded (`BARRIER_TIMEOUT_SECONDS`, default 3600s), names the peers that never opened their port, and exits 1 so SLURM can reclaim the nodes; `--timeout 0` restores the old behaviour.

### Review follow-ups

Both Copilot threads are answered and fixed. Briefly: the `log_interval: 1` complaint pointed at a real inconsistency but resolved the other way round — the doc was right and the YAML comment was the false claim (see the Training note above). The BF16-guard complaint was accurate; the Kimi-specific part was worse than reported, since `MXFP8`/`MXFP4`/`FP4` and an unrecognized `DEVICE` matched no branch at all and fell through with no diagnostic, and `$EXP` can never resolve for a non-BF16 datatype because the overlay injects only the BF16 YAML.
