### PR TITLE
JAX/MaxText multi-node RCCL overlay

### DIFF
--- a/.claude/skills/mad-slurm-multinode/assets/manifests/primus_maxtext_llama3-8b.template.json
+++ b/.claude/skills/mad-slurm-multinode/assets/manifests/primus_maxtext_llama3-8b.template.json
@@ -49,7 +49,8 @@
       "IBV_DRIVERS": "<FILL_DRIVER  see references/cluster-types.md>",
       "RCCL_AINIC_ROCE": "<FILL_RCCL_AINIC_ROCE  per archetype, see references/cluster-types.md; delete this key if not needed>",
       "NCCL_NET_PLUGIN": "none",
-      "IBV_SHOW_WARNINGS": "1"
+      "IBV_SHOW_WARNINGS": "1",
+      "XLA_GPU_AUTOTUNE_LEVEL": "0"
     },
     "docker_mounts": {
       "/dev/infiniband": "/dev/infiniband"
@@ -116,7 +117,8 @@
       "RCCL_AINIC_ROCE": "<FILL_RCCL_AINIC_ROCE  per archetype, see references/cluster-types.md; delete this key if not needed>",
       "NCCL_NET_PLUGIN": "none",
       "NCCL_TIMEOUT": "900",
-      "OMP_NUM_THREADS": "8"
+      "OMP_NUM_THREADS": "8",
+      "XLA_GPU_AUTOTUNE_LEVEL": "0"
     },
     "debug": false,
     "docker_gpus": "0,1,2,3,4,5,6,7"

--- a/.claude/skills/mad-slurm-multinode/assets/manifests/primus_maxtext_llama3-8b.template.json
+++ b/.claude/skills/mad-slurm-multinode/assets/manifests/primus_maxtext_llama3-8b.template.json
@@ -1,0 +1,110 @@
+{
+  "built_images": {
+    "rocm-primus-maxtext-llama3-8b-overlay": {
+      "model": "jax-maxtext/maxtext_MI355X_llama3_8B-fp8-pretrain",
+      "docker_image": "rocm/jax-training:maxtext-v26.6-<FILL_RCCL_TAG e.g. rccl-7.2.1 or rccl-develop-<sha7>>",
+      "dockerfile": "docker/primus_maxtext_rccl_overlay.ubuntu.amd.Dockerfile",
+      "base_docker": "rocm/jax-training:maxtext-v26.6",
+      "build_duration": 0,
+      "local_image": true,
+      "registry_image": null,
+      "registry": null,
+      "gpu_vendor": "AMD"
+    }
+  },
+  "built_models": {
+    "rocm-primus-maxtext-llama3-8b-overlay": {
+      "name": "jax-maxtext/maxtext_MI355X_llama3_8B-fp8-pretrain",
+      "url": "",
+      "dockerfile": "docker/primus_maxtext_rccl_overlay.ubuntu.amd.Dockerfile",
+      "scripts": "scripts/jax-maxtext/run.sh",
+      "n_gpus": "-1",
+      "owner": "mad.support@amd.com",
+      "training_precision": "fp8",
+      "multiple_results": "primus_perf_output.csv",
+      "tags": ["maxtext", "jax", "MI355X", "llama3_8B-fp8-pretrain", "fp8", "training"],
+      "timeout": -1,
+      "args": "--config_path examples/maxtext/configs/MI355X/llama3_8B-fp8-pretrain.yaml",
+      "additional_docker_run_options": "--privileged --group-add render --shm-size 64G --device=/dev/infiniband --cap-add IPC_LOCK --ulimit memlock=-1 --ulimit nofile=1048576 -v /sys:/sys:ro -v /run/udev:/run/udev:ro"
+    }
+  },
+  "context": {
+    "docker_env_vars": {
+      "NCCL_DEBUG": "INFO",
+      "NCCL_DEBUG_SUBSYS": "INIT,NET",
+      "NCCL_IB_DISABLE": "0",
+      "NCCL_NET": "IB",
+      "NCCL_IB_HCA": "<FILL_NCCL_IB_HCA  data-plane HCA list, see references/cluster-types.md>",
+      "NCCL_IB_GID_INDEX": "<FILL_GID  RoCEv2 GID index, see references/cluster-types.md>",
+      "NCCL_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "GLOO_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "RDMAV_DRIVERS": "<FILL_DRIVER  see references/cluster-types.md>",
+      "IBV_DRIVERS": "<FILL_DRIVER  see references/cluster-types.md>",
+      "RCCL_AINIC_ROCE": "<FILL_RCCL_AINIC_ROCE  per archetype, see references/cluster-types.md; delete this key if not needed>",
+      "NCCL_NET_PLUGIN": "none",
+      "IBV_SHOW_WARNINGS": "1"
+    },
+    "docker_mounts": {
+      "/dev/infiniband": "/dev/infiniband"
+    },
+    "docker_build_arg": {},
+    "gpu_vendor": "AMD",
+    "guest_os": "UBUNTU",
+    "docker_gpus": "0,1,2,3,4,5,6,7"
+  },
+  "credentials_required": [],
+  "summary": {
+    "successful_builds": [],
+    "failed_builds": [],
+    "total_build_time": 0,
+    "successful_pushes": [],
+    "failed_pushes": []
+  },
+  "deployment_config": {
+    "target": "slurm",
+    "slurm": {
+      "partition": "<FILL_PARTITION>",
+      "account": "<FILL_ACCOUNT or remove if cluster has none>",
+      "qos": "<FILL_QOS>",
+      "nodes": 2,
+      "gpus_per_node": 8,
+      "time": "12:00:00",
+      "output_dir": "./slurm_output",
+      "exclusive": true,
+      "network_interface": "<FILL_IFNAME  management iface, see references/cluster-types.md>"
+    },
+    "distributed": {
+      "launcher": "primus",
+      "backend": "nccl",
+      "port": 29500,
+      "nnodes": 2,
+      "nproc_per_node": 8,
+      "primus": {
+        "config_path": "examples/maxtext/configs/MI355X/llama3_8B-fp8-pretrain.yaml",
+        "backend": "MaxText"
+      }
+    },
+    "env_vars": {
+      "HF_HOME": "${HF_HOME}",
+      "XDG_CACHE_HOME": "${XDG_CACHE_HOME}",
+      "PIP_CACHE_DIR": "${PIP_CACHE_DIR}",
+      "MAD_DATAHOME": "${MAD_DATAHOME}",
+      "NCCL_DEBUG": "INFO",
+      "NCCL_DEBUG_SUBSYS": "INIT,NET",
+      "NCCL_IB_DISABLE": "0",
+      "NCCL_NET": "IB",
+      "NCCL_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "GLOO_SOCKET_IFNAME": "<FILL_IFNAME  management iface, see references/cluster-types.md>",
+      "NCCL_IB_GID_INDEX": "<FILL_GID  RoCEv2 GID index, see references/cluster-types.md>",
+      "NCCL_IB_HCA": "<FILL_NCCL_IB_HCA  same value as context.docker_env_vars>",
+      "RDMAV_DRIVERS": "<FILL_DRIVER  see references/cluster-types.md>",
+      "IBV_DRIVERS": "<FILL_DRIVER  see references/cluster-types.md>",
+      "RCCL_AINIC_ROCE": "<FILL_RCCL_AINIC_ROCE  per archetype, see references/cluster-types.md; delete this key if not needed>",
+      "NCCL_NET_PLUGIN": "none",
+      "NCCL_TIMEOUT": "900",
+      "OMP_NUM_THREADS": "8"
+    },
+    "debug": false,
+    "docker_gpus": "0,1,2,3,4,5,6,7"
+  }
+}

--- a/.claude/skills/mad-slurm-multinode/assets/manifests/primus_maxtext_llama3.1-405b.template.json
+++ b/.claude/skills/mad-slurm-multinode/assets/manifests/primus_maxtext_llama3.1-405b.template.json
@@ -1,7 +1,7 @@
 {
   "built_images": {
-    "rocm-primus-maxtext-llama3-8b-overlay": {
-      "model": "jax-maxtext/maxtext_MI355X_llama3_8B-fp8-pretrain",
+    "rocm-primus-maxtext-llama3.1-405b-overlay": {
+      "model": "jax-maxtext/maxtext_MI355X_llama3.1_405B-fp8-pretrain",
       "docker_image": "rocm/jax-training:maxtext-v26.6-<FILL_RCCL_TAG e.g. rccl-7.2.1 or rccl-develop-<sha7>>",
       "dockerfile": "docker/primus_maxtext_rccl_overlay.ubuntu.amd.Dockerfile",
       "base_docker": "rocm/jax-training:maxtext-v26.6",
@@ -13,8 +13,8 @@
     }
   },
   "built_models": {
-    "rocm-primus-maxtext-llama3-8b-overlay": {
-      "name": "jax-maxtext/maxtext_MI355X_llama3_8B-fp8-pretrain",
+    "rocm-primus-maxtext-llama3.1-405b-overlay": {
+      "name": "jax-maxtext/maxtext_MI355X_llama3.1_405B-fp8-pretrain",
       "url": "",
       "dockerfile": "docker/primus_maxtext_rccl_overlay.ubuntu.amd.Dockerfile",
       "scripts": "scripts/jax-maxtext/run.sh",
@@ -26,12 +26,12 @@
         "maxtext",
         "jax",
         "MI355X",
-        "llama3_8B-fp8-pretrain",
+        "llama3.1_405B-fp8-pretrain",
         "fp8",
         "training"
       ],
       "timeout": -1,
-      "args": "--config_path examples/maxtext/configs/MI355X/llama3_8B-fp8-pretrain.yaml",
+      "args": "--config_path examples/maxtext/configs/MI355X/llama3.1_405B-fp8-pretrain.yaml per_device_batch_size=1",
       "additional_docker_run_options": "--privileged --group-add render --shm-size 64G --device=/dev/infiniband --cap-add IPC_LOCK --ulimit memlock=-1 --ulimit nofile=1048576 -v /sys:/sys:ro -v /run/udev:/run/udev:ro"
     }
   },
@@ -80,7 +80,7 @@
       "partition": "<FILL_PARTITION>",
       "account": "<FILL_ACCOUNT or remove if cluster has none>",
       "qos": "<FILL_QOS>",
-      "nodes": 2,
+      "nodes": 4,
       "gpus_per_node": 8,
       "time": "12:00:00",
       "output_dir": "./slurm_output",
@@ -91,10 +91,10 @@
       "launcher": "primus",
       "backend": "nccl",
       "port": 29500,
-      "nnodes": 2,
+      "nnodes": 4,
       "nproc_per_node": 8,
       "primus": {
-        "config_path": "examples/maxtext/configs/MI355X/llama3_8B-fp8-pretrain.yaml",
+        "config_path": "examples/maxtext/configs/MI355X/llama3.1_405B-fp8-pretrain.yaml",
         "backend": "MaxText"
       }
     },

--- a/.claude/skills/mad-slurm-multinode/assets/manifests/primus_maxtext_llama3.1-405b.template.json
+++ b/.claude/skills/mad-slurm-multinode/assets/manifests/primus_maxtext_llama3.1-405b.template.json
@@ -49,7 +49,8 @@
       "IBV_DRIVERS": "<FILL_DRIVER  see references/cluster-types.md>",
       "RCCL_AINIC_ROCE": "<FILL_RCCL_AINIC_ROCE  per archetype, see references/cluster-types.md; delete this key if not needed>",
       "NCCL_NET_PLUGIN": "none",
-      "IBV_SHOW_WARNINGS": "1"
+      "IBV_SHOW_WARNINGS": "1",
+      "XLA_GPU_AUTOTUNE_LEVEL": "0"
     },
     "docker_mounts": {
       "/dev/infiniband": "/dev/infiniband"
@@ -116,7 +117,8 @@
       "RCCL_AINIC_ROCE": "<FILL_RCCL_AINIC_ROCE  per archetype, see references/cluster-types.md; delete this key if not needed>",
       "NCCL_NET_PLUGIN": "none",
       "NCCL_TIMEOUT": "900",
-      "OMP_NUM_THREADS": "8"
+      "OMP_NUM_THREADS": "8",
+      "XLA_GPU_AUTOTUNE_LEVEL": "0"
     },
     "debug": false,
     "docker_gpus": "0,1,2,3,4,5,6,7"

