### PR TITLE
add ep back to qwen 235b + 397b

### DIFF
--- a/scripts/vllm/configs/extended.yaml
+++ b/scripts/vllm/configs/extended.yaml
@@ -60,6 +60,8 @@
   max_concurrency: 1
   env:
     VLLM_ROCM_USE_AITER: 1
+  extra_args:
+    --enable-expert-parallel: True
 
 - benchmark: serving
   model:


### PR DESCRIPTION
aforementioned models cannot serve without `--enable-expert-parallel` flag. 