### PR TITLE
DSv4 max-num-batched-tokens 8192

### DIFF
--- a/scripts/vllm/configs/default.yaml
+++ b/scripts/vllm/configs/default.yaml
@@ -95,6 +95,7 @@
     VLLM_USE_BREAKABLE_CUDAGRAPH: 0
   extra_args:
     --kv-cache-dtype: fp8
+    --max-num-batched-tokens: 8192
 
 - benchmark: serving
   model:


### PR DESCRIPTION
VLLM now defaults to 16384; too much at 1m context