--- a/.claude/skills/mad-slurm-multinode/references/gotchas.md
+++ b/.claude/skills/mad-slurm-multinode/references/gotchas.md
@@ -10,7 +10,11 @@ slurm.nodes distributed.nnodes nodelist world size,
 heterogeneous nodes NCCL_SOCKET_IFNAME GLOO_SOCKET_IFNAME network_interface,
 routable interface eth0 eth1 IPv6 link-local fe80 gloo connect timeout subnet,
 madengine --timeout 0 None sbatch template, -o output csv ignored classic slurm,
-docker commit ENTRYPOINT cat exit 126, NFS root_squash docker mount permission denied
+docker commit ENTRYPOINT cat exit 126, NFS root_squash docker mount permission denied,
+jax maxtext JAX_COORDINATOR_IP NODE_RANK SLURM_PROCID loopback rendezvous hang,
+nofile fd limit Initialize clique silent stall 32 devices,
+built_models.env_vars not read docker_env_vars, RCCL overlay strings marker positive control,
+empty quantization override replaces yaml value, seconds_per_step first performance match
 
 Cross-cutting and per-workload pitfalls observed in real runs. SKILL.md links
 here; this file is read before a run.
@@ -103,6 +107,44 @@ here; this file is read before a run.
   `error while creating mount source path ...: mkdir ...: permission denied`,
   even though the user's own shell reads it fine. Stage run data under a path
   whose whole chain is world-traversable (`o+x`), not just group-readable.
