### PR TITLE
Add Cohere Command R7B and Command A+ to vLLM extended suite (#243)

### DIFF
--- a/benchmark/vllm/README.md
+++ b/benchmark/vllm/README.md
@@ -14,8 +14,8 @@ This Docker image packages vLLM with PyTorch for AMD Instinct™ MI300X, MI325X,
 accelerators. It includes:
 
 -   ✅ ROCm™ 7.2.3
--   ✅ vLLM 0.26.0
--   ✅ PyTorch 2.11.0 (2.11.0+gitd0c8b1f3)
+-   ✅ vLLM 0.28.0
+-   ✅ PyTorch 2.12.0 (2.12.0+git6bbd260)
 -   ✅ hipBLASLt 1.0
 
 With this Docker image, users can quickly validate the expected inference performance numbers on the Instinct accelerators listed above. 
@@ -58,7 +58,7 @@ To override the benchmark configs, specify a certain benchmark to use, or add yo
 The following command pulls the Docker image from Docker Hub.
 
 ```sh
-docker pull vllm/vllm-openai-rocm:v0.26.0
+docker pull vllm/vllm-openai-rocm:v0.28.0
 ```
 
 ### MAD-integrated benchmarking
@@ -90,6 +90,8 @@ users can also directly run the vLLm benchmark scripts and change the benchmarki
 
 | MAD model name                         | Model repo                             |
 | -------------------------------------- | -------------------------------------- |
+| pyt_vllm_command-a-plus                | [CohereLabs/command-a-plus-05-2026-bf16](https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16) |
+| pyt_vllm_command-r7b                   | [CohereLabs/c4ai-command-r7b-12-2024](https://huggingface.co/CohereLabs/c4ai-command-r7b-12-2024) |
 | pyt_vllm_deepseek-r1                   | [deepseek-ai/DeepSeek-R1-0528](https://huggingface.co/deepseek-ai/DeepSeek-R1-0528) |
 | pyt_vllm_deepseek-r1_fp4               | [amd/DeepSeek-R1-0528-MXFP4](https://huggingface.co/amd/DeepSeek-R1-0528-MXFP4) |
 | pyt_vllm_deepseek-v3.2_fp4             | [amd/DeepSeek-V3.2-MXFP4](https://huggingface.co/amd/DeepSeek-V3.2-MXFP4) |
@@ -131,8 +133,7 @@ users can also directly run the vLLm benchmark scripts and change the benchmarki
 | pyt_vllm_qwen3.5-397b-a17b_fp8         | [Qwen/Qwen3.5-397B-A17B-FP8](https://huggingface.co/Qwen/Qwen3.5-397B-A17B-FP8) |
 
 >[!NOTE]
->`pyt_vllm_kimi-k3` is the one exception to the shared Docker image above. Kimi K3 requires
->vLLM >= 0.27.0, which is not yet in a tagged `vllm-openai-rocm` release, so it builds from
+>`pyt_vllm_kimi-k3` is the one exception to the shared Docker image above. It builds from
 >the model-specific `vllm/vllm-openai-rocm:kimi-k3` image via
 >[docker/pyt_vllm_kimi_k3.ubuntu.amd.Dockerfile](../../docker/pyt_vllm_kimi_k3.ubuntu.amd.Dockerfile).
 >It needs an 8x MI350X/MI355X (gfx950) node — the ~1680 GB minimum footprint does not fit a
@@ -157,9 +158,9 @@ Users also can run the benchmark tool after they launch a Docker container. For 
 
 #### Docker launch
 ```sh
-docker pull vllm/vllm-openai-rocm:v0.26.0
+docker pull vllm/vllm-openai-rocm:v0.28.0
 
-docker run -it --device=/dev/kfd --device=/dev/dri --group-add video --shm-size 16G --security-opt seccomp=unconfined --security-opt apparmor=unconfined --cap-add=SYS_PTRACE -v $(pwd):/workspace --env VLLM_ROCM_USE_AITER=1 --env HUGGINGFACE_HUB_CACHE=/workspace --name test vllm/vllm-openai-rocm:v0.26.0
+docker run -it --device=/dev/kfd --device=/dev/dri --group-add video --shm-size 16G --security-opt seccomp=unconfined --security-opt apparmor=unconfined --cap-add=SYS_PTRACE -v $(pwd):/workspace --env VLLM_ROCM_USE_AITER=1 --env HUGGINGFACE_HUB_CACHE=/workspace --name test vllm/vllm-openai-rocm:v0.28.0
 ```
 
 >[!NOTE]
@@ -374,6 +375,9 @@ owners and are only mentioned for informative purposes.   
 ## Changelog
 ----------
 This release note summarizes notable changes since the previous docker release.
+
+v0.28.0
+- Added Cohere Command R7B and Command A+ to the extended benchmark suite
 
 v0.26.0
 - Minimax gfx942 fix

--- a/docker/pyt_vllm.ubuntu.amd.Dockerfile
+++ b/docker/pyt_vllm.ubuntu.amd.Dockerfile
@@ -24,7 +24,7 @@
 # SOFTWARE.
 #
 #################################################################################
-ARG BASE_DOCKER=vllm/vllm-openai-rocm:v0.23.0
+ARG BASE_DOCKER=vllm/vllm-openai-rocm:v0.28.0
 FROM $BASE_DOCKER
 
 USER root

--- a/scripts/vllm/configs/extended.yaml
+++ b/scripts/vllm/configs/extended.yaml
@@ -80,3 +80,25 @@
   arch_overrides:
     gfx942:
       dtype: float16
+
+- benchmark: serving
+  model:
+    CohereLabs/c4ai-command-r7b-12-2024
+  tp: 1
+  inp: 1024
+  out: 1024
+  dtype: auto
+  max_concurrency: 1
+  env:
+    VLLM_ROCM_USE_AITER: 1
+
+- benchmark: serving
+  model:
+    CohereLabs/command-a-plus-05-2026-bf16
+  tp: 8
+  inp: 1024
+  out: 1024
+  dtype: auto
+  max_concurrency: 1
+  env:
+    VLLM_ROCM_USE_AITER: 1

--- a/scripts/vllm/models.json
+++ b/scripts/vllm/models.json
@@ -1,5 +1,41 @@
 [
     {
+        "name": "pyt_vllm_command-a-plus",
+        "dockerfile": "../../docker/pyt_vllm",
+        "scripts": "run.sh",
+        "data": "huggingface",
+        "n_gpus": "-1",
+        "owner": "mad.support@amd.com",
+        "training_precision": "",
+        "multiple_results": "perf_command-a-plus-05-2026-bf16.csv",
+        "tags": [
+            "pyt",
+            "vllm",
+            "vllm_extended",
+            "inference"
+        ],
+        "timeout": -1,
+        "args": "--model_repo CohereLabs/command-a-plus-05-2026-bf16 --config configs/extended.yaml"
+    },
+    {
+        "name": "pyt_vllm_command-r7b",
+        "dockerfile": "../../docker/pyt_vllm",
+        "scripts": "run.sh",
+        "data": "huggingface",
+        "n_gpus": "-1",
+        "owner": "mad.support@amd.com",
+        "training_precision": "",
+        "multiple_results": "perf_c4ai-command-r7b-12-2024.csv",
+        "tags": [
+            "pyt",
+            "vllm",
+            "vllm_extended",
+            "inference"
+        ],
+        "timeout": -1,
+        "args": "--model_repo CohereLabs/c4ai-command-r7b-12-2024 --config configs/extended.yaml"
+    },
+    {
         "name": "pyt_vllm_deepseek-r1",
         "dockerfile": "../../docker/pyt_vllm",
         "scripts": "run.sh",


### PR DESCRIPTION
* Add Cohere Command R7B and Command A+ to vLLM extended suite

Also bump the pyt_vllm base image to vllm/vllm-openai-rocm:v0.28.0.


Claude-Session: https://claude.ai/code/session_015S3frHBxF3j5AsWL6gt3dk

* Drop comments and keep vision tower for Cohere extended configs


Claude-Session: https://claude.ai/code/session_015S3frHBxF3j5AsWL6gt3dk

---------

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md#pull-requests.