+- **The SLURM path exports `NCCL_IB_DISABLE=1` by default — set it to 0 or the run uses
+  TCP.** It is one of the variables madengine injects into the generated sbatch itself
+  (alongside `MIOPEN_*`, `OMP_NUM_THREADS`, `NCCL_TIMEOUT`, `RCCL_ENABLE_HIPGRAPH`), so it is
+  absent from the manifest and easy to miss. Nothing fails: RCCL reports `via NET/Socket` and
+  the job simply runs several times slower — measured here at 0.936 s/step over RDMA versus
+  4.4-6.8 s/step over sockets for the same 8B workload on the same nodes, with TFLOP/s down
+  from 935 to 125. Put `NCCL_IB_DISABLE: "0"` in BOTH env blocks, and keep `NCCL_DEBUG=INFO`
+  with `NCCL_DEBUG_SUBSYS=INIT,NET` enabled so every run records its own transport instead of
+  needing a separate probe to find this out. Restricted to those subsystems the logging is at
+  connection setup rather than per collective, and costs nothing measurable: 0.906-0.909
+  s/step with it against 0.936 without. An A/B taken over
+  sockets is not just slow, it is insensitive: both arms sit on the same transport ceiling,
+  and a 405B comparison that shows +192 % over RDMA collapsed to +0.59 % over sockets.
+- **`built_models.*.env_vars` is not read on the docker/SLURM path.** Only
+  `context.docker_env_vars` becomes container environment; `deployment_config.env_vars`
+  configures the host-side launcher. The reference manifests here carry the transport
+  profile in BOTH, and `scripts/validate_manifest.sh` checks `NCCL_IB_HCA` is equal in the
+  two blocks for exactly this reason. A profile placed only under `built_models` is silently
+  absent at run time: the job trains, reports a number, and used RCCL defaults.
+- **Raise the open-file limit at 4+ nodes** via
+  `built_models.*.additional_docker_run_options` (`--ulimit nofile=1048576:1048576`). A
+  32-device clique exhausts the default; the symptom is not an fd error but a multi-hour
+  silent stall at the framework's clique/communicator init. 16 devices fit under the
+  default, 32 do not. The same option is where `--device=/dev/infiniband` belongs — the
+  hardcoded per-vendor docker options expose only `/dev/kfd` and `/dev/dri/renderD*`, and
+  without the RDMA device ibverbs finds nothing and the run falls back to TCP, which reads
+  as "slower" rather than "broken".
+- **A verification that cannot fail is worse than none.** Two instances seen here: a
+  `strings`-based marker census returns 0 both when the marker is absent and when the file
+  was never read (missing binary, over-eager filter) — always pair it with a positive
+  control string that must be present; and installing a source-built rdma-core *over* the
+  distro packages leaves both provider sets in place, so a presence check passes while
+  libibverbs can still resolve the old provider. Remove the packaged rdma-core before
+  `ninja install` (see `docker/sglang_disagg_inference_full_overlay.ubuntu.amd.Dockerfile`).
+- **`bash -n` does not parse heredoc bodies.** A syntax check on a script that generates a
+  per-node script proves nothing about the generated one. Extract the body between the
+  delimiters and check it separately — and assert the extraction is non-empty, since an
+  extraction yielding 0 lines "passes" trivially.
 - **Node environments can be heterogeneous across a cluster — don't trust a
   single detect probe.** The interface that carries the routable control-plane
   IP is not guaranteed to have the same name on every node (e.g. one node routes
@@ -118,6 +160,88 @@ here; this file is read before a run.
   rather than hard-coding an interface name. This is an environment
   (cluster-provisioning) inconsistency, not a workload bug — flag it to the
   cluster owner if a uniform-environment guarantee is expected.
+
+## jax_maxtext (training)
+
+Keywords: jax maxtext llama3 pretrain, JAX_COORDINATOR_IP JAX_COORDINATOR_PORT NNODES
+NODE_RANK, SLURM_PROCID rank derivation, loopback 127.0.0.1 rendezvous hang, RCCL overlay
+RCCL_COMMIT, base_output_directory device_info.json FileNotFoundError, empty quantization
+override, seconds_per_step median first performance match, XLA autotune level 32 ranks,
+gated Llama repo tokenizer synthetic dataset.
+
+- **The model script translates the launcher's variables, it does not source them.**
+  MaxText's `initialize_jax_for_gpu` reads `JAX_COORDINATOR_IP` / `JAX_COORDINATOR_PORT` /
+  `NNODES` / `NODE_RANK` from the environment and calls `jax.distributed.initialize` itself;
+  supplying those four is the model script's job. Note the gate: the whole block is skipped
+  unless `JAX_COORDINATOR_IP` is set, so a multi-node job that forgets it does not fail - it
+  runs single-process per node. On the standard SLURM path the inputs are already there:
+  madengine resolves `MASTER_ADDR` on the host, sets `NODE_RANK` from `SLURM_PROCID` inside
+  the srun task, and forwards both into the container. Reading `SLURM_PROCID` /
+  `SLURM_JOB_NODELIST` in the model script is a **fallback for direct invocation** — when a
+  coordinator looks wrong, check what the launcher forwarded before suspecting the fallback.
+  **Reject a loopback result**: JAX accepts `127.0.0.1` as a coordinator, every rank then
+  binds its own, and the run hangs in rendezvous with no error. `scontrol` is not in these
+  images, so a `SLURM_JOB_NODELIST` fallback must check for it rather than assume it.
+- **One container per node owning all 8 GPUs.** That is the topology multi-threaded RCCL
+  state is exercised in; eight single-GPU processes per node are a different workload.
+  Counter-intuitively this needs `nproc_per_node: 8`, not 1: on the container path
+  `container_runner.py` resolves the container's GPU count from `NPROC_PER_NODE` **first**
+  and only then `GPUS_PER_NODE`, so a 1 there exposes a single GPU per node while every
+  other part of the config still says eight. SLURM starts one task per node regardless
+  (`#SBATCH --ntasks=<nodes>`), so the one-container-per-node topology is unaffected. The
+  mirror-image mistake is letting `NPROC_PER_NODE` stand in for the GPU count inside the
+  model script: the variable means the per-node GPU count on the container path but a
+  process count for a process-based launcher like torchrun, and may be unset on a direct
+  invocation, so a `GPUS_PER_NODE:-$NPROC_PER_NODE` fallback makes the reported `num_gpus`
+  depend on which launcher ran. Give the model script an explicit default.
+- **Append-mode training logs plus a reused workspace silently blend runs.** MAD report
+  scripts typically pipe training to `tee -a`, so a second run of the same model in a
+  workspace that is not discarded leaves both runs in one file and every metric is computed
+  over the mix - an A/B result then depends on what was already in the log. **Truncate per
+  invocation**; confining the parser to the final run is not sufficient on its own, because a
+  run that emits no step records at all (steps=0, an early crash, a changed log format)
+  leaves no boundary to detect and the previous run's records are read as the current
+  result - demonstrated: an appended log whose latest run has no steps yields the earlier
+  run's median with no indication anything is wrong. Keep the boundary detection as defence
+  in depth for logs the harness did not produce. The same reuse hazard applies to the result CSV: delete the destination
+  *before* parsing, or a parser that refuses to produce a measurement leaves the previous
+  run's valid-looking file in place for the collector to pick up. And where a launcher may
+  give every rank the same workspace, the training log needs a rank suffix too, not just the
+  CSV - otherwise the ranks interleave step records into one file and rank 0's median is
+  taken over a sample that never existed.
+- **Per-rank output filenames are collected by nobody.** The SLURM template collects
+  artifacts by the EXACT `multiple_results` filename, so a `perf_..._rankN.csv` written by a
+  worker stays in that node's local workspace and is discarded with it. On this path each
+  task copies the project into a node-local `SLURM_TMPDIR`/`/tmp` workspace, so the ranks do
+  not share a path and every rank can just write the canonical name - each node's copy is
+  then collected under its own `node_<PROCID>` directory. Reserve rank suffixes for
+  launchers that hand every rank the same shared workspace; `MAD_COLLECT_METRICS`, which the
+  template sets per task and forwards into the container, is a usable signal for telling the
+  two apart.
+- **`XLA_AUTOTUNE_LEVEL=0` is required at 32 ranks.** The gfx950 env scripts default to
+  level 4; levels 1 and 2 did not finish compiling within 50 and 90 minutes at 32 ranks,
+  while level 0 compiles in under a minute at no measured compute cost (962 vs 968
+  TFLOP/s/device on a 2-node control).
+- **An empty `quantization=` on the MaxText command line replaces the config value, it is
+  not ignored.** A card passing no `--quantization` made the wrapper hand MaxText
+  `quantization=`, and `gfx950_llama3.1_405b.yml` — which sets `quantization: "fp8"` —
+  trained in bf16 while every label said FP8 (`Config param quantization: None` in the log).
+  Declare the precision on the card.
+- **`gfx950_llama3.1_405b.yml` set no `base_output_directory`.** MaxText fell back to a
+  default whose parent does not exist and died in `initialize()` at
+  `save_device_information()` with `FileNotFoundError` on `maxtext_output/device_info.json` —
+  before the mesh is built, so zero steps and a prompt, quiet exit.
+- **The tokenizer fetch fails on hosts without access to the gated Llama repos**
+  ("Access denied. This repository requires approval.") and this is harmless: these cards
+  train on `dataset_type: synthetic`. Do not make setup failure fatal — verified against
+  logs of runs that completed normally and carry the same error.
+- **madengine scrapes the FIRST `performance:` match.** The single-node cards emit
+  `performance: 1 pass`; a report script that prints a real metric earlier silently
+  redefines what every existing card reports. Gate a new metric to the multi-node path.
+- **Median `seconds_per_step` is comparable only between runs with equal `steps`.** Step
+  time drifts upward over the first steady steps before plateauing (0.860 s at step 3 vs
+  0.874–0.876 s at steps 10–14 on a 4-node run), so a `steps=15` median is systematically
+  lower than a `steps=25` one.
 
 ## sglang_disagg
 

--- a/.claude/skills/mad-slurm-multinode/references/gotchas.md
+++ b/.claude/skills/mad-slurm-multinode/references/gotchas.md
@@ -108,9 +108,10 @@ here; this file is read before a run.
   even though the user's own shell reads it fine. Stage run data under a path
   whose whole chain is world-traversable (`o+x`), not just group-readable.
 - **The SLURM path exports `NCCL_IB_DISABLE=1` by default — set it to 0 or the run uses
-  TCP.** It is one of the variables madengine injects into the generated sbatch itself
-  (alongside `MIOPEN_*`, `OMP_NUM_THREADS`, `NCCL_TIMEOUT`, `RCCL_ENABLE_HIPGRAPH`), so it is
-  absent from the manifest and easy to miss. Nothing fails: RCCL reports `via NET/Socket` and
+  TCP.** It comes from madengine's own multi-node profile
+  (`src/madengine/deployment/presets/slurm/profiles/multi-node.json`, alongside `MIOPEN_*`,
+  `OMP_NUM_THREADS`, `NCCL_TIMEOUT`), not from anything you wrote, so it is absent from the
+  manifest and easy to miss. Grepping the generated sbatch for it is the fast check. Nothing fails: RCCL reports `via NET/Socket` and
   the job simply runs several times slower — measured here at 0.936 s/step over RDMA versus
   4.4-6.8 s/step over sockets for the same 8B workload on the same nodes, with TFLOP/s down
   from 935 to 125. Put `NCCL_IB_DISABLE: "0"` in BOTH env blocks, and keep `NCCL_DEBUG=INFO`
@@ -163,10 +164,10 @@ here; this file is read before a run.
 
 ## jax_maxtext (training)
 
-Keywords: jax maxtext llama3 pretrain, JAX_COORDINATOR_IP JAX_COORDINATOR_PORT NNODES
+Keywords: jax maxtext llama3 pretrain primus, JAX_COORDINATOR_IP JAX_COORDINATOR_PORT NNODES
 NODE_RANK, SLURM_PROCID rank derivation, loopback 127.0.0.1 rendezvous hang, RCCL overlay
-RCCL_COMMIT, base_output_directory device_info.json FileNotFoundError, empty quantization
-override, seconds_per_step median first performance match, XLA autotune level 32 ranks,
+RCCL_COMMIT, launcher primus BACKEND MaxText PRIMUS_CONFIG_PATH, stale primus_perf_output.csv,
+seconds_per_step median first performance match, XLA_GPU_AUTOTUNE_LEVEL fp8 NaN compile time,
 gated Llama repo tokenizer synthetic dataset.
 
 - **The model script translates the launcher's variables, it does not source them.**
@@ -194,21 +195,17 @@ gated Llama repo tokenizer synthetic dataset.
   process count for a process-based launcher like torchrun, and may be unset on a direct
   invocation, so a `GPUS_PER_NODE:-$NPROC_PER_NODE` fallback makes the reported `num_gpus`
   depend on which launcher ran. Give the model script an explicit default.
-- **Append-mode training logs plus a reused workspace silently blend runs.** MAD report
-  scripts typically pipe training to `tee -a`, so a second run of the same model in a
-  workspace that is not discarded leaves both runs in one file and every metric is computed
-  over the mix - an A/B result then depends on what was already in the log. **Truncate per
-  invocation**; confining the parser to the final run is not sufficient on its own, because a
-  run that emits no step records at all (steps=0, an early crash, a changed log format)
-  leaves no boundary to detect and the previous run's records are read as the current
-  result - demonstrated: an appended log whose latest run has no steps yields the earlier
-  run's median with no indication anything is wrong. Keep the boundary detection as defence
-  in depth for logs the harness did not produce. The same reuse hazard applies to the result CSV: delete the destination
-  *before* parsing, or a parser that refuses to produce a measurement leaves the previous
-  run's valid-looking file in place for the collector to pick up. And where a launcher may
-  give every rank the same workspace, the training log needs a rank suffix too, not just the
-  CSV - otherwise the ranks interleave step records into one file and rank 0's median is
-  taken over a sample that never existed.
+- **A stale result CSV outlives the run that failed to overwrite it.** `run.sh` writes the
+  perf CSV to `$RUN_DIR/../primus_perf_output.csv` — the PARENT of `run_directory`, because
+  madengine deletes `run_directory` before parsing. That parent is not deleted, and the write
+  is skipped entirely when the training log is missing and swallowed by `|| true` when the
+  extractor fails. So on any path that reuses the parent directory, a crashed run can be
+  scored with the previous run's numbers and nothing looks wrong. On the SLURM path each task
+  gets a fresh node-local workspace, which hides this; a local re-run does not. Delete the
+  destination CSV *before* the training command, not after it. The same reasoning applies to
+  the training log: prefer truncation per invocation over append, since a run that emits no
+  step records at all — steps=0, an early crash, a changed log format — leaves no boundary
+  for a parser to detect and the previous run's records are read as the current result.
 - **Per-rank output filenames are collected by nobody.** The SLURM template collects
   artifacts by the EXACT `multiple_results` filename, so a `perf_..._rankN.csv` written by a
   worker stays in that node's local workspace and is discarded with it. On this path each
@@ -218,19 +215,18 @@ gated Llama repo tokenizer synthetic dataset.
   launchers that hand every rank the same shared workspace; `MAD_COLLECT_METRICS`, which the
   template sets per task and forwards into the container, is a usable signal for telling the
   two apart.
-- **`XLA_AUTOTUNE_LEVEL=0` is required at 32 ranks.** The gfx950 env scripts default to
-  level 4; levels 1 and 2 did not finish compiling within 50 and 90 minutes at 32 ranks,
-  while level 0 compiles in under a minute at no measured compute cost (962 vs 968
-  TFLOP/s/device on a 2-node control).
-- **An empty `quantization=` on the MaxText command line replaces the config value, it is
-  not ignored.** A card passing no `--quantization` made the wrapper hand MaxText
-  `quantization=`, and `gfx950_llama3.1_405b.yml` — which sets `quantization: "fp8"` —
-  trained in bf16 while every label said FP8 (`Config param quantization: None` in the log).
-  Declare the precision on the card.
-- **`gfx950_llama3.1_405b.yml` set no `base_output_directory`.** MaxText fell back to a
-  default whose parent does not exist and died in `initialize()` at
-  `save_device_information()` with `FileNotFoundError` on `maxtext_output/device_info.json` —
-  before the mesh is built, so zero steps and a prompt, quiet exit.
+- **XLA autotune level pulls in two directions — do not set it blind.** Primus owns
+  `XLA_FLAGS` for MaxText (`primus/backends/maxtext/env_spec.py`, applied in-process before
+  JAX init) and defaults `--xla_gpu_autotune_level=4`, because `>=4` is what lets XLA pick a
+  numerically stable fp8 kernel — below it, fp8 MoE runs NaN. Against that: on the retired
+  MAD-native env scripts at 32 ranks, levels 1 and 2 did not finish compiling within 50 and
+  90 minutes, while level 0 compiled in under a minute at no measured compute cost (962 vs
+  968 TFLOP/s/device on a 2-node control). Those two facts were measured on different stacks
+  and level 4 itself was never timed at 32 ranks, so treat neither as settled: if a 4-node
+  fp8 run appears to hang before step 1, suspect compilation and time it before changing the
+  level. The knob is `XLA_GPU_AUTOTUNE_LEVEL` (Primus reads that name, not
+  `XLA_AUTOTUNE_LEVEL`), and lowering it trades an fp8 correctness guarantee for compile
+  time.
 - **The tokenizer fetch fails on hosts without access to the gated Llama repos**
   ("Access denied. This repository requires approval.") and this is harmless: these cards
   train on `dataset_type: synthetic`. Do not make setup failure fatal — verified against

--- a/.claude/skills/mad-slurm-multinode/references/gotchas.md
+++ b/.claude/skills/mad-slurm-multinode/references/gotchas.md
@@ -221,12 +221,19 @@ gated Llama repo tokenizer synthetic dataset.
   numerically stable fp8 kernel — below it, fp8 MoE runs NaN. Against that: on the retired
   MAD-native env scripts at 32 ranks, levels 1 and 2 did not finish compiling within 50 and
   90 minutes, while level 0 compiled in under a minute at no measured compute cost (962 vs
-  968 TFLOP/s/device on a 2-node control). Those two facts were measured on different stacks
-  and level 4 itself was never timed at 32 ranks, so treat neither as settled: if a 4-node
-  fp8 run appears to hang before step 1, suspect compilation and time it before changing the
-  level. The knob is `XLA_GPU_AUTOTUNE_LEVEL` (Primus reads that name, not
-  `XLA_AUTOTUNE_LEVEL`), and lowering it trades an fp8 correctness guarantee for compile
-  time.
+  968 TFLOP/s/device on a 2-node control). **Level 4 has since been observed at 24 and 32
+  ranks and it does not finish**: the run presents as a dead hang — zero steps, zero
+  `NCCL INFO`, one thread pinned at ~100 % in `libhsa-runtime64.so.1` — for hours, on the
+  stock image as well as an overlay, on fp8 and bf16 alike, and across independent node sets.
+  Sixteen ranks survive it. The same job with `XLA_GPU_AUTOTUNE_LEVEL=0` reached RCCL init in
+  about a minute and trained 50 steps. So the failure scales with rank count, not with
+  anything about the library under test — and it is indistinguishable from a hang without
+  timing it, which is why it was misdiagnosed here once as an upstream defect at >=3 hosts.
+  The knob is `XLA_GPU_AUTOTUNE_LEVEL` (Primus reads that name; the MAD-native
+  `XLA_AUTOTUNE_LEVEL` is a silent no-op under Primus, so carrying the old key across does
+  nothing), and lowering it trades an fp8 correctness guarantee for compile time. Set it in
+  BOTH env blocks — `context.docker_env_vars` and `deployment_config.env_vars` — since only
+  the first reaches the container.
 - **The tokenizer fetch fails on hosts without access to the gated Llama repos**
   ("Access denied. This repository requires approval.") and this is harmless: these cards
   train on `dataset_type: synthetic`. Do not make setup failure fatal — verified against

--- a/docker/primus_maxtext_rccl_overlay.ubuntu.amd.Dockerfile
+++ b/docker/primus_maxtext_rccl_overlay.ubuntu.amd.Dockerfile
@@ -339,6 +339,11 @@ RUN if [[ -n "${RDMA_CORE_VERSION}" ]]; then \
 # rocm_sdk.initialize_process with "libamd_smi.so.26: cannot open shared object file"
 # before a single step runs. Copy the bytes, restore the destination's RUNPATH.
 #
+# "Restore" includes restoring an EMPTY one. A destination that carried no RUNPATH resolves
+# through the loader's own search path; leaving the candidate's $ORIGIN/../lib behind would
+# silently change WHERE its dependencies come from, and the soname gate below cannot see
+# that - it checks which names are unresolved, not which file each name resolved to.
+#
 # The ldd gate below is the check that would have caught that at build time instead of
 # 4 minutes into a 2-node job. It records the SET of unresolved sonames per target before
 # the swap and fails if the set afterwards contains any name that was not already there.
@@ -369,7 +374,9 @@ RUN set -e; \
       echo "  overwrite: $t (rpath: ${rp:-none})"; \
       cp -fL --remove-destination "$SRC" "$t"; \
       if [ -n "$rp" ]; then patchelf --set-rpath "$rp" "$t" || \
-        { echo "GATE FAIL: could not restore RUNPATH on $t"; exit 1; }; fi; \
+        { echo "GATE FAIL: could not restore RUNPATH on $t"; exit 1; }; \
+      else patchelf --remove-rpath "$t" || \
+        { echo "GATE FAIL: could not clear RUNPATH on $t"; exit 1; }; fi; \
     done < /opt/RCCL_TARGETS.txt; \
     ldconfig || true; \
     while IFS="$(printf '\t')" read -r n t; do \

--- a/docker/primus_maxtext_rccl_overlay.ubuntu.amd.Dockerfile
+++ b/docker/primus_maxtext_rccl_overlay.ubuntu.amd.Dockerfile
@@ -1,0 +1,361 @@
+# CONTEXT {'gpu_vendor': 'AMD', 'guest_os': 'UBUNTU'}
+# MIT License
+#
+# Copyright (c) Advanced Micro Devices, Inc.
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Primus JAX/MaxText training image with a candidate RCCL built from source.
+#
+#   base : rocm/jax-training:maxtext-v26.6
+#   +    : the Primus payload of docker/primus_maxtext.ubuntu.amd.Dockerfile
+#   +    : RCCL built from ${RCCL_REPO}@${RCCL_BRANCH}[/${RCCL_COMMIT}] for
+#          ${BUILD_GPU_TARGETS} (gfx942=MI300X/MI325X, gfx950=MI350X/MI355X)
+#   +    : candidate librccl installed over EVERY librccl on disk
+#   +    : optional rdma-core ${RDMA_CORE_VERSION} from source (Broadcom Thor2
+#          bnxt_re EFAULT fix on some fabrics; empty = keep base rdma-core)
+#
+# A drop-in for docker/primus_maxtext.ubuntu.amd.Dockerfile: same PRIMUS_ROOT,
+# MAXTEXT_PATH and mad.launcher label, so the same model card and the same
+# scripts/jax-maxtext/run.sh work against either image and the only difference
+# between them is librccl. Swapping the two is the A/B.
+#
+# WHY the Primus payload is duplicated here rather than layered on top of the
+# primus_maxtext image: that image is not published under a stable tag, and
+# FROM-ing a locally built one would make this build order-dependent. The
+# duplicated part is small and its two `test -f` gates fail loudly if it drifts.
+#
+# This is the JAX/MaxText counterpart of
+# docker/primus_megatron_train_rccl_overlay.ubuntu.amd.Dockerfile and follows its
+# structure and reasoning; what differs is the base image, the Primus payload
+# (rocm/primus:* already ships Primus, rocm/jax-training:maxtext-* does not) and
+# how the candidate librccl is spliced in. A fix that applies to both belongs in
+# both.
+#
+# WHY overwrite every librccl on disk rather than LD_LIBRARY_PATH: /opt/rocm/lib
+# is NOT in this base's ldconfig cache, so a path override is unreliable, and a
+# partially-overridden image runs and reports a number for the wrong library.
+# There is no torch/lib to special-case here, so it is one find-based sweep.
+#
+# The clone keeps .git, so RCCL bakes the real commit into its version banner.
+#
+# IMAGE LAYOUT: RCCL is compiled in a throwaway `rccl-builder` stage and only the
+# installed ${RCCL_INSTALL_DIR} tree is COPYed into the final image, keeping the
+# source/build tree and the build toolchain out of the shipped image.
+#
+# BUILD CONTEXT is the repository root, not ./docker: madengine gives repo-root
+# context to any dockerfile whose path contains "primus" (see
+# DockerBuilder.get_context_path), which is what makes `COPY scripts/Primus/`
+# below resolve. Check Primus out first with tools/fetch_primus.sh:
+#   bash tools/fetch_primus.sh
+#   docker build -f docker/primus_maxtext_rccl_overlay.ubuntu.amd.Dockerfile .
+#
+ARG BASE_DOCKER=rocm/jax-training:maxtext-v26.6
+
+# ---- shared base: apt mirror hygiene (so both stages resolve the same) ------
+FROM ${BASE_DOCKER} AS apt-base
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+USER root
+RUN set -e && \
+    sed -i 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g; s|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' /etc/apt/sources.list 2>/dev/null || true && \
+    if [ -d /etc/apt/sources.list.d ]; then \
+      sed -i 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g; s|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/*.list 2>/dev/null || true; \
+      sed -i 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g; s|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/*.sources 2>/dev/null || true; \
+      sed -i -E 's/^Components:.*/Components: main restricted universe multiverse/g' /etc/apt/sources.list.d/*.sources 2>/dev/null || true; \
+    fi
+
+# ---- Stage 1 (throwaway): build + verify candidate RCCL ---------------------
+# Everything heavy (full RCCL clone, submodules, build tree, gcc/cmake/ninja)
+# lives here and is discarded; only ${RCCL_INSTALL_DIR} is carried forward.
+FROM apt-base AS rccl-builder
+
+ARG RCCL_REPO=https://github.com/ROCm/rocm-systems.git
+ARG RCCL_BRANCH=develop
+ARG RCCL_COMMIT=
+ARG RCCL_INSTALL_DIR=/opt/rccl
+# gfx942 = MI300X / MI325X ; gfx950 = MI350X / MI355X
+ARG BUILD_GPU_TARGETS=gfx950
+# Extra cmake options forwarded to RCCL's install.sh, e.g.
+# "-DFAULT_INJECTION=OFF". Empty = RCCL's own defaults.
+ARG RCCL_CMAKE_OPTIONS=
+
+RUN mkdir -p "${RCCL_INSTALL_DIR}"
+WORKDIR /opt
+
+RUN apt-get -o Acquire::ForceIPv4=true \
+            -o Acquire::Retries=5 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      git \
+      ca-certificates \
+      cmake \
+      ninja-build \
+      pkg-config \
+      make \
+      patch \
+      build-essential \
+      libnuma-dev \
+      libatomic1 \
+      patchelf && \
+    rm -rf /var/lib/apt/lists/*
+
+# clone the candidate RCCL and record the exact built commit. A pinned SHA is not
+# reachable from a shallow clone, so clone fully when RCCL_COMMIT is set.
+RUN if [[ -n "${RCCL_COMMIT}" ]]; then \
+      git clone "${RCCL_REPO}" /tmp/rccl; \
+    else \
+      git clone --depth 1 --branch "${RCCL_BRANCH}" "${RCCL_REPO}" /tmp/rccl; \
+    fi && \
+    cd /tmp/rccl && \
+    if [[ -n "${RCCL_COMMIT}" ]]; then git checkout "${RCCL_COMMIT}"; \
+    elif [[ -n "${RCCL_BRANCH}" ]]; then git checkout "${RCCL_BRANCH}"; fi && \
+    if [[ -d projects/rccl ]]; then \
+      cd projects/rccl && git submodule update --init --recursive; \
+      echo "/tmp/rccl/projects/rccl" > /tmp/BLD_RCCL_HOME.txt; \
+    else \
+      git submodule update --init --recursive; \
+      echo "/tmp/rccl" > /tmp/BLD_RCCL_HOME.txt; \
+    fi && \
+    git -C "$(cat /tmp/BLD_RCCL_HOME.txt)" rev-parse HEAD > "${RCCL_INSTALL_DIR}/RCCL_BUILT_SHA" && \
+    echo "RCCL_BUILT_SHA=$(cat ${RCCL_INSTALL_DIR}/RCCL_BUILT_SHA)"
+
+RUN set -e && \
+    BLD_RCCL_HOME=$(cat /tmp/BLD_RCCL_HOME.txt) && \
+    cd "${BLD_RCCL_HOME}" && \
+    ./install.sh --amdgpu_targets="${BUILD_GPU_TARGETS}" --prefix="${RCCL_INSTALL_DIR}" \
+                 ${RCCL_CMAKE_OPTIONS:+--cmake-options "${RCCL_CMAKE_OPTIONS}"}
+
+# ---- build-verification gate: artifact exists + 0 undefined GDAKI/atomic ----
+# Fail first if the built librccl is missing (otherwise `nm` would error, the
+# counts would default to 0, and the gate would wrongly pass). The `|| true` on
+# the grep counts is only to tolerate "no match" (grep exit 1) under -o pipefail.
+#
+# The gate also checks that RCCL_CMAKE_OPTIONS was actually honoured when it names
+# FAULT_INJECTION, because cmake merely warns about an unrecognised -D cache
+# variable: on a commit that does not define it, ON and OFF build the same library
+# while the provenance file records different options. A positive-control string is
+# required first - a marker count of 0 means "not built in" only if `strings` found
+# something else in the same file.
+#
+# The option is located as a whole token (-DFAULT_INJECTION=v, -DFAULT_INJECTION:BOOL=v,
+# or "-D FAULT_INJECTION=v") and its value read with cmake's own truth rules, which are
+# case-insensitive and accept far more than ON/1. A substring test would call
+# -DFAULT_INJECTION=TRUE a request for OFF and then fail a build that is in fact correct,
+# and would also fire on an unrelated option whose name merely contains FAULT_INJECTION.
+RUN set -e; \
+    LIB="${RCCL_INSTALL_DIR}/lib/librccl.so"; \
+    echo "=== librccl.so ==="; ls -laL "${RCCL_INSTALL_DIR}/lib/" | grep -i rccl || true; \
+    [ -e "$LIB" ] || { echo "BUILD GATE FAIL: $LIB is missing"; exit 1; }; \
+    nd=$(nm -D --undefined-only "$LIB" | grep -cE "[Gg]daki|GDAKI" || true); \
+    na=$(nm -D --undefined-only "$LIB" | grep -E "__atomic_" | grep -vc "@LIBATOMIC" || true); \
+    echo "gdaki_undefined=${nd:-0} unversioned_atomic_undefined=${na:-0}"; \
+    if [ "${nd:-0}" -ne 0 ] || [ "${na:-0}" -ne 0 ]; then echo "BUILD GATE FAIL: undefined symbols present"; exit 1; fi; \
+    ctl=$(strings -a "$LIB" | grep -c "ncclCommInitRank" || true); \
+    [ "${ctl:-0}" -gt 0 ] || { echo "BUILD GATE FAIL: positive control absent - strings found nothing in $LIB, so any marker count below would be meaningless"; exit 1; }; \
+    set -f; fi_seen=0; fi_val=""; prev=""; \
+    for tok in ${RCCL_CMAKE_OPTIONS}; do \
+      case "${prev}${tok}" in \
+        -DFAULT_INJECTION=*|-DFAULT_INJECTION:*=*) fi_seen=1; fi_val="${tok#*=}" ;; \
+      esac; \
+      if [ "$tok" = "-D" ]; then prev="-D"; else prev=""; fi; \
+    done; set +f; \
+    if [ "$fi_seen" = 0 ]; then \
+      case "${RCCL_CMAKE_OPTIONS}" in *FAULT_INJECTION*) \
+        echo "WARNING: RCCL_CMAKE_OPTIONS mentions FAULT_INJECTION but carries no"; \
+        echo "         -DFAULT_INJECTION[:TYPE]=<value> token, so the effect check is skipped." ;; \
+      esac; \
+    fi; \
+    if [ "$fi_seen" = 1 ]; then \
+      case "${fi_val^^}" in ""|0|OFF|NO|FALSE|N|IGNORE|NOTFOUND|*-NOTFOUND) want=0 ;; *) want=1 ;; esac; \
+      got=$(strings -a "$LIB" | grep -c "NET/IB ops-fault" || true); \
+      echo "fault_injection value='${fi_val}' requested=${want} marker_count=${got} positive_control=${ctl}"; \
+      if { [ "$want" = 1 ] && [ "${got:-0}" -eq 0 ]; } || { [ "$want" = 0 ] && [ "${got:-0}" -ne 0 ]; }; then \
+        echo "BUILD GATE FAIL: RCCL_CMAKE_OPTIONS='${RCCL_CMAKE_OPTIONS}' did not take effect."; \
+        echo "  cmake only warns about an unknown -D cache variable, so a commit that does not"; \
+        echo "  define this option builds fine and yields a library identical to the other arm,"; \
+        echo "  while the provenance file claims they differ."; exit 1; fi; \
+    fi; \
+    echo "GATE PASS (built RCCL @ $(cat ${RCCL_INSTALL_DIR}/RCCL_BUILT_SHA))"
+
+# ---- final image ------------------------------------------------------------
+FROM apt-base
+
+ARG BASE_DOCKER
+ARG RCCL_REPO=https://github.com/ROCm/rocm-systems.git
+ARG RCCL_BRANCH=develop
+# Re-declared in this stage only so the provenance file can record it: without it a
+# pinned-commit build reports RCCL_BRANCH=develop and nothing else, which reads as a
+# branch-tip build. RCCL_BUILT_SHA is the authoritative value either way.
+ARG RCCL_COMMIT=
+ARG RCCL_INSTALL_DIR=/opt/rccl
+# gfx942 = MI300X / MI325X ; gfx950 = MI350X / MI355X
+ARG BUILD_GPU_TARGETS=gfx950
+ARG RCCL_CMAKE_OPTIONS=
+# Optional rdma-core from source (e.g. 63.0 for the Broadcom Thor2 bnxt_re
+# EFAULT fix). Empty string keeps the base image's rdma-core untouched.
+ARG RDMA_CORE_VERSION=
+
+ENV WORKSPACE_DIR=/workspace
+# The Primus repo root, not /workspace: run.sh resolves examples/ relative to it.
+ENV PRIMUS_ROOT=/workspace/Primus
+# Pin the base's tree; prepare.py would otherwise default to
+# $PRIMUS_ROOT/third_party/maxtext, which this image does not ship.
+ENV MAXTEXT_PATH=/workspace/maxtext
+ENV RCCL_HOME=${RCCL_INSTALL_DIR}
+# Prepend the candidate RCCL dir but KEEP the base image's paths (ROCm libs).
+# The candidate librccl is also installed over every on-disk copy + ldconfig, so
+# this is belt-and-suspenders rather than the sole resolution mechanism.
+ENV LD_LIBRARY_PATH=${RCCL_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
+
+# Same label as primus_maxtext, so madengine treats this image the same way.
+LABEL mad.launcher=primus
+
+RUN mkdir -p "${WORKSPACE_DIR}"
+WORKDIR ${WORKSPACE_DIR}
+
+# Bring in ONLY the installed candidate RCCL tree (no source/build artifacts).
+COPY --from=rccl-builder ${RCCL_INSTALL_DIR} ${RCCL_INSTALL_DIR}
+
+# binutils for the final verification (nm / strings / readelf); libatomic1 is a
+# runtime dep of the candidate librccl.
+RUN apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      binutils libatomic1 && \
+    rm -rf /var/lib/apt/lists/*
+
+# ---- Primus payload (mirrors docker/primus_maxtext.ubuntu.amd.Dockerfile) ----
+# Placed BEFORE the librccl sweep below so that anything these layers drop on
+# disk - a wheel that vendors its own librccl, say - is caught by the sweep and
+# overwritten too. Reversing the order would leave such a copy at the base
+# version while the provenance file claims the candidate.
+#
+# The base may ship /workspace/Primus as a git clone, and COPY cannot replace a
+# .git directory with a submodule checkout's .git file.
+RUN rm -rf /workspace/Primus
+COPY scripts/Primus/ /workspace/Primus/
+
+RUN test -f /workspace/Primus/examples/run_pretrain.sh
+RUN test -f /workspace/Primus/requirements-jax.txt
+
+# Prove the base's stack is really there, so a wrong base fails the build instead
+# of step 0 of a training run.
+RUN test -f /workspace/maxtext/pyproject.toml \
+    || (echo "ERROR: no MaxText at /workspace/maxtext. Use a base that bakes it, or point MAXTEXT_PATH at a checkout." >&2 && exit 1)
+
+# Installed here rather than on every run: run.sh sets PRIMUS_SKIP_PIP=1 so a
+# launch stays off the network. On this base it adds loguru, wandb, pre-commit.
+RUN pip3 install --no-cache-dir -r /workspace/Primus/requirements-jax.txt
+
+# ---- Stage 2 (optional): rdma-core from source ------------------------------
+# Builds only when RDMA_CORE_VERSION is non-empty (e.g. 63.0). Replaces the
+# distro rdma-core to pick up the Broadcom Thor2 bnxt_re EFAULT fix; the build
+# toolchain it needs is installed inside the script, so the default image
+# (RDMA_CORE_VERSION empty) never pays for it.
+#
+# ORDERING IS LOAD-BEARING: `dpkg -r --force-all` leaves dependents with dangling
+# deps, so every apt operation MUST run BEFORE it; only dpkg and `ninja install`
+# may follow. Installing over the distro tree instead of replacing it leaves both
+# provider sets in place and libibverbs can still resolve the old one.
+#
+# Inlined rather than COPYed from a sibling script: keeping it in the dockerfile
+# means the file is self-contained regardless of what the build context is.
+RUN if [[ -n "${RDMA_CORE_VERSION}" ]]; then \
+      set -e; \
+      apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 update; \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git ca-certificates cmake ninja-build build-essential pkg-config make \
+        libnl-3-dev libnl-route-3-dev libudev-dev libssl-dev libsystemd-dev \
+        python3-docutils pandoc; \
+      rm -rf /var/lib/apt/lists/*; \
+      git clone --depth 1 --branch "v${RDMA_CORE_VERSION}" https://github.com/linux-rdma/rdma-core.git /tmp/rdma-core; \
+      cd /tmp/rdma-core && git log -1 --format='%H %s'; \
+      mkdir build && cd build; \
+      cmake -GNinja \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu \
+        -DCMAKE_INSTALL_SYSCONFDIR=/etc \
+        -DCMAKE_INSTALL_RUNDIR=/run \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DNO_PYVERBS=1 \
+        ..; \
+      ninja -j"$(nproc)"; \
+      DEBIAN_FRONTEND=noninteractive apt-get purge -y python3-docutils pandoc; \
+      DEBIAN_FRONTEND=noninteractive apt-get autoremove -y; \
+      rm -rf /var/lib/apt/lists/*; \
+      to_remove=""; \
+      for p in ibverbs-providers libibverbs1 libibverbs-dev ibverbs-utils \
+               librdmacm1 librdmacm-dev rdma-core libibumad3 libibmad5 \
+               infiniband-diags; do \
+        if dpkg-query -W -f='${Status}' "$p" 2>/dev/null | grep -q "install ok installed"; then \
+          to_remove="$to_remove $p"; \
+        fi; \
+      done; \
+      if [[ -n "$to_remove" ]]; then \
+        echo "removing distro rdma packages:$to_remove"; \
+        dpkg -r --force-all $to_remove; \
+      fi; \
+      ninja install && ldconfig; \
+      rm -f /usr/local/lib/x86_64-linux-gnu/libbnxt_re-rdmav*.so /usr/local/lib/libbnxt_re-rdmav*.so; \
+      cd / && rm -rf /tmp/rdma-core; \
+      shopt -s nullglob; \
+      prov=(/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav*.so); \
+      shopt -u nullglob; \
+      echo "bnxt_re providers: ${#prov[@]}"; \
+      [[ ${#prov[@]} -gt 0 ]] && ls -l "${prov[@]}"; \
+      if [[ ${#prov[@]} -eq 0 ]]; then \
+        echo "GATE FAIL: no bnxt_re provider after rdma-core install"; exit 1; \
+      fi; \
+    else \
+      echo "RDMA_CORE_VERSION empty -- keeping the base image's rdma-core"; \
+    fi
+
+# ---- Stage 3: install candidate librccl over EVERY librccl on disk ----------
+# -type f, so the .so/.so.1 symlinks keep pointing at what is replaced. An empty
+# target list fails the build: such an image would run against the base library.
+RUN set -e; \
+    SRC="$(ls -L ${RCCL_INSTALL_DIR}/lib/librccl.so.1.0 2>/dev/null || ls -L ${RCCL_INSTALL_DIR}/lib/librccl.so)"; \
+    [ -n "$SRC" ] || { echo "GATE FAIL: no librccl in ${RCCL_INSTALL_DIR}"; exit 1; }; \
+    echo "candidate librccl: $SRC"; \
+    canon_src="$(readlink -f "$SRC")"; \
+    find / -xdev -type f -name 'librccl.so*' -not -path "${RCCL_INSTALL_DIR}/*" \
+      2>/dev/null > /opt/RCCL_TARGETS.txt || true; \
+    [ -s /opt/RCCL_TARGETS.txt ] || { echo "GATE FAIL: no librccl found in base image"; exit 1; }; \
+    while read -r t; do \
+      [ "$(readlink -f "$t")" = "$canon_src" ] && continue; \
+      echo "  overwrite: $t"; cp -fL --remove-destination "$SRC" "$t"; \
+    done < /opt/RCCL_TARGETS.txt; \
+    ldconfig || true
+
+# ---- provenance: recorded INSIDE the image ---------------------------------
+# The build log is not carried by the image. RCCL_CMAKE_OPTIONS is recorded too:
+# two images can share a commit and a version banner and still differ.
+RUN cp "${RCCL_INSTALL_DIR}/RCCL_BUILT_SHA" /opt/RCCL_BUILT_SHA && \
+    pip3 list > /opt/RCCL_IMAGE_PIP_LIST.txt && \
+    { echo "RCCL_BUILT_SHA=$(cat /opt/RCCL_BUILT_SHA)"; \
+      echo "RCCL_REPO=${RCCL_REPO}"; \
+      echo "RCCL_BRANCH=${RCCL_BRANCH}"; \
+      echo "RCCL_COMMIT=${RCCL_COMMIT}"; \
+      echo "RCCL_CMAKE_OPTIONS=${RCCL_CMAKE_OPTIONS}"; \
+      echo "BUILD_GPU_TARGETS=${BUILD_GPU_TARGETS}"; \
+      echo "BASE_DOCKER=${BASE_DOCKER}"; \
+      echo "RDMA_CORE_VERSION=${RDMA_CORE_VERSION}"; \
+      echo "LIBRCCL_TARGETS:"; cat /opt/RCCL_TARGETS.txt; \
+    } > /opt/RCCL_IMAGE_PROVENANCE.txt && \
+    cat /opt/RCCL_IMAGE_PROVENANCE.txt

--- a/docker/primus_maxtext_rccl_overlay.ubuntu.amd.Dockerfile
+++ b/docker/primus_maxtext_rccl_overlay.ubuntu.amd.Dockerfile
@@ -340,12 +340,14 @@ RUN if [[ -n "${RDMA_CORE_VERSION}" ]]; then \
 # before a single step runs. Copy the bytes, restore the destination's RUNPATH.
 #
 # The ldd gate below is the check that would have caught that at build time instead of
-# 4 minutes into a 2-node job. It compares each target BEFORE and AFTER the swap and
-# fails only on an INCREASE. An absolute "must resolve everything" test would fail a
-# perfectly good build: on this base the pristine _rocm_sdk_devel copy already reports
-# 6 unresolved deps (its RUNPATH is a row of empty entries), because it is only ever
-# dlopen'd into a namespace where those libraries are already loaded. What must not
-# happen is the swap making linkage worse than it found it.
+# 4 minutes into a 2-node job. It records the SET of unresolved sonames per target before
+# the swap and fails if the set afterwards contains any name that was not already there.
+# Comparing counts is not enough: dropping one missing soname while introducing a
+# different one leaves the count unchanged and would pass. An absolute "must resolve
+# everything" test would fail a perfectly good build instead: on this base the pristine
+# _rocm_sdk_devel copy already reports 6 unresolved deps (its RUNPATH is a row of empty
+# entries), because it is only ever dlopen'd into a namespace where those libraries are
+# already loaded. What must not happen is the swap making linkage worse than it found it.
 RUN set -e; \
     SRC="$(ls -L ${RCCL_INSTALL_DIR}/lib/librccl.so.1.0 2>/dev/null || ls -L ${RCCL_INSTALL_DIR}/lib/librccl.so)"; \
     [ -n "$SRC" ] || { echo "GATE FAIL: no librccl in ${RCCL_INSTALL_DIR}"; exit 1; }; \
@@ -355,8 +357,11 @@ RUN set -e; \
       2>/dev/null > /opt/RCCL_TARGETS.txt || true; \
     [ -s /opt/RCCL_TARGETS.txt ] || { echo "GATE FAIL: no librccl found in base image"; exit 1; }; \
     : > /opt/RCCL_PRESWAP.txt; \
+    mkdir -p /tmp/rcclswap; n=0; \
     while read -r t; do \
-      echo "$t $(ldd "$t" 2>/dev/null | grep -c 'not found' || true)" >> /opt/RCCL_PRESWAP.txt; \
+      n=$((n+1)); \
+      ldd "$t" 2>/dev/null | awk '/not found/ {print $1}' | sort -u > "/tmp/rcclswap/pre.$n"; \
+      printf '%s\t%s\n' "$n" "$t" >> /opt/RCCL_PRESWAP.txt; \
     done < /opt/RCCL_TARGETS.txt; \
     while read -r t; do \
       [ "$(readlink -f "$t")" = "$canon_src" ] && continue; \
@@ -367,17 +372,19 @@ RUN set -e; \
         { echo "GATE FAIL: could not restore RUNPATH on $t"; exit 1; }; fi; \
     done < /opt/RCCL_TARGETS.txt; \
     ldconfig || true; \
-    while read -r t before; do \
-      after="$(ldd "$t" 2>/dev/null | grep -c 'not found' || true)"; \
-      echo "  deps unresolved before=${before} after=${after}  $t"; \
-      if [ "${after:-0}" -gt "${before:-0}" ]; then \
-        echo "GATE FAIL: the swap ADDED $(( after - before )) unresolved dependencies to $t:"; \
-        ldd "$t" 2>/dev/null | grep 'not found'; \
+    while IFS="$(printf '\t')" read -r n t; do \
+      ldd "$t" 2>/dev/null | awk '/not found/ {print $1}' | sort -u > "/tmp/rcclswap/post.$n"; \
+      newmiss="$(comm -13 "/tmp/rcclswap/pre.$n" "/tmp/rcclswap/post.$n")"; \
+      echo "  unresolved sonames before=$(wc -l < "/tmp/rcclswap/pre.$n") after=$(wc -l < "/tmp/rcclswap/post.$n")  $t"; \
+      if [ -n "$newmiss" ]; then \
+        echo "GATE FAIL: the swap introduced unresolved sonames not present before on $t:"; \
+        printf '    %s\n' $newmiss; \
         echo "  The candidate was installed without the RUNPATH this location needs;"; \
         echo "  loading it would fail at import time, before any step runs."; exit 1; \
       fi; \
     done < /opt/RCCL_PRESWAP.txt; \
-    echo "SWAP GATE PASS: $(wc -l < /opt/RCCL_TARGETS.txt) librccl replaced, no new unresolved deps"
+    rm -rf /tmp/rcclswap; \
+    echo "SWAP GATE PASS: $(wc -l < /opt/RCCL_TARGETS.txt) librccl replaced, no new unresolved sonames"
 
 # ---- provenance: recorded INSIDE the image ---------------------------------
 # The build log is not carried by the image. RCCL_CMAKE_OPTIONS is recorded too:

--- a/docker/primus_maxtext_rccl_overlay.ubuntu.amd.Dockerfile
+++ b/docker/primus_maxtext_rccl_overlay.ubuntu.amd.Dockerfile
@@ -234,10 +234,11 @@ WORKDIR ${WORKSPACE_DIR}
 COPY --from=rccl-builder ${RCCL_INSTALL_DIR} ${RCCL_INSTALL_DIR}
 
 # binutils for the final verification (nm / strings / readelf); libatomic1 is a
-# runtime dep of the candidate librccl.
+# runtime dep of the candidate librccl; patchelf to carry each replaced library's
+# own RUNPATH across the swap (see the sweep below).
 RUN apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      binutils libatomic1 && \
+      binutils libatomic1 patchelf && \
     rm -rf /var/lib/apt/lists/*
 
 # ---- Primus payload (mirrors docker/primus_maxtext.ubuntu.amd.Dockerfile) ----
@@ -329,6 +330,22 @@ RUN if [[ -n "${RDMA_CORE_VERSION}" ]]; then \
 # ---- Stage 3: install candidate librccl over EVERY librccl on disk ----------
 # -type f, so the .so/.so.1 symlinks keep pointing at what is replaced. An empty
 # target list fails the build: such an image would run against the base library.
+#
+# EACH REPLACED FILE KEEPS ITS OWN RUNPATH. A librccl inside the ROCm pip wheels
+# resolves its DT_NEEDED libamd_smi.so.26 through a RUNPATH that reaches the sibling
+# wheel ($ORIGIN/../../_rocm_sdk_core/lib); the candidate is built for /opt/rccl and
+# carries $ORIGIN/../lib instead. Dropping the candidate in verbatim therefore leaves a
+# librccl that cannot resolve its own dependencies, and `import torch` dies in
+# rocm_sdk.initialize_process with "libamd_smi.so.26: cannot open shared object file"
+# before a single step runs. Copy the bytes, restore the destination's RUNPATH.
+#
+# The ldd gate below is the check that would have caught that at build time instead of
+# 4 minutes into a 2-node job. It compares each target BEFORE and AFTER the swap and
+# fails only on an INCREASE. An absolute "must resolve everything" test would fail a
+# perfectly good build: on this base the pristine _rocm_sdk_devel copy already reports
+# 6 unresolved deps (its RUNPATH is a row of empty entries), because it is only ever
+# dlopen'd into a namespace where those libraries are already loaded. What must not
+# happen is the swap making linkage worse than it found it.
 RUN set -e; \
     SRC="$(ls -L ${RCCL_INSTALL_DIR}/lib/librccl.so.1.0 2>/dev/null || ls -L ${RCCL_INSTALL_DIR}/lib/librccl.so)"; \
     [ -n "$SRC" ] || { echo "GATE FAIL: no librccl in ${RCCL_INSTALL_DIR}"; exit 1; }; \
@@ -337,11 +354,30 @@ RUN set -e; \
     find / -xdev -type f -name 'librccl.so*' -not -path "${RCCL_INSTALL_DIR}/*" \
       2>/dev/null > /opt/RCCL_TARGETS.txt || true; \
     [ -s /opt/RCCL_TARGETS.txt ] || { echo "GATE FAIL: no librccl found in base image"; exit 1; }; \
+    : > /opt/RCCL_PRESWAP.txt; \
+    while read -r t; do \
+      echo "$t $(ldd "$t" 2>/dev/null | grep -c 'not found' || true)" >> /opt/RCCL_PRESWAP.txt; \
+    done < /opt/RCCL_TARGETS.txt; \
     while read -r t; do \
       [ "$(readlink -f "$t")" = "$canon_src" ] && continue; \
-      echo "  overwrite: $t"; cp -fL --remove-destination "$SRC" "$t"; \
+      rp="$(patchelf --print-rpath "$t" 2>/dev/null || true)"; \
+      echo "  overwrite: $t (rpath: ${rp:-none})"; \
+      cp -fL --remove-destination "$SRC" "$t"; \
+      if [ -n "$rp" ]; then patchelf --set-rpath "$rp" "$t" || \
+        { echo "GATE FAIL: could not restore RUNPATH on $t"; exit 1; }; fi; \
     done < /opt/RCCL_TARGETS.txt; \
-    ldconfig || true
+    ldconfig || true; \
+    while read -r t before; do \
+      after="$(ldd "$t" 2>/dev/null | grep -c 'not found' || true)"; \
+      echo "  deps unresolved before=${before} after=${after}  $t"; \
+      if [ "${after:-0}" -gt "${before:-0}" ]; then \
+        echo "GATE FAIL: the swap ADDED $(( after - before )) unresolved dependencies to $t:"; \
+        ldd "$t" 2>/dev/null | grep 'not found'; \
+        echo "  The candidate was installed without the RUNPATH this location needs;"; \
+        echo "  loading it would fail at import time, before any step runs."; exit 1; \
+      fi; \
+    done < /opt/RCCL_PRESWAP.txt; \
+    echo "SWAP GATE PASS: $(wc -l < /opt/RCCL_TARGETS.txt) librccl replaced, no new unresolved deps"
 
 # ---- provenance: recorded INSIDE the image ---------------------------------
 # The build log is not carried by the image. RCCL_CMAKE_OPTIONS is recorded too:

--- a/scripts/jax-maxtext/extract_maxtext_perf.py
+++ b/scripts/jax-maxtext/extract_maxtext_perf.py
@@ -25,6 +25,14 @@ is step latency and a single straggler step — a checkpoint flush, an eval, a h
 moves a 10-sample mean by percent while the effect under test can itself be a few percent.
 The median ignores it. The two throughput metrics above keep their existing mean so their
 published numbers stay comparable across releases.
+
+The row is written for EVERY run whose log carries step timings, single- and multi-node
+alike, and is deliberately not gated behind an opt-in flag. It is additive: this parser
+writes the madengine `multiple_results` CSV, it does not print a `performance:` line into
+the log, so the two throughput rows every existing card already reports are unchanged and
+madengine's "first `performance:` match wins" scraping is not involved. The gating that
+existed in the retired MAD-native harness protected that log-line path for cards which no
+longer exist on the Primus path.
 """
 import argparse
 import csv

--- a/scripts/jax-maxtext/extract_maxtext_perf.py
+++ b/scripts/jax-maxtext/extract_maxtext_perf.py
@@ -16,10 +16,20 @@ per-GPU convention used by the existing MAD JAX/MaxText perf CSVs:
   model,performance,metric
   maxtext_run,12345.6,tok_per_s_per_gpu
   maxtext_run,421.3,TFLOPS_per_gpu
+  maxtext_run,0.8500,seconds_per_step
+
+seconds_per_step is the MEDIAN of the same trailing window, not the mean. It exists for
+A/B comparisons of the collective library (see
+docker/primus_maxtext_rccl_overlay.ubuntu.amd.Dockerfile), where the quantity of interest
+is step latency and a single straggler step — a checkpoint flush, an eval, a host hiccup —
+moves a 10-sample mean by percent while the effect under test can itself be a few percent.
+The median ignores it. The two throughput metrics above keep their existing mean so their
+published numbers stay comparable across releases.
 """
 import argparse
 import csv
 import re
+import statistics
 import sys
 
 # Number of trailing per-step samples to average (matches the old JAX report).
@@ -27,11 +37,15 @@ AVG_WINDOW = 10
 
 
 def extract_metrics(log_path: str) -> dict:
-    """Parse a MaxText log and return averaged tps/tflops from the trailing steps."""
+    """Parse a MaxText log and return tps/tflops/sec_per_step from the trailing steps."""
     tps_re = re.compile(r'Tokens/s/device:\s*([0-9][0-9.eE+-]*)')
     tflops_re = re.compile(r'TFLOP/s/device:\s*([0-9][0-9.eE+-]*)')
+    # Anchored on "completed step:" so an unrelated line that happens to say
+    # "seconds:" (a timer, a summary) cannot contribute a sample.
+    secs_re = re.compile(r'completed step:\s*\d+\s*,\s*seconds:\s*([0-9][0-9.eE+-]*)')
     tps_samples = []
     tflops_samples = []
+    secs_samples = []
 
     try:
         with open(log_path, "r", encoding="utf-8", errors="ignore") as f:
@@ -48,19 +62,28 @@ def extract_metrics(log_path: str) -> dict:
                         tflops_samples.append(float(m.group(1)))
                     except ValueError:
                         pass
+                m = secs_re.search(line)
+                if m:
+                    try:
+                        secs_samples.append(float(m.group(1)))
+                    except ValueError:
+                        pass
     except OSError as e:
         print(f"Error reading log {log_path}: {e}", file=sys.stderr)
         return {}
 
-    tps = tflops = None
+    tps = tflops = sec_per_step = None
     if tps_samples:
         window = tps_samples[-AVG_WINDOW:]
         tps = f"{sum(window) / len(window):.4f}"
     if tflops_samples:
         window = tflops_samples[-AVG_WINDOW:]
         tflops = f"{sum(window) / len(window):.4f}"
+    if secs_samples:
+        window = secs_samples[-AVG_WINDOW:]
+        sec_per_step = f"{statistics.median(window):.4f}"
 
-    return {"tps": tps, "tflops": tflops}
+    return {"tps": tps, "tflops": tflops, "sec_per_step": sec_per_step}
 
 
 def main():
@@ -79,6 +102,13 @@ def main():
         {"model": args.model_id, "performance": metrics.get("tps") or "", "metric": "tok_per_s_per_gpu"},
         {"model": args.model_id, "performance": metrics.get("tflops") or "", "metric": "TFLOPS_per_gpu"},
     ]
+    # Omitted rather than written blank when the log carries no step timings: an
+    # empty performance cell reads downstream as a measured value, and 0 s/step
+    # would look like an impossibly good result instead of a missing one.
+    if metrics.get("sec_per_step") is not None:
+        rows.append(
+            {"model": args.model_id, "performance": metrics["sec_per_step"], "metric": "seconds_per_step"}
+        )
 
     with open(args.output_csv, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=["model", "performance", "metric"])
@@ -87,7 +117,8 @@ def main():
 
     print(
         f"Wrote {args.output_csv}: {len(rows)} rows "
-        f"(tok_per_s_per_gpu={rows[0]['performance']}, TFLOPS_per_gpu={rows[1]['performance']})"
+        f"(tok_per_s_per_gpu={rows[0]['performance']}, TFLOPS_per_gpu={rows[1]['performance']}, "
+        f"seconds_per_step={metrics.get('sec_per_step') or 'n/a'})"
     )
 
 

--- a/scripts/jax-maxtext/run.sh
+++ b/scripts/jax-maxtext/run.sh
@@ -54,24 +54,28 @@ fi
 # EXP is required by run_pretrain.sh. --config_path must also be stripped from the
 # forwarded args: run_pretrain.sh appends leftovers to the training command and it is
 # not a valid MaxText flag.
+# Stripped unconditionally. Doing it only when PRIMUS_CONFIG_PATH is unset left the
+# flag in the forwarded args on exactly the path that sets it: madengine's
+# `launcher: primus` exports PRIMUS_CONFIG_PATH, every discovered model card carries
+# `args: --config_path <rel>`, so run_pretrain.sh appended `--config_path ...` to the
+# training command and MaxText died with
+# "ValueError: 'config_path' not in 'emb_dim', ..." before step 1 on every multi-node run.
 forward_args=()
-if [[ -n "${PRIMUS_CONFIG_PATH:-}" ]]; then
-  export EXP="$PRIMUS_CONFIG_PATH"
-  forward_args=("$@")
-else
-  export EXP=""
-  args=("$@")
-  i=0
-  while [[ $i -lt ${#args[@]} ]]; do
-    if [[ "${args[i]}" == "--config_path" && -n "${args[i+1]:-}" ]]; then
-      export EXP="${args[i+1]}"
-      i=$((i + 2))
-      continue
-    fi
-    forward_args+=("${args[i]}")
-    i=$((i + 1))
-  done
-fi
+args=("$@")
+cli_config=""
+i=0
+while [[ $i -lt ${#args[@]} ]]; do
+  if [[ "${args[i]}" == "--config_path" && -n "${args[i+1]:-}" ]]; then
+    cli_config="${args[i+1]}"
+    i=$((i + 2))
+    continue
+  fi
+  forward_args+=("${args[i]}")
+  i=$((i + 1))
+done
+# The launcher's value wins: when madengine sets it, that is the authoritative config
+# for the deployment, and the card's args are just how the same path reaches a local run.
+export EXP="${PRIMUS_CONFIG_PATH:-$cli_config}"
 
 if [[ -z "$EXP" ]]; then
   echo "ERROR: --config_path or PRIMUS_CONFIG_PATH required." >&2


### PR DESCRIPTION
Enables the JAX/MaxText workload to run against **any RCCL commit** rather than only the
librccl the base image ships:

```
--build-arg RCCL_COMMIT=<sha>          # any commit of ROCm/rocm-systems
--build-arg RCCL_CMAKE_OPTIONS=<flags> # and any build options
```

Comparing two builds is two images and the same model card twice — no A/B driver, no variant
switch, nothing added to the model path.

**Rewritten onto the current `mad-rccl`.** The previous revision targeted the pre-#238 MaxText
harness (the per-model `env_scripts/`, `models.json`, and the three `jax-maxtext_benchmark_*`
scripts), all of which #238 removed. Rebasing was not possible — every file it touched had been
deleted underneath it — so the same capability is re-done on the Primus path: the overlay image,
the median `seconds_per_step` metric, the skill notes and manifest templates, plus the fixes
found while validating and in review.

## Worked example

One pinned RCCL commit, `-DFAULT_INJECTION=ON` vs `=OFF`, only `librccl.so` differing.
MI355X/gfx950, Broadcom Thor2 RoCEv2, base `rocm/jax-training:maxtext-v26.6`.

| Model | Nodes | Inter-node traffic per step | FI=ON | FI=OFF | Delta |
| --- | --- | --- | --- | --- | --- |
| 8B FP8 | 1 | none | 2.9240 s | 2.9200 s | **+0.14 %** |
| 8B FP8 | 2 | grad all-reduce, `QPS=1` | 3.0335 s | 3.0320 s | **+0.05 %** |
| 8B FP8 | 2 | grad all-reduce, `QPS=8` | 3.0590 s | 3.0300 s | **+0.96 %** |
| 8B FP8 | 4 | grad all-reduce, `QPS=8` | 3.2205 s | 3.0835 s | **+4.44 %** |
| 405B FP8 | 4 | **FSDP across nodes**, `QPS=8` | 61.02 s | 17.40 s | **+250.8 %** |

The cost scales with inter-node collective volume. The single-node row is the control — the flag
also compiles a delay into the collective device kernels, so a slowdown under it is not
automatically a network result. Every run is 50 steps (step-time medians only compare at equal
`steps`), each A/B pair ran back-to-back on the same nodes, and every run confirmed
`NET/IB/*/GDRDMA` with zero socket fallback. Single repeats.

These percentages are **not** comparable with the v26.5 numbers this PR previously carried: the
Primus configs have a ~3.5× larger baseline step time, so the same absolute overhead is a much
smaller fraction of it (v26.5 at 4 nodes: 1.064 − 0.888 = 0.176 s; here: 3.2205 − 3.0835 = 0.137 s).

### Two settings the table depends on — both are in the shipped templates

- **`XLA_GPU_AUTOTUNE_LEVEL=0`.** Primus defaults `--xla_gpu_autotune_level=4`, and at 24 and 32
  ranks that presents as a dead hang: zero steps, zero `NCCL INFO`, one thread pinned at 100 % in
  `libhsa-runtime64.so.1` for hours. Sixteen ranks survive it. It is compilation, not a defect —
  but it is indistinguishable from a hang without timing it. Note that Primus reads
  `XLA_GPU_AUTOTUNE_LEVEL`; the MAD-native `XLA_AUTOTUNE_LEVEL` is a silent no-op on this path, so
  carrying the old key across does nothing. Both templates set it in `context.docker_env_vars` and
  `deployment_config.env_vars`, since only the former reaches the container.
- **405B at 4 nodes needs `per_device_batch_size=1`.** The shipped config OOMs at
  `241.25 GiB` for `jit_train_step`. Setting `dcn_fsdp_parallelism=-1` / `ici_fsdp_parallelism=8`
  does not change that figure by a byte (the overrides verifiably reach MaxText), so the 241.25 GiB
  is an activation, not parameter or optimizer state. `primus_maxtext_llama3.1-405b.template.json`
  carries it, so the row is reproducible from a shipped card rather than from overrides typed at
  the prompt.

## Traps worth knowing beyond this PR

- **The standard SLURM path exports `NCCL_IB_DISABLE=1` itself.** It is injected into the generated
  sbatch, absent from the manifest, and nothing fails — RCCL reports `via NET/Socket` and the job
  just runs slower. Worse, an A/B taken over sockets is *insensitive*. Set it to 0 in both env
  blocks; the templates do.
- **`--ulimit nofile=1048576` is required at 4+ nodes.** A 32-device clique exhausts the default and
  stalls silently at `Initialize clique` rather than reporting an error.
- **A librccl swap must preserve each destination's own RUNPATH — including an empty one.** The copy
  in the ROCm pip wheels resolves `libamd_smi.so.26` through a RUNPATH reaching a sibling wheel,
  while the candidate is built for `/opt/rccl`. Dropping the candidate in verbatim leaves a librccl
  that cannot resolve its own dependencies, and `import torch` dies before step 1. Where the
  destination carried *no* RUNPATH the candidate's `$ORIGIN/../lib` has to be removed rather than
  left behind, or that location quietly begins resolving its dependencies somewhere else.
- **Gate that swap on the set of unresolved sonames, not on how many there are.** Comparing counts
  passes a swap that drops one missing soname and introduces a different one — the number is
  unchanged and the image is broken in exactly the way the gate exists to catch. The overlay records
  the set per target before the swap and fails on any name that was not already there. It stays a
  relative check rather than "must resolve everything", because on this base the pristine
  `_rocm_sdk_devel` copy already reports six unresolved deps: it is only ever `dlopen`'d into a
  namespace where those libraries are loaded. Note the limit of any such check — it sees which
  *names* are unresolved, never which *file* a name resolved to, which is why the RUNPATH is
  restored rather than merely inspected.

The durable findings are in `.claude/skills/mad-slurm-multinode/references/gotchas.md`.

## Testing

MI355X/gfx950, Broadcom Thor2 RoCEv2. Both images built from scratch and verified in-image: pinned
SHA, `.rodata` marker 2 vs 0 with a positive control, `bnxt_re` provider present. 1-, 2- and 4-node
runs go through `madengine run` end to end. Every run manifest passes the skill's
`validate_manifest.sh` with zero FAILs; the two templates report the same profile as the existing
ones in `assets/manifests/` (their FAILs are the unfilled `<FILL_...>` placeholders, by design).

The 1-node control could not be run through madengine's single-node SLURM path on this cluster and
needed a node-local workspace: that path opens the manifest by basename while its local-workspace
branch copies it in as `build_manifest.json`, and with `shared_workspace` set it then fails to
create `run_directory` as container-root against NFS `root_squash`. That is a madengine issue, not
one this PR touches.
